### PR TITLE
mlab.savefig with positive magnification fix

### DIFF
--- a/tvtk/pyface/tvtk_scene.py
+++ b/tvtk/pyface/tvtk_scene.py
@@ -405,7 +405,7 @@ class TVTKScene(HasPrivateTraits):
         """Saves the rendered scene to a rasterized PostScript image.
         For vector graphics use the save_gl2ps method."""
         if len(file_name) != 0:
-            w2if = tvtk.WindowToImageFilter(read_front_buffer=False)
+            w2if = tvtk.WindowToImageFilter(read_front_buffer=True)
             w2if.magnification = self.magnification
             self._lift()
             w2if.input = self._renwin
@@ -417,7 +417,7 @@ class TVTKScene(HasPrivateTraits):
     def save_bmp(self, file_name):
         """Save to a BMP image file."""
         if len(file_name) != 0:
-            w2if = tvtk.WindowToImageFilter(read_front_buffer=False)
+            w2if = tvtk.WindowToImageFilter(read_front_buffer=True)
             w2if.magnification = self.magnification
             self._lift()
             w2if.input = self._renwin
@@ -429,7 +429,7 @@ class TVTKScene(HasPrivateTraits):
     def save_tiff(self, file_name):
         """Save to a TIFF image file."""
         if len(file_name) != 0:
-            w2if = tvtk.WindowToImageFilter(read_front_buffer=False)
+            w2if = tvtk.WindowToImageFilter(read_front_buffer=True)
             w2if.magnification = self.magnification
             self._lift()
             w2if.input = self._renwin
@@ -441,7 +441,7 @@ class TVTKScene(HasPrivateTraits):
     def save_png(self, file_name):
         """Save to a PNG image file."""
         if len(file_name) != 0:
-            w2if = tvtk.WindowToImageFilter(read_front_buffer=False)
+            w2if = tvtk.WindowToImageFilter(read_front_buffer=True)
             w2if.magnification = self.magnification
             self._lift()
             w2if.input = self._renwin
@@ -457,7 +457,7 @@ class TVTKScene(HasPrivateTraits):
         if len(file_name) != 0:
             if not quality and not progressive:
                 quality, progressive = self.jpeg_quality, self.jpeg_progressive
-            w2if = tvtk.WindowToImageFilter(read_front_buffer=False)
+            w2if = tvtk.WindowToImageFilter(read_front_buffer=True)
             w2if.magnification = self.magnification
             self._lift()
             w2if.input = self._renwin


### PR DESCRIPTION
I tracked down the source of a fairly old bug in mlab.savefig() to some tvtk code which directs the WindowToImageFilter to use the back buffer, causing snapshots with magnification>1 to produce erroneous output.  I don't know why this design choice was made, but I ran the tvtk test suite and found no regressions.
