### PR TITLE
Remove redefined trait from scene model 

### DIFF
--- a/tvtk/pyface/scene_model.py
+++ b/tvtk/pyface/scene_model.py
@@ -17,7 +17,6 @@ Caveats:
 from traits.api import Dict, Event, \
                                  Instance, List, Property
 from traitsui.api import View, Group, Item, InstanceEditor
-from tvtk.pyface import light_manager
 from tvtk.pyface.tvtk_scene import TVTKScene
 
 
@@ -35,9 +34,6 @@ class SceneModel(TVTKScene):
 
     ########################################
     # TVTKScene traits.
-
-    # The light manager.
-    light_manager = Instance(light_manager.LightManager, record=True)
 
     picker = Property
 


### PR DESCRIPTION
Based on @prabhuramachandran  comment for PR #231, remove redefined light manager trait from scene model, which is not necessary. This was added when `closed` event was used to remove ref cycles.