### PR TITLE
Fixes #173: Allow long keys when looking up points

### DIFF
--- a/tvtk/special_gen.py
+++ b/tvtk/special_gen.py
@@ -319,8 +319,11 @@ class SpecialGenerator:
                 yield obj.GetPoint(i)
 
         def _check_key(self, key, n):
-            if type(key) != type(1):
-                raise TypeError, "Only integers are valid keys."
+            ##############################################
+            # Allow int and long keys. Fixes GH Issue 173.
+            ##############################################
+            if type(key) not in [type(1), type(1L)]:
+                raise TypeError, "Only int and long are valid keys."
             if key < 0:
                 key =  n + key
             if key < 0 or key >= n:

--- a/tvtk/special_gen.py
+++ b/tvtk/special_gen.py
@@ -322,7 +322,7 @@ class SpecialGenerator:
             ##############################################
             # Allow int and long keys. Fixes GH Issue 173.
             ##############################################
-            if type(key) not in [type(1), type(1L)]:
+            if not isinstance(key, (int, long)):
                 raise TypeError, "Only int and long are valid keys."
             if key < 0:
                 key =  n + key

--- a/tvtk/tests/test_tvtk.py
+++ b/tvtk/tests/test_tvtk.py
@@ -291,6 +291,21 @@ class TestTVTK(unittest.TestCase):
         self.assertEqual(p.ambient_color, val)
         self.assertEqual(p.color, (0.5, 0.5, 0.5))
 
+    def test_points_lookup(self):
+        """ Test if points can be looked up with both int and long keys.
+            Fixes GH Issue 173.
+        """
+        points = tvtk.Points()
+        points.insert_next_point((0, 1, 2))
+        pt = points[0]
+        self.assertEqual(pt, (0, 1, 2))
+        ptl = points[0L]
+        self.assertEqual(ptl, (0, 1, 2))
+        get_pt = points.get_point(0)
+        self.assertEqual(get_pt, (0, 1, 2))
+        get_ptl = points.get_point(0L)
+        self.assertEqual(get_ptl, (0, 1, 2))
+
     def test_collection(self):
         """Test if Collection objects work nicely."""
         ac = tvtk.ActorCollection()


### PR DESCRIPTION
Fixes #173.

The special code generation in wrapping code is modified to allow look up with `long` keys in addition to existing int.

Test case added to test look up with `int`, `long` keys and also `get_point`.

---
Travis may fail for `qt4` with object_cache error, known issue and `wx` for wx src download problems. See PR #221 and #222.
