### PR TITLE
FIX: don't wrap vtkQt classes

### DIFF
--- a/tvtk/code_gen.py
+++ b/tvtk/code_gen.py
@@ -92,6 +92,7 @@ class TVTKGenerator:
         #classes = dir(vtk)
         classes = [x.name for x in wrap_gen.get_tree() \
                    if x.name.startswith('vtk') and \
+                   not x.name.startswith('vtkQt') and \
                    not issubclass(getattr(vtk, x.name), object) ]
         for nodes in tree:
             for node in nodes:


### PR DESCRIPTION
Don't build TVTK classes for vtkQt classes, which currently doesn't work, see 

https://github.com/enthought/mayavi/issues/24

As far as I can tell wrapping vtkQt classes should not be necessary, but I may be wrong.
