### PR TITLE
Ensure cutter is updated when cut plane is changed.

### DIFF
--- a/integrationtests/mayavi/test_cut_plane.py
+++ b/integrationtests/mayavi/test_cut_plane.py
@@ -1,0 +1,105 @@
+"""Simple test for the scalar cut plane
+"""
+# Author: Deepak Surti
+# Copyright (c) 2015,  Enthought, Inc.
+# License: BSD Style.
+
+# Standard library imports.
+
+# Local imports.
+from common import TestCase, get_example_data
+
+class TestCutPlane(TestCase):
+    def check(self):
+        """Do the actual testing."""
+        script = self.script
+        e = script.engine
+        scene = e.current_scene
+        src = scene.children[0]
+        mm = src.children[0]
+        cp = mm.children[0]
+        ip = cp.implicit_plane
+        poly_data = cp.cutter.outputs[0]
+        initial_cells = poly_data.number_of_cells
+
+        # Change the plane normal
+        ip.normal = 1, 1, 1
+        updated_cells =  poly_data.number_of_cells
+        assert initial_cells != updated_cells
+
+        # Change the plane origin
+        ip.normal = 1, 1, 1
+        updated_cells =  poly_data.number_of_cells
+        assert initial_cells != updated_cells
+
+    def test(self):
+        self.main()
+
+    def add_cut_plane(self):
+        ############################################################
+        # Imports.
+        script = self.script
+        from mayavi.modules.scalar_cut_plane import ScalarCutPlane
+
+        ############################################################
+        # An interactive scalar cut plane.
+        cp = ScalarCutPlane()
+        script.add_module(cp)
+        ip = cp.implicit_plane
+        ip.normal = 0,0,1
+        ip.origin = 0,0,5
+        ip.widget.enabled = False
+
+    def do(self):
+        ############################################################
+        # Imports.
+        script = self.script
+        from mayavi.sources.vtk_file_reader import VTKFileReader
+        from mayavi.sources.vtk_xml_file_reader import VTKXMLFileReader
+
+        ############################################################
+        # Create a new scene and set up the visualization for structured data.
+        s = self.new_scene()
+
+        # Read a VTK (old style) data file.
+        r = VTKFileReader()
+        r.initialize(get_example_data('heart.vtk'))
+        script.add_source(r)
+
+        # Add the scalar cut plane
+        self.add_cut_plane()
+
+        # Set the scene to an isometric view.
+        s.scene.isometric_view()
+
+        # Now test.
+        self.check()
+
+        # Remove existing scene.
+        engine = script.engine
+        engine.close_scene(s)
+
+        # Create a new scene and set up the visualization for unstructured data.
+        s = self.new_scene()
+
+        # Read a VTK (old style) data file.
+        r = VTKXMLFileReader()
+        r.initialize(get_example_data('fire_ug.vtu'))
+        script.add_source(r)
+
+        # Add the scalar cut plane
+        self.add_cut_plane()
+
+        # Set the scene to an isometric view.
+        s.scene.isometric_view()
+
+        # Now test.
+        self.check()
+
+        # Remove existing scene.
+        engine = script.engine
+        engine.close_scene(s)
+
+if __name__ == "__main__":
+    t = TestCutPlane()
+    t.test()

--- a/mayavi/__init__.py
+++ b/mayavi/__init__.py
@@ -5,7 +5,7 @@
     Part of the Mayavi project of the Enthought Tool Suite.
 """
 
-__version__ = '4.4.4.dev0'
+__version__ = '4.4.3'
 
 __requires__ = [
     'apptools',

--- a/mayavi/__init__.py
+++ b/mayavi/__init__.py
@@ -5,7 +5,7 @@
     Part of the Mayavi project of the Enthought Tool Suite.
 """
 
-__version__ = '4.4.3'
+__version__ = '4.4.4.dev0'
 
 __requires__ = [
     'apptools',

--- a/mayavi/components/implicit_plane.py
+++ b/mayavi/components/implicit_plane.py
@@ -149,15 +149,18 @@ class ImplicitPlane(Component):
     ######################################################################
     def _get_normal(self):
         return self.widget.normal
+
     def _set_normal(self, value):
         w = self.widget
         old = w.normal
         w.normal = value
         self.trait_property_changed('normal', old, value)
         self.update_plane()
+        self.pipeline_changed = True
 
     def _get_origin(self):
         return self.widget.origin
+
     def _set_origin(self, value):
         # Ugly, but needed.
         w = tvtk.to_vtk(self.widget)

--- a/mayavi/tests/test_cut_plane.py
+++ b/mayavi/tests/test_cut_plane.py
@@ -80,3 +80,6 @@ class TestCutter(unittest.TestCase):
         e.add_source(r)
 
         self.check()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/mayavi/tests/test_cut_plane.py
+++ b/mayavi/tests/test_cut_plane.py
@@ -1,0 +1,82 @@
+# Author: Deepak Surti <dsurti@enthought.com>
+# Copyright (c) 2015,  Enthought, Inc.
+# License: BSD Style.
+
+# Standard library imports.
+import unittest
+
+# Local imports.
+import datasets
+from common import get_example_data
+
+# Enthought library imports
+from mayavi.core.null_engine import NullEngine
+from mayavi.sources.vtk_data_source import VTKDataSource
+from mayavi.modules.scalar_cut_plane import ScalarCutPlane
+from mayavi.sources.unstructured_grid_reader import UnstructuredGridReader
+
+
+class TestCutter(unittest.TestCase):
+
+    def setUp(self):
+        """Initial setting up of test fixture, automatically called by TestCase
+           before any other test method is invoked"""
+
+        e = NullEngine()
+        # Uncomment to see visualization for debugging etc.
+        #from mayavi.core.engine import Engine
+        #e = Engine()
+        e.start()
+        e.new_scene()
+        self.e = e
+
+    def tearDown(self):
+        """For necessary clean up, automatically called by TestCase after the
+           test methods have been invoked""" 
+        self.e.stop()
+        return
+
+    def check(self):
+        """ Configures the scalar cut plane and checks the cutter output
+            changes when the plane is changed.
+        """
+        e = self.e
+
+        # An interactive scalar cut plane.
+        cp = ScalarCutPlane()
+        e.add_module(cp)
+        self.cp = cp
+
+        ip = cp.implicit_plane
+        ip.origin = -1.5, -1.5, -1.5
+        poly_data = cp.cutter.outputs[0]
+        initial_cells = poly_data.number_of_cells
+
+        # Change the plane normal
+        ip.normal = 1, 1, 1
+        updated_cells =  poly_data.number_of_cells
+        self.assertNotEqual(initial_cells, updated_cells)
+
+        # Change the plane origin
+        ip.normal = 1, 1, 1
+        updated_cells =  poly_data.number_of_cells
+        self.assertNotEqual(initial_cells, updated_cells)
+
+    def test_with_structured_data(self):
+        e = self.e
+
+        sgrid=datasets.generateStructuredGrid()
+        src = VTKDataSource(data = sgrid)
+        e.add_source(src)
+
+        self.check()
+
+    def test_with_unstructured_data(self):
+        e = self.e
+
+        # Read a AVSUCD data file.
+        r = UnstructuredGridReader()
+        r.initialize(get_example_data('cellsnd.ascii.inp'))
+        e.add_source(r)
+
+        self.check()


### PR DESCRIPTION
Fixes #164.

1. The implicit plane fires `pipeline_changed` which ensures `cutter` is updated.
2. Unit test to test with both structured and unstructured data that cutter output changes when cut plane normal/origin is changed.
3. Integration test.