### PR TITLE
Clean up memory leaks implementation in #218

### DIFF
--- a/integrationtests/mayavi/common.py
+++ b/integrationtests/mayavi/common.py
@@ -5,6 +5,7 @@
 # License: BSD Style.
 
 # Standard library imports
+import gc
 import os
 import os.path
 import sys
@@ -17,7 +18,6 @@ from traits.etsconfig.api import ETSConfig
 from traits.api import  Any, Bool, Instance
 from pyface.api import GUI
 from tvtk.api import tvtk
-from tvtk.common import MemoryAssistant
 from mayavi.plugins.app import Mayavi, setup_logger
 
 # The TVTK window.
@@ -39,6 +39,118 @@ def off_screen_viewer():
 
 class MayaviTestError(Exception):
     pass
+
+###########################################################################
+# `MemoryAssistant` class.
+###########################################################################
+
+class MemoryAssistant(object):
+    """ Assistant methods to assert memory usage and memory leaks.
+    """
+    def assertMemoryUsage(self, process, usage, slack=0, msg=None):
+        """ Assert that the memory usage does not exceed the provided limit.
+
+        Parameters
+        ----------
+        process : psutil.Process
+            The process to check.
+        usage : float
+            The target memory usage. This is used as a soft-limit.
+        msg : str
+            The message to show on AssertionError.
+        slack : float
+            The percentage (relative to `usage`) that we allow the
+            process memory usage to exceed the soft limit. The default is 0.0
+
+        Raises
+        ------
+        AssertionError :
+            if the current memory usage of the process is higher than
+            :math:`usage * (1 + slack)`.
+
+        """
+        current_usage = self._memory_usage(process)
+        hard_limit = usage * (1 + slack)
+        if  hard_limit < current_usage:
+            if msg is None:
+                difference = (current_usage - usage) / usage
+                msg = "Memory leak of {:.2%}".format(difference)
+            raise AssertionError(msg)
+
+    def assertReturnsMemory(self, function, args=None, iterations=100,
+                            slack=0.0, msg=None):
+        """ Assert that the function does not retain memory over a number of
+        runs.
+
+        Parameters
+        ----------
+        func : callable
+            The function to check. The function should take no arguments.
+        args : tuple
+            The tuple of arguments to pass to the callable.
+        iterations : int
+            The number of times to run the function. Default is 100.
+        msg : str
+            The message to show on AssertionError.
+        slack : float
+            The percentage (relative to the first run) that we allow the
+            process memory usage to exceed the expected. The default is 0.0
+
+        Note
+        ----
+        The function is executed in-process thus any memory leaks will be
+        there to cause problems to other tests that are part of the currently
+        running test suite.
+
+        """
+        process = psutil.Process(os.getpid())
+
+        def test_function():
+            if args is None:
+                function()
+            else:
+                function(*args)
+
+        gc.collect()
+        baseline = self._memory_usage(process)
+        samples_msg   = "Samples           : {}"
+        mem_usage_msg = "Memory growth (MB): {:5.1f} to {:5.1f}"
+        mem_leak_msg =  "Memory leak   (%) : {:5.1f}"
+
+        try:
+            print 'Profiling',
+            sys.stdout.flush()
+            for index in xrange(iterations):
+                test_function()
+                print '.',
+                sys.stdout.flush()
+                gc.collect()
+                self.assertMemoryUsage(process, baseline, slack=slack)
+            ##########################################
+            # If we have come this far, we are golden!
+            ##########################################
+            final = self._memory_usage(process)
+            leak = (final - baseline) / baseline
+            print
+            print samples_msg.format(index + 1)
+            print mem_usage_msg.format(baseline, final)
+            print mem_leak_msg.format(leak * 100.0, index + 1)
+        except AssertionError:
+            final = self._memory_usage(process)
+            leak = (final - baseline) / baseline
+            if msg is None:
+                msg = 'Memory Leak!!!\n'
+                msg += samples_msg.format(index + 1)
+                msg += '\n'
+                msg += mem_usage_msg.format(baseline, final)
+                msg += '\n'
+                msg += mem_leak_msg.format(leak * 100.0, index + 1)
+                raise AssertionError(msg)
+            else:
+                raise AssertionError(msg)
+
+    def _memory_usage(self, process):
+        return float(process.get_memory_info().rss) / (1024 ** 2)
 
 ######################################################################
 # Image comparison utility functions.
@@ -461,6 +573,13 @@ class TestCase(Mayavi):
         if options.verbose:
             VERBOSE = True
             self.log_mode = logging.DEBUG
+        global psutil
+        if options.profile:
+            try:
+                import psutil
+            except ImportError:
+                msg = "Please install psutil to check memory usage"
+                raise ImportError(msg)
         self.offscreen = options.offscreen
         self.interact = options.interact
         self.profile = options.profile

--- a/integrationtests/mayavi/common.py
+++ b/integrationtests/mayavi/common.py
@@ -103,6 +103,12 @@ class MemoryAssistant(object):
         running test suite.
 
         """
+        try:
+            import psutil
+        except ImportError:
+            msg = "Please install psutil to check memory usage"
+            raise ImportError(msg)
+
         process = psutil.Process(os.getpid())
 
         def test_function():
@@ -573,13 +579,6 @@ class TestCase(Mayavi):
         if options.verbose:
             VERBOSE = True
             self.log_mode = logging.DEBUG
-        global psutil
-        if options.profile:
-            try:
-                import psutil
-            except ImportError:
-                msg = "Please install psutil to check memory usage"
-                raise ImportError(msg)
         self.offscreen = options.offscreen
         self.interact = options.interact
         self.profile = options.profile

--- a/tvtk/common.py
+++ b/tvtk/common.py
@@ -4,9 +4,7 @@
 # Copyright (c) 2005-2015, Enthought, Inc.
 # License: BSD Style.
 
-import gc
 import os
-import psutil
 import string
 import sys
 import re
@@ -144,118 +142,6 @@ class _Camel2Enthought:
                 return '_' + g1
         else:
             return '_' + g1 + g2
-
-###########################################################################
-# `MemoryAssistant` class.
-###########################################################################
-
-class MemoryAssistant(object):
-    """ Assistant methods to assert memory usage and memory leaks.
-    """
-    def assertMemoryUsage(self, process, usage, slack=0, msg=None):
-        """ Assert that the memory usage does not exceed the provided limit.
-
-        Parameters
-        ----------
-        process : psutil.Process
-            The process to check.
-        usage : float
-            The target memory usage. This is used as a soft-limit.
-        msg : str
-            The message to show on AssertionError.
-        slack : float
-            The percentage (relative to `usage`) that we allow the
-            process memory usage to exceed the soft limit. The default is 0.0
-
-        Raises
-        ------
-        AssertionError :
-            if the current memory usage of the process is higher than
-            :math:`usage * (1 + slack)`.
-
-        """
-        current_usage = self._memory_usage(process)
-        hard_limit = usage * (1 + slack)
-        if  hard_limit < current_usage:
-            if msg is None:
-                difference = (current_usage - usage) / usage
-                msg = "Memory leak of {:.2%}".format(difference)
-            raise AssertionError(msg)
-
-    def assertReturnsMemory(self, function, args=None, iterations=100,
-                            slack=0.0, msg=None):
-        """ Assert that the function does not retain memory over a number of
-        runs.
-
-        Parameters
-        ----------
-        func : callable
-            The function to check. The function should take no arguments.
-        args : tuple
-            The tuple of arguments to pass to the callable.
-        iterations : int
-            The number of times to run the function. Default is 100.
-        msg : str
-            The message to show on AssertionError.
-        slack : float
-            The percentage (relative to the first run) that we allow the
-            process memory usage to exceed the expected. The default is 0.0
-
-        Note
-        ----
-        The function is executed in-process thus any memory leaks will be
-        there to cause problems to other tests that are part of the currently
-        running test suite.
-
-        """
-        process = psutil.Process(os.getpid())
-
-        def test_function():
-            if args is None:
-                function()
-            else:
-                function(*args)
-
-        gc.collect()
-        baseline = self._memory_usage(process)
-        samples_msg   = "Samples           : {}"
-        mem_usage_msg = "Memory growth (MB): {:5.1f} to {:5.1f}"
-        mem_leak_msg =  "Memory leak   (%) : {:5.1f}"
-
-        try:
-            print 'Profiling',
-            sys.stdout.flush()
-            for index in xrange(iterations):
-                test_function()
-                print '.',
-                sys.stdout.flush()
-                gc.collect()
-                self.assertMemoryUsage(process, baseline, slack=slack)
-            ##########################################
-            # If we have come this far, we are golden!
-            ##########################################
-            final = self._memory_usage(process)
-            leak = (final - baseline) / baseline
-            print
-            print samples_msg.format(index + 1)
-            print mem_usage_msg.format(baseline, final)
-            print mem_leak_msg.format(leak * 100.0, index + 1)
-        except AssertionError:
-            final = self._memory_usage(process)
-            leak = (final - baseline) / baseline
-            if msg is None:
-                msg = 'Memory Leak!!!\n'
-                msg += samples_msg.format(index + 1)
-                msg += '\n'
-                msg += mem_usage_msg.format(baseline, final)
-                msg += '\n'
-                msg += mem_leak_msg.format(leak * 100.0, index + 1)
-                raise AssertionError(msg)
-            else:
-                raise AssertionError(msg)
-
-    def _memory_usage(self, process):
-        return float(process.get_memory_info().rss) / (1024 ** 2)
 
 # Instantiate a converter.
 camel2enthought = _Camel2Enthought()

--- a/tvtk/pyface/ui/wx/scene.py
+++ b/tvtk/pyface/ui/wx/scene.py
@@ -569,6 +569,7 @@ class Scene(TVTKScene, Widget):
     ###########################################################################
 
     def _closed_fired(self):
+        super(Scene, self)._closed_fired()
         self.picker = None
         self.light_manager = None
         self._interactor = None

--- a/tvtk/pyface/ui/wx/scene.py
+++ b/tvtk/pyface/ui/wx/scene.py
@@ -571,8 +571,6 @@ class Scene(TVTKScene, Widget):
     def _closed_fired(self):
         super(Scene, self)._closed_fired()
         self.picker = None
-        self.light_manager = None
-        self._interactor = None
         self._vtk_control = None
 
     ###########################################################################


### PR DESCRIPTION
This is a clean up for PR #218.

1. Remove `psutil` dependency. Moved the `MemoryAssistant` from `tvtk.common` to `integrationtests.common`.
2. Conditional import of `psutil`.
3. Call super `_closed_fired` for `wx Scene` implementation.