### PR TITLE
Use travis ci containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_install:
   - export PATH=/usr/lib/ccache:${PATH}
   - pip install --upgrade pip
   - if [[ ${ETS_TOOLKIT} == "wx" ]]; then sh travis-install-wx.sh; fi
+  - export LD_LIBRARY_PATH=$VIRTUAL_ENV/lib:${LD_LIBRARY_PATH}
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ addons:
 before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
+  - bash travis-install-wx sh
 install:
   - pip install -r travis-requirements.txt
   - python setup.py develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ cache:
     - $HOME/.ccache
 before_install:
   - export PATH=/usr/lib/ccache:${PATH}
-  - if [ $ETS_TOOKIT = wx ]; then bash travis-install-wx.sh; fi
+  - if [ ${ETS_TOOKIT} = "wx" ]; then bash travis-install-wx.sh; fi
 install:
   - pip install -r travis-requirements.txt
   - python setup.py develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ cache:
     - $HOME/.ccache
 before_install:
   - export PATH=/usr/lib/ccache:${PATH}
-  - if [ $ETS_TOOKIT = wx] then bash travis-install-wx.sh fi
+  - if [ $ETS_TOOKIT = wx ]; then bash travis-install-wx.sh fi
 install:
   - pip install -r travis-requirements.txt
   - python setup.py develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - sh -e /etc/init.d/xvfb start
   - export ETS_TOOLKIT=qt4
 install:
-  - pip install -r travis-requirements
+  - pip install -r travis-requirements.txt
   - python setup.py develop
 script:
   # Running all tests in tvtk/tests and mayavi.

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,15 +33,10 @@ install:
   - pip install -r travis-requirements.txt
   - python setup.py develop
 script:
-  # Running all tests in tvtk/tests and mayavi.
   - coverage erase
   - coverage run -p -m nose.core -v tvtk/tests
   - coverage run -p -m nose.core -v mayavi
-  # Run the integration tests.
-  - cd integrationtests/mayavi
-  - coverage run --rcfile=../../.coveragerc -p run.py
-  - cd ../../
-  - cp integrationtests/mayavi/.coverage.* ./
+  - if [[ ${ETS_TOOLKIT} == "wx" ]]; then sh travis-run-integration-tests.sh; fi
   - coverage combine
 after_success:
   - pip install codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ cache:
 before_install:
   - export PATH=/usr/lib/ccache:${PATH}
   - if [[ ${ETS_TOOLKIT} == "wx" ]]; then sh travis-install-wx.sh; fi
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
 install:
   - pip install -r travis-requirements.txt
   - python setup.py develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ cache:
     - $HOME/.ccache
 before_install:
   - export PATH=/usr/lib/ccache:${PATH}
-  - if [ $ETS_TOOKIT = wx ]; then bash travis-install-wx.sh fi
+  - if [ $ETS_TOOKIT = wx ]; then bash travis-install-wx.sh; fi
 install:
   - pip install -r travis-requirements.txt
   - python setup.py develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ cache:
     - $HOME/.cache/pip
     - $HOME/.ccache
 before_install:
+  - ccache -s
   - export PATH=/usr/lib/ccache:${PATH}
   - pip install --upgrade pip
   - if [[ ${ETS_TOOLKIT} == "wx" ]]; then sh travis-install-wx.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ addons:
     - python-imaging
     - python-pip
     - mesa-common-dev
-    - libgtk-2.0-dev
+    - libgtk2.0-dev
     - ccache
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,23 @@
 language: python
+sudo: false
 python:
   - 2.7
 virtualenv:
-  # This allows installing python-vtk using apt-get and being able to import it.
   system_site_packages: true
+addons:
+  apt:
+    packages:
+    - python-vtk
+    - python-qt4
+    - python-qt4-gl
+    - python-imaging
+    - python-pip
 before_install:
-  - source .travis_before_install
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+  - export ETS_TOOLKIT=qt4
 install:
-  # nose is already installed
-  - pip install Sphinx
-  - pip install coverage
-  - pip install coveralls
-  # Test against the current master of traits, traitsui and apptools
-  - pip install git+http://github.com/enthought/traits.git#egg=traits
-  - pip install git+http://github.com/enthought/traitsui.git#egg=traitsui
-  - pip install git+http://github.com/enthought/apptools.git#egg=apptools
-  - pip install git+http://github.com/enthought/pyface.git#egg=pyface
-  - pip install git+http://github.com/enthought/envisage.git#egg=envisage
+  - pip install -r travis-requirements
   - python setup.py develop
 script:
   # Running all tests in tvtk/tests and mayavi.
@@ -29,8 +30,6 @@ script:
   - cd ../../
   - cp integrationtests/mayavi/.coverage.* ./
   - coverage combine
-notifications:
-  email:
-    - travis-ci@enthought.com
 after_success:
-  coveralls
+  - pip install codecov
+  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,14 @@ addons:
     - python-pip
     - mesa-common-dev
     - libgtk-2.0-dev
+    - ccache
+cache:
+  directories:
+    - $HOME/.cache/pip
+    - $HOME/.ccache
 before_install:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
-  - bash travis-install-wx.sh
+  - export PATH=/usr/lib/ccache:${PATH}
+  - if [ $ETS_TOOKIT = wx] then bash travis-install-wx.sh fi
 install:
   - pip install -r travis-requirements.txt
   - python setup.py develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ cache:
     - $HOME/.ccache
 before_install:
   - export PATH=/usr/lib/ccache:${PATH}
-  - if [ ${ETS_TOOKIT} = "wx" ]; then bash travis-install-wx.sh; fi
+  - if [[ ${ETS_TOOLKIT} == "wx" ]]; then sh travis-install-wx.sh; fi
 install:
   - pip install -r travis-requirements.txt
   - python setup.py develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,21 @@ python:
   - 2.7
 virtualenv:
   system_site_packages: true
+env:
+  - ETS_TOOLKIT=qt4
+  - ETS_TOOLKIT=wx
 addons:
   apt:
     packages:
     - python-vtk
     - python-qt4
     - python-qt4-gl
+    - python-wxgtk2.8
     - python-imaging
     - python-pip
 before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  - export ETS_TOOLKIT=qt4
 install:
   - pip install -r travis-requirements.txt
   - python setup.py develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,14 @@ addons:
     - python-vtk
     - python-qt4
     - python-qt4-gl
-    - python-wxgtk2.8
     - python-imaging
     - python-pip
+    - mesa-common-dev
+    - libgtk-2.0-dev
 before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  - bash travis-install-wx sh
+  - bash travis-install-wx.sh
 install:
   - pip install -r travis-requirements.txt
   - python setup.py develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ cache:
     - $HOME/.ccache
 before_install:
   - export PATH=/usr/lib/ccache:${PATH}
+  - pip install --upgrade pip
   - if [[ ${ETS_TOOLKIT} == "wx" ]]; then sh travis-install-wx.sh; fi
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 =======================================================
-MayaVi2: 3D visualization of scientific data in Python 
+MayaVi2: 3D visualization of scientific data in Python
 =======================================================
 
 http://github.enthought.com/mayavi/mayavi
@@ -7,6 +7,10 @@ http://github.enthought.com/mayavi/mayavi
 .. image:: https://api.travis-ci.org/enthought/mayavi.png?branch=master
    :target: https://travis-ci.org/enthought/mayavi
    :alt: Build status
+
+.. image:: http://codecov.io/github/enthought/mayavi/coverage.svg?branch=master
+   :target: http://codecov.io/github/enthought/mayavi?branch=master
+
 
 Vision
 ======
@@ -26,7 +30,7 @@ Additionally Mayavi2 strives to be a reusable tool that can be embedded in your
 applications in different ways or combined with the envisage
 application-building framework to assemble domain-specific tools.
 
-Mayavi is part of the Enthought Tool Suite (ETS). 
+Mayavi is part of the Enthought Tool Suite (ETS).
 
 
 Features
@@ -88,7 +92,7 @@ Source tarballs for all stable ETS packages are available at
 Documentation
 ==============
 
-More documentation is available in the online user manual, 
+More documentation is available in the online user manual,
 
 http://github.enthought.com/mayavi/mayavi
 
@@ -144,9 +148,8 @@ Authors and Contributors
 
 * Support and code contributions from Enthought Inc.
 
-* Patches from many people (see the release notes), including K K Rai and 
+* Patches from many people (see the release notes), including K K Rai and
   R A Ambareesha for tensor support, parametric source and image data.
 
   Many thanks to all those who have submitted bug reports and suggestions for
   further enhancements.
-

--- a/checksums
+++ b/checksums
@@ -1,0 +1,1 @@
+8c06c5941477beee213b4f2fa78be620  download

--- a/travis-install-wx.sh
+++ b/travis-install-wx.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -e
-rm -Rf wxPython-src-2.8.12.1
-wget http://sourceforge.net/projects/wxpython/files/wxPython/2.8.12.1/wxPython-src-2.8.12.1.tar.bz2/download
+wget http://sourceforge.net/projects/wxpython/files/wxPython/2.8.12.1/wxPython-src-2.8.12.1.tar.bz2/download && md5sum -c checksums
 tar -xf download
 cd wxPython-src-2.8.12.1
 sed -i '/SEARCH_LIB=/a SEARCH_LIB=${SEARCH_LIB}" \/usr\/lib\/x86_64-linux-gnu"' ./configure

--- a/travis-install-wx.sh
+++ b/travis-install-wx.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 set -e
 rm -Rf wxPython-src-2.8.12.1
 wget http://sourceforge.net/projects/wxpython/files/wxPython/2.8.12.1/wxPython-src-2.8.12.1.tar.bz2/download
@@ -8,11 +9,11 @@ mkdir wxGTK-build
 cd wxGTK-build
 ../configure --enable-unicode --prefix=$VIRTUAL_ENV --enable-debug_flag --enable-optimize --with-opengl
 make -j 3
-make -C contrib/src/stc -j 3
-make -C contrib/src/gizmos -j 3
-make -j 3
 make install
+make -C contrib/src/stc -j 3
 make -C contrib/src/stc install
+make -C contrib/src/gizmos -j 3
 make -C contrib/src/gizmos install
+export LD_LIBRARY_PATH=$VIRTUAL_ENV/lib:${LD_LIBRARY_PATH}
 cd ../wxPython
 python setup.py install

--- a/travis-install-wx.sh
+++ b/travis-install-wx.sh
@@ -1,0 +1,17 @@
+set -e
+wget http://sourceforge.net/projects/wxpython/files/wxPython/2.8.12.1/wxPython-src-2.8.12.1.tar.bz2/download
+tar -xf download
+cd wxPython-src-2.8.12.1
+sed -i '/SEARCH_LIB=/a SEARCH_LIB=${SEARCH_LIB}" \/usr\/lib\/x86_64-linux-gnu"' ./configure
+mkdir wxGTK
+cd wxGTK
+../configure --enable-unicode --prefix=$VIRTUAL_ENV --enable-debug_flag --enable-optimize --with-opengl
+make -j 3
+make -C contrib/src/stc -j 3
+make -C contrib/src/gizmos -j 3
+make -j 3
+make install
+make -C contrib/src/stc install
+make -C contrib/src/gizmos install
+cd ../wxPython
+python setup.py install

--- a/travis-install-wx.sh
+++ b/travis-install-wx.sh
@@ -14,6 +14,5 @@ make -C contrib/src/stc -j 3
 make -C contrib/src/stc install
 make -C contrib/src/gizmos -j 3
 make -C contrib/src/gizmos install
-export LD_LIBRARY_PATH=$VIRTUAL_ENV/lib:${LD_LIBRARY_PATH}
 cd ../wxPython
 python setup.py install

--- a/travis-install-wx.sh
+++ b/travis-install-wx.sh
@@ -1,10 +1,11 @@
 set -e
+rm -Rf wxPython-src-2.8.12.1
 wget http://sourceforge.net/projects/wxpython/files/wxPython/2.8.12.1/wxPython-src-2.8.12.1.tar.bz2/download
 tar -xf download
 cd wxPython-src-2.8.12.1
 sed -i '/SEARCH_LIB=/a SEARCH_LIB=${SEARCH_LIB}" \/usr\/lib\/x86_64-linux-gnu"' ./configure
-mkdir wxGTK
-cd wxGTK
+mkdir wxGTK-build
+cd wxGTK-build
 ../configure --enable-unicode --prefix=$VIRTUAL_ENV --enable-debug_flag --enable-optimize --with-opengl
 make -j 3
 make -C contrib/src/stc -j 3

--- a/travis-requirements.txt
+++ b/travis-requirements.txt
@@ -1,0 +1,7 @@
+Sphinx
+coverage
+git+http://github.com/enthought/traits.git#egg=traits
+git+http://github.com/enthought/traitsui.git#egg=traitsui
+git+http://github.com/enthought/apptools.git#egg=apptools
+git+http://github.com/enthought/pyface.git#egg=pyface
+git+http://github.com/enthought/envisage.git#egg=envisage

--- a/travis-run-integration-tests.sh
+++ b/travis-run-integration-tests.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+cd integrationtests/mayavi
+coverage run --rcfile=../../.coveragerc -p run.py
+cd ../..
+cp integrationtests/mayavi/.coverage.* ./


### PR DESCRIPTION
This PR converted the travis-ci tests to use the new travis-ci containers so that the builds start faster.

In more details:
- Tests are run on both qt and wx
- Coverage is now uploaded onto codecov.io (https://codecov.io/github/enthought/mayavi)
- caching is used to speed up builds

**note**: The integration tests hang with Qt so they are skipped