### PR TITLE
Fix tvtk class browser failure with vtkQt classes

### DIFF
--- a/tvtk/tools/tvtk_doc.py
+++ b/tvtk/tools/tvtk_doc.py
@@ -54,7 +54,7 @@ def get_tvtk_class_names():
     filter = []
     sink = []
     for name in dir(vtk):
-        if name.startswith('vtk'):
+        if name.startswith('vtk') and not name.startswith('vtkQt'):
             klass = getattr(vtk, name)
             try:
                 c = klass()


### PR DESCRIPTION
Fix the following error:
QWidget: Must construct a QApplication before a QPaintDevice
In the VTK class browser when VTK was built with QT/SIP support.
