### PR TITLE
Check for a `find` method of parsed VTK docstring

### DIFF
--- a/tvtk/vtk_parser.py
+++ b/tvtk/vtk_parser.py
@@ -308,6 +308,8 @@ class VTKMethodParser:
                 return None
         # Remove all the C++ function signatures.
         doc = method.__doc__
+        if not hasattr(doc, 'find'):
+            return None
         doc = doc[:doc.find('\n\n')]
         sig = []
         c_sig = [] # The C++ signature


### PR DESCRIPTION
The VTK parser method `get_method_signature` now uses `hasattr()` to confirm that the `__doc__` attributes it is inspecting do in fact have valid string methods, prior to calling any of those methods.

This fixes #261 – a bug that, without this change, will persist for me when building mayavi on OS X (10.10 and 10.11) regardless of whether I apply PR #247 (q.v. http://git.io/vRS8E).