### PR TITLE
Catch TraitError when trying to set line_width.

### DIFF
--- a/mayavi/tools/modules.py
+++ b/mayavi/tools/modules.py
@@ -16,6 +16,7 @@ import new
 
 from traits.api import Trait, CArray, Instance, CFloat, \
     Any, false, true, TraitTuple, Range, Bool, Property, CInt, Enum, Either
+from traits.trait_errors import TraitError
 from tvtk.api import tvtk
 from tvtk.common import camel2enthought
 
@@ -73,10 +74,10 @@ class ModuleFactory(PipeFactory):
     def _line_width_changed(self):
         try:
             self._target.actor.property.line_width = self.line_width
-        except AttributeError:
+        except (AttributeError, TraitError):
             try:
                 self._target.property.line_width = self.line_width
-            except AttributeError:
+            except (AttributeError, TraitError):
                 pass
 
 


### PR DESCRIPTION
Trying to run the imshow example from the mayavi documentation a TraitError is thrown trying to set the line_width. This seems to be because Mayavi expects an AttributeError where a TraitError is thrown. This fixes that by also catching TraitErrors. 

``` python
import numpy
from mayavi.mlab import *

def test_imshow():
    """ Use imshow to visualize a 2D 10x10 random array.
    """
    s = numpy.random.random((10,10))
    return imshow(s, colormap='gist_earth')
```
