### PR TITLE
Passing the single coordinates to the method instead of the tuple.

### DIFF
--- a/mayavi/core/mouse_pick_dispatcher.py
+++ b/mayavi/core/mouse_pick_dispatcher.py
@@ -165,7 +165,10 @@ class MousePickDispatcher(HasTraits):
         if self._mouse_no_mvt:
             x, y = vtk_picker.GetEventPosition()
             for picker in self._active_pickers.values():
-                picker.pick((x, y, 0), self.scene.scene.renderer)
+                try:
+                    picker.pick((x, y, 0), self.scene.scene.renderer)
+                except TypeError:
+                    picker.pick(x, y, 0, self.scene.scene.renderer)
         self._mouse_no_mvt = 0
 
 


### PR DESCRIPTION
mouse_dispatcher calls a generated method, which has two signature: V.pick(float, float, float, Renderer) -> int, and V.pick((float, float, float), Renderer) -> int.

In my system, the second one is never used. Instead the first one is used and an error is thrown, due to the wrong number of args. Therefore, passing the single coordinates fixes the problem.
