### PR TITLE
Fix the MultiBlockPLOT3DReader for vtk 5

### DIFF
--- a/mayavi/sources/plot3d_reader.py
+++ b/mayavi/sources/plot3d_reader.py
@@ -235,7 +235,7 @@ class PLOT3DReader(Source):
         # Now setup the outputs by resetting self.outputs.  Changing
         # the outputs automatically fires a pipeline_changed event.
         try:
-            n = r.number_of_output_ports
+            n = r.get_output().number_of_blocks
         except AttributeError: # for VTK >= 4.5
             n = r.number_of_outputs
         outputs = []

--- a/mayavi/tests/test_plot3d_mb_reader.py
+++ b/mayavi/tests/test_plot3d_mb_reader.py
@@ -92,7 +92,6 @@ class TestPlot3dMbReader(unittest.TestCase):
                                 (1.0, 2.0, 1.0, 2.0, 1.0, 2.0))
 
 
-    @unittest.skip("Plot3DReader and MultiBlock version are broken in 5.10.1")
     def test_deepcopied(self):
         """Test if the MayaVi2 visualization can be deep-copied.
            XXX: The plot 3d reader and multi block version are broken in
@@ -109,7 +108,7 @@ class TestPlot3dMbReader(unittest.TestCase):
         o1 = r1.children[0].children[0].children[0]
         self.assertEqual(o1.outline_filter.output.bounds,
                                     (1.0, 2.0, 1.0, 2.0, 1.0, 2.0))
-        r1.children[0].output_index = 0
+        r1.children[0].output_index = 1
         self.assertEqual(o1.outline_filter.output.bounds,
                                     (2.0, 3.0, 1.0, 2.0, 1.0, 2.0))
 


### PR DESCRIPTION
This fixes the MultiBlockPLOT3DReader issues when introduced in place of the old PLOT3DReader. 

It sets the correct number of outputs which should be the number of blocks in the output.
