### PR TITLE
Added setting of QVariant for example to work with PyQt4

### DIFF
--- a/docs/source/mayavi/auto/qt_embedding.py
+++ b/docs/source/mayavi/auto/qt_embedding.py
@@ -21,6 +21,7 @@ from pyface.qt import QtGui, QtCore
 # the following lines are executed before the import of PyQT:
 #   import sip
 #   sip.setapi('QString', 2)
+#   sip.setapi('QVariant', 2)
 
 from traits.api import HasTraits, Instance, on_trait_change
 from traitsui.api import View, Item


### PR DESCRIPTION
Hi Guys,

The qt embedding example with PyQt didn't work for me. Not on my mac, neither on my linux machines. I think it will also hold for others. Apparently, the QVariant also needs to be set before loading the PyQt modules. Couldn't find any other way to let you know, so I added this to the example here so it's easy to change.

kinds regards,

Mike Wilmer
