### PR TITLE
Changes for the next Mayavi release which uses VTK's new pipeline.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -140,6 +140,8 @@ Authors and Contributors
 
   Gaël Varoquaux: mlab, icons, many general improvements and maintainance.
 
+  Deepak Surti: Upgrade to VTK 5.10.1, VTK 6.x with new pipeline.
+
 * Support and code contributions from Enthought Inc.
 
 * Patches from many people (see the release notes), including K K Rai and 

--- a/docs/CHANGES.txt
+++ b/docs/CHANGES.txt
@@ -1,4 +1,4 @@
-Mayavi 5.0.0
+Mayavi 4.4.0
 ============
 
 Enhancements

--- a/docs/CHANGES.txt
+++ b/docs/CHANGES.txt
@@ -4,23 +4,23 @@ Mayavi 5.0.0
 Enhancements
 ------------
 
-22 Dec 2014 (PR)
+22 Dec 2014 (DS)
     - Add function to set data at input port, add stanford (bunny,
       dragon, lucy) examples, and use new volume mapper for new pipeline.
 
-24 Jan 2014 (PR)
+24 Jan 2014 (DS)
     - Upgrade to VTK 6.0 with VTK's new pipeline.
 
 Fixes
 -----
 
-22 Dec 2014 (PR)
+22 Dec 2014 (DS)
     - Support dynamic dimensions in array source.
 
 03 Dec 2014 (paulmueller)
     - Fix MRI brain data URL.
 
-13 Nov 2014 (PR)
+13 Nov 2014 (DS)
     - More fixes for connection topology, information request and tube filter
       after upgrading to new pipeline.
 

--- a/docs/CHANGES.txt
+++ b/docs/CHANGES.txt
@@ -1,3 +1,44 @@
+Mayavi 5.0.0
+============
+
+Enhancements
+------------
+
+22 Dec 2014 (PR)
+    - Add function to set data at input port, add stanford (bunny,
+      dragon, lucy) examples, and use new volume mapper for new pipeline.
+
+24 Jan 2014 (PR)
+    - Upgrade to VTK 6.0 with VTK's new pipeline.
+
+Fixes
+-----
+
+22 Dec 2014 (PR)
+    - Support dynamic dimensions in array source.
+
+03 Dec 2014 (paulmueller)
+    - Fix MRI brain data URL.
+
+13 Nov 2014 (PR)
+    - More fixes for connection topology, information request and tube filter
+      after upgrading to new pipeline.
+
+24 Sep 2014 (pberkes)
+    - Handle the non-Latin-1 keypresses.
+
+23 Sep 2014 (rkern)
+    - Prevent ndarray comparisions with None.
+
+17 Jul 2014 (mdickinson)
+    - Fix the trait error raised when the threshold range is updated.
+
+24 May 2014 (markkness)
+    - Update installation documentation links.
+
+21 Apr 2014 (PR)
+    - Fix integration tests after upgrade to VTK's new pipeline.
+
 Mayavi 4.3.1
 =============
 

--- a/docs/THANKS.txt
+++ b/docs/THANKS.txt
@@ -1,6 +1,7 @@
 Developers:
     Prabhu Ramachandran (2001-)
     Gaël Varoquaux (2007-)
+    Deepak Surti (2013-)
 
 We gratefully acknowledge patches and other contributions from the
 following.  Please let us know if we missed anyone, thanks!

--- a/mayavi/__init__.py
+++ b/mayavi/__init__.py
@@ -5,7 +5,7 @@
     Part of the Mayavi project of the Enthought Tool Suite.
 """
 
-__version__ = '5.0.0'
+__version__ = '4.4.0'
 
 __requires__ = [
     'apptools',

--- a/mayavi/__init__.py
+++ b/mayavi/__init__.py
@@ -5,7 +5,7 @@
     Part of the Mayavi project of the Enthought Tool Suite.
 """
 
-__version__ = '4.3.2'
+__version__ = '5.0.0'
 
 __requires__ = [
     'apptools',


### PR DESCRIPTION
1. Bump up to version 5.0.0.
2. Document all enhancements and fixes.
3. Add self name as contributor.