### PR TITLE
BUG: tvtk_doc barfs on searching for text.

### DIFF
--- a/tvtk/tools/tvtk_doc.py
+++ b/tvtk/tools/tvtk_doc.py
@@ -366,7 +366,7 @@ class TVTKClassChooser(HasTraits):
             return
 
         f = self.finder
-        result = f.search(value)
+        result = f.search(str(value))
         if len(result) == 0:
             self.available = self._orig_available
         elif len(result) == 1:
@@ -404,4 +404,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-


### PR DESCRIPTION
The tvtk_doc would barf when a user enters a search string.
