### PR TITLE
Changes for the next Mayavi release 4.4.1

### DIFF
--- a/docs/CHANGES.txt
+++ b/docs/CHANGES.txt
@@ -1,3 +1,12 @@
+Mayavi 4.4.1
+============
+
+Fixes
+-----
+
+23 Apr 2015 (DS)
+    - Fix trackpad scrolling to zoom in/out smoothly on OS X.
+
 Mayavi 4.4.0
 ============
 

--- a/docs/source/mayavi/auto/changes.rst
+++ b/docs/source/mayavi/auto/changes.rst
@@ -1,3 +1,53 @@
+Mayavi 4.4.1
+============
+
+Fixes
+-----
+
+23 Apr 2015 (DS)
+    - Fix trackpad scrolling to zoom in/out smoothly on OS X.
+
+Mayavi 4.4.0
+============
+
+Enhancements
+------------
+
+22 Dec 2014 (DS)
+    - Add function to set data at input port, add stanford (bunny,
+      dragon, lucy) examples, and use new volume mapper for new pipeline.
+
+24 Jan 2014 (DS)
+    - Upgrade to VTK 6.0 with VTK's new pipeline.
+
+Fixes
+-----
+
+22 Dec 2014 (DS)
+    - Support dynamic dimensions in array source.
+
+03 Dec 2014 (paulmueller)
+    - Fix MRI brain data URL.
+
+13 Nov 2014 (DS)
+    - More fixes for connection topology, information request and tube filter
+      after upgrading to new pipeline.
+
+24 Sep 2014 (pberkes)
+    - Handle the non-Latin-1 keypresses.
+
+23 Sep 2014 (rkern)
+    - Prevent ndarray comparisions with None.
+
+17 Jul 2014 (mdickinson)
+    - Fix the trait error raised when the threshold range is updated.
+
+24 May 2014 (markkness)
+    - Update installation documentation links.
+
+21 Apr 2014 (PR)
+    - Fix integration tests after upgrade to VTK's new pipeline.
+
 Mayavi 4.3.1
 =============
 

--- a/docs/source/mayavi/conf.py
+++ b/docs/source/mayavi/conf.py
@@ -60,7 +60,7 @@ master_doc = 'index'
 
 # General substitutions.
 project = 'mayavi'
-copyright = u'2008-2015, Prabhu Ramachandran, Gaël Varoquaux, Deepak Surti'
+copyright = u'2008-2015, Enthought Inc.'
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.

--- a/docs/source/mayavi/conf.py
+++ b/docs/source/mayavi/conf.py
@@ -60,7 +60,7 @@ master_doc = 'index'
 
 # General substitutions.
 project = 'mayavi'
-copyright = u'2008-2014, Prabhu Ramachandran, Gaël Varoquaux'
+copyright = u'2008-2015, Prabhu Ramachandran, Gaël Varoquaux, Deepak Surti'
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.

--- a/docs/source/tvtk/conf.py
+++ b/docs/source/tvtk/conf.py
@@ -36,7 +36,7 @@ master_doc = 'index'
 
 # General substitutions.
 project = 'tvtk'
-copyright = '2008-2014, Enthought Inc.'
+copyright = '2008-2015, Enthought Inc.'
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.

--- a/mayavi/__init__.py
+++ b/mayavi/__init__.py
@@ -5,7 +5,7 @@
     Part of the Mayavi project of the Enthought Tool Suite.
 """
 
-__version__ = '4.4.0'
+__version__ = '4.4.1'
 
 __requires__ = [
     'apptools',


### PR DESCRIPTION
1. Bump up to version 4.4.1.
2. Document the fixes.
3. Update the copyright year.