### PR TITLE
Partial support for python3 sphinx-build

### DIFF
--- a/docs/source/mayavi/sphinxext/docscrape.py
+++ b/docs/source/mayavi/sphinxext/docscrape.py
@@ -6,7 +6,7 @@ import inspect
 import textwrap
 import re
 import pydoc
-from StringIO import StringIO
+from io import StringIO
 from warnings import warn
 
 class Reader(object):
@@ -399,13 +399,13 @@ class FunctionDoc(NumpyDocString):
         self._role = role # e.g. "func" or "meth"
         try:
             NumpyDocString.__init__(self,inspect.getdoc(func) or '')
-        except ValueError, e:
-            print '*'*78
-            print "ERROR: '%s' while parsing `%s`" % (e, self._f)
-            print '*'*78
-            #print "Docstring follows:"
-            #print doclines
-            #print '='*78
+        except ValueError as e:
+            print('*'*78)
+            print("ERROR: '%s' while parsing `%s`" % (e, self._f))
+            print('*'*78)
+            #print("Docstring follows:")
+            #print(doclines)
+            #print('='*78)
 
         if not self['Signature']:
             func, func_name = self.get_func()
@@ -415,7 +415,7 @@ class FunctionDoc(NumpyDocString):
                 argspec = inspect.formatargspec(*argspec)
                 argspec = argspec.replace('*','\*')
                 signature = '%s%s' % (func_name, argspec)
-            except TypeError, e:
+            except TypeError as e:
                 signature = '%s()' % func_name
             self['Signature'] = signature
 
@@ -438,7 +438,7 @@ class FunctionDoc(NumpyDocString):
 
         if self._role:
             if not roles.has_key(self._role):
-                print "Warning: invalid role %s" % self._role
+                print("Warning: invalid role %s" % self._role)
             out += '.. %s:: %s\n    \n\n' % (roles.get(self._role,''),
                                              func_name)
 
@@ -471,7 +471,7 @@ class ClassDoc(NumpyDocString):
         out += "\n\n"
 
         #for m in self.methods:
-        #    print "Parsing `%s`" % m
+        #    print("Parsing `%s`" % m)
         #    out += str(self._func_doc(getattr(self._cls,m), 'meth')) + '\n\n'
         #    out += '.. index::\n   single: %s; %s\n\n' % (self._name, m)
 

--- a/docs/source/mayavi/sphinxext/numpydoc.py
+++ b/docs/source/mayavi/sphinxext/numpydoc.py
@@ -26,7 +26,7 @@ def mangle_docstrings(app, what, name, obj, options, lines,
             try:
                 references.append(int(l[len('.. ['):l.index(']')]))
             except ValueError:
-                print "WARNING: invalid reference in %s docstring" % name
+                print("WARNING: invalid reference in %s docstring" % name)
 
     # Start renaming from the biggest number, otherwise we may
     # overwrite references.
@@ -81,7 +81,7 @@ def initialize(app):
 
     fn = app.config.numpydoc_phantom_import_file
     if (fn and os.path.isfile(fn)):
-        print "[numpydoc] Phantom importing modules from", fn, "..."
+        print("[numpydoc] Phantom importing modules from", fn, "...")
         import_phantom_module(fn)
 
 def setup(app):
@@ -275,7 +275,7 @@ def _import_by_name(name):
             return obj
         else:
             return sys.modules[modname]
-    except (ValueError, ImportError, AttributeError, KeyError), e:
+    except (ValueError, ImportError, AttributeError, KeyError) as e:
         raise ImportError(e)
 
 #------------------------------------------------------------------------------
@@ -315,7 +315,7 @@ def monkeypatch_sphinx_ext_autodoc():
     if sphinx.ext.autodoc.format_signature is our_format_signature:
         return
 
-    print "[numpydoc] Monkeypatching sphinx.ext.autodoc ..."
+    print("[numpydoc] Monkeypatching sphinx.ext.autodoc ...")
     _original_format_signature = sphinx.ext.autodoc.format_signature
     sphinx.ext.autodoc.format_signature = our_format_signature
 

--- a/docs/source/mayavi/sphinxext/traitsdoc.py
+++ b/docs/source/mayavi/sphinxext/traitsdoc.py
@@ -126,7 +126,7 @@ def initialize(app):
 
     fn = app.config.numpydoc_phantom_import_file
     if (fn and os.path.isfile(fn)):
-        print "[numpydoc] Phantom importing modules from", fn, "..."
+        print("[numpydoc] Phantom importing modules from", fn, "...")
         numpydoc.import_phantom_module(fn)
 
 def setup(app):


### PR DESCRIPTION
Fedora recently (and briefly) shifted /usr/bin/sphinx-build to use python3.  mayavi build breaks with:
~~~~~
sphinx-build -b html -d build/mayavi/doctrees   source/mayavi build/mayavi/html
Running Sphinx v1.3.1
making output directory...
Exception occurred:
  File "/usr/lib/python3.5/site-packages/sphinx/application.py", line 429, in
setup_extension
    mod = __import__(extension, None, None, ['setup'])
  File
"/builddir/build/BUILD/mayavi-4.4.3/docs/source/mayavi/sphinxext/traitsdoc.py", line
129
    print "[numpydoc] Phantom importing modules from", fn, "..."
                                                    ^
SyntaxError: Missing parentheses in call to 'print'
~~~~~
and other similar python3 issues.  This is a partial fix for them.  It's still failing with:
~~~~~
Running Sphinx v1.3.1
making output directory...
Extension error:
Could not import extension traitsdoc (exception: No module named 'compiler')
~~~~~
But I'm done for now, and Fedora has switched back to python2 for sphinx-build for now.  But it will be updated at some point.