### PR TITLE
Ignore false positives for built in methods/functions when parsing

### DIFF
--- a/tvtk/common.py
+++ b/tvtk/common.py
@@ -11,6 +11,7 @@ import re
 import vtk
 
 vtk_major_version = vtk.vtkVersion.GetVTKMajorVersion()
+vtk_minor_version = vtk.vtkVersion.GetVTKMinorVersion()
 
 ######################################################################
 # Utility functions.
@@ -45,6 +46,9 @@ def get_tvtk_name(vtk_name):
 
 def is_old_pipeline():
     return vtk_major_version < 6
+
+def is_version_62():
+    return vtk_major_version == 6 and vtk_minor_version == 2
 
 def configure_connection(obj, inp):
     """ Configure topology for vtk pipeline obj."""

--- a/tvtk/tests/test_vtk_parser.py
+++ b/tvtk/tests/test_vtk_parser.py
@@ -136,10 +136,12 @@ class TestVTKParser(unittest.TestCase):
 
         res = ['BackfaceRender', 'DeepCopy', 'Render']
         if hasattr(obj, 'GetTexture'):
-            if vtk_major_version == 6 and vtk_minor_version >= 1:
+            if vtk_major_version == 6:
                 res = ['AddShaderVariable', 'BackfaceRender', 'DeepCopy',
-                       'ReleaseGraphicsResources', 'RemoveAllTextures', 'RemoveTexture',
-                       'Render']
+                       'ReleaseGraphicsResources', 'RemoveAllTextures', 
+                       'RemoveTexture', 'Render']
+                if vtk_minor_version == 2:
+                    res.append('VTKTextureUnit')
             else:
                 res = ['AddShaderVariable', 'BackfaceRender', 'DeepCopy',
                        'LoadMaterial', 'LoadMaterialFromString',

--- a/tvtk/vtk_parser.py
+++ b/tvtk/vtk_parser.py
@@ -7,11 +7,12 @@ type information, and organizes them.
 # License: BSD Style.
 
 import re
+import types
 
 # Local imports (these are relative imports for a good reason).
 import class_tree
 import vtk_module as vtk
-
+from common import is_version_62
 
 class VTKMethodParser:
     """This class provides useful methods for parsing methods of a VTK
@@ -299,6 +300,12 @@ class VTKMethodParser:
           A VTK method object.
 
         """
+        # VTK 6.2 false built in funcs/methods are ignored
+        if is_version_62():
+            built_in_func = isinstance(method, types.BuiltinFunctionType)
+            built_in_meth = isinstance(method, types.BuiltinMethodType)
+            if not (built_in_func or built_in_meth):
+                return None
         # Remove all the C++ function signatures.
         doc = method.__doc__
         doc = doc[:doc.find('\n\n')]

--- a/tvtk/wrapper_gen.py
+++ b/tvtk/wrapper_gen.py
@@ -1046,7 +1046,8 @@ class WrapperGenerator:
         if sig is None:
             sig = self.parser.get_method_signature(vtk_meth)
         
-        # VTK 6.2: When the method signature is None, ignore the method
+        # VTK 6.2: There exists no method signature for false built in
+        # functions/methods
         if sig is None:
             return
 

--- a/tvtk/wrapper_gen.py
+++ b/tvtk/wrapper_gen.py
@@ -16,7 +16,7 @@ import copy
 
 # Local imports (these are relative imports because the package is not
 # installed when these modules are imported).
-from common import get_tvtk_name, camel2enthought
+from common import get_tvtk_name, camel2enthought, is_version_62
 import vtk_parser
 import indenter
 import special_gen
@@ -744,6 +744,7 @@ class WrapperGenerator:
             vtk_meth = getattr(klass, m)
             self._write_tvtk_method(out, vtk_meth)
 
+
     #################################################################
     # Private utility methods.
     #################################################################
@@ -1044,6 +1045,9 @@ class WrapperGenerator:
         """
         if not sig:
             sig = self.parser.get_method_signature(vtk_meth)
+            # VTK 6.2 false built in funcs/methods are ignored
+            if sig is None:
+                return
 
         # Figure out if we really need to wrap the return and deref
         # the args.

--- a/tvtk/wrapper_gen.py
+++ b/tvtk/wrapper_gen.py
@@ -1043,11 +1043,12 @@ class WrapperGenerator:
           If None, this is computed.  If not, the passed signature
           information is used.
         """
-        if not sig:
+        if sig is None:
             sig = self.parser.get_method_signature(vtk_meth)
-            # VTK 6.2 false built in funcs/methods are ignored
-            if sig is None:
-                return
+        
+        # VTK 6.2: When the method signature is None, ignore the method
+        if sig is None:
+            return
 
         # Figure out if we really need to wrap the return and deref
         # the args.


### PR DESCRIPTION
This implements support for #190 (and hence #159).

* When generating the TVTK bindings for VTK python wrappings, for VTK version 6.2, due to the API changes, a few additions (example: EventIds in vtkCommand and DesiredOutputPrecision in vtkAlgorithm) are falsely deteced as methods to be parsed. These are ignored when generating the tvtk methods.
* The method signature implementation now checks for VTK version 6.2 and ignores those methods which are not built in functions or methods. The method that writes out the TVTK method then ignores such signatures which are `None`.
* Tested on OS X 10.10: `python setup.py build` with VTK 6.2 egg now runs without errors.
* Tested for backwards compatibility with VTK 6.1 and VTK 5.10.