### PR TITLE
FIX: use kwargs for wxpython 2.9 compat

### DIFF
--- a/tvtk/pyface/ui/wx/wxVTKRenderWindowInteractor.py
+++ b/tvtk/pyface/ui/wx/wxVTKRenderWindowInteractor.py
@@ -187,7 +187,8 @@ class wxVTKRenderWindowInteractor(baseClass):
                                    attribList=attribList)
             except wx.PyAssertionError:
                 # visual couldn't be allocated, so we go back to default
-                baseClass.__init__(self, parent, ID, position, size, style)
+                baseClass.__init__(self, parent, id=ID, pos=position,
+                                   size=size, style=style)
                 if stereo:
                     # and make sure everyone knows that the stereo
                     # visual wasn't set.


### PR DESCRIPTION
The order of arguments in the constructor for wxGLCanvas has changed for wxPython 2.9 this fixes it by using keyword arguments. I haven't extensively tested if all the functionality works with wxPython 2.9, but the things I use work.
