### PR TITLE
Win32 specific fixes to integration tests.

### DIFF
--- a/integrationtests/mayavi/test_mlab_envisage.py
+++ b/integrationtests/mayavi/test_mlab_envisage.py
@@ -15,6 +15,8 @@ def test_mlab_envisage():
     "Test if mlab runs correctly when the backend is set to 'envisage'."
     @mlab.show
     def f():
+        from mayavi.preferences.api import preference_manager
+        preference_manager.root.show_splash_screen = False
         mlab.options.backend = 'envisage'
         mlab.test_contour3d()
         GUI.invoke_after(3000, close)

--- a/integrationtests/mayavi/test_streamline.py
+++ b/integrationtests/mayavi/test_streamline.py
@@ -37,9 +37,8 @@ class TestStreamline(TestCase):
 
     def test(self):
         if is_running_with_nose():
-            if sys.platform == 'darwin' or sys.platform.startswith('linux'):
-                import unittest
-                raise unittest.SkipTest('This test Segfaults after passing.')
+            import unittest
+            raise unittest.SkipTest('This test Segfaults after passing or fails.')
         self.main()
 
     def do(self):


### PR DESCRIPTION
Do not show the splash screen as it requires a mouse click to go away.
Also skip the streamline test on windows.
