### PR TITLE
Fix contours argument when creating a contour surface

### DIFF
--- a/mayavi/tools/modules.py
+++ b/mayavi/tools/modules.py
@@ -173,6 +173,7 @@ class ContourModuleFactory(DataModuleFactory):
             contour_list = False
 
         if contour_list:
+            self._target.contour.auto_contours = False
             self._target.contour.contours = self.contours
         else:
             assert type(self.contours) == int, \


### PR DESCRIPTION
This corrects the documentation for the contours argument and allows setting a list of contour values for a contour surface, without having to also set auto_contours to False manually (which nobody would know to do without reading the source code).

This fixes issue #29.
