### PR TITLE
mlab.imshow fails with extent keyword argument

### DIFF
--- a/mayavi/tools/tools.py
+++ b/mayavi/tools/tools.py
@@ -291,12 +291,12 @@ def set_extent(module, extents):
     extenty = 0.5*(ymax - ymin)
     extentz = 0.5*(zmax - zmin)
     # Now the actual bounds.
-    xmin, xmax, ymin, ymax, zmin, zmax = module.actor.actor.bounds
+    xmin, xmax, ymin, ymax, zmin, zmax = module.actor.bounds
     # Scale the object
     boundsx = 0.5*(xmax - xmin)
     boundsy = 0.5*(ymax - ymin)
     boundsz = 0.5*(zmax - zmin)
-    xs, ys, zs = module.actor.actor.scale
+    xs, ys, zs = module.actor.scale
     if not numpy.allclose(xmin, xmax):
         scalex = xs*extentx/boundsx
     else:
@@ -310,16 +310,16 @@ def set_extent(module, extents):
     else:
         scalez = 1
 
-    module.actor.actor.scale = (scalex, scaley, scalez)
+    module.actor.scale = (scalex, scaley, scalez)
     ## Remeasure the bounds
-    xmin, xmax, ymin, ymax, zmin, zmax = module.actor.actor.bounds
+    xmin, xmax, ymin, ymax, zmin, zmax = module.actor.bounds
     xcenter = 0.5*(xmax + xmin)
     ycenter = 0.5*(ymax + ymin)
     zcenter = 0.5*(zmax + zmin)
     # Center the object
-    module.actor.actor.origin = (0.,  0.,  0.)
-    xpos, ypos, zpos = module.actor.actor.position
-    module.actor.actor.position = (xpos + xo -xcenter, ypos + yo - ycenter,
+    module.actor.origin = (0.,  0.,  0.)
+    xpos, ypos, zpos = module.actor.position
+    module.actor.position = (xpos + xo -xcenter, ypos + yo - ycenter,
                                             zpos + zo -zcenter)
 
 


### PR DESCRIPTION
Replacing module.actor.actor with module.actor. Not sure if this will break other things but this changes allows mlab.imshow(img, extent=[-.1, .1, -.1, .1, 0, 0]) to work which did not work previously. Also the integration test cases run fine.
