### PR TITLE
make sure that the __file__ points to the srcipt file when running scripts

### DIFF
--- a/mayavi/action/save_load.py
+++ b/mayavi/action/save_load.py
@@ -109,6 +109,7 @@ class RunScript(Action):
                 mv = get_imayavi(self.window)
                 g['mayavi'] = mv
                 g['engine'] = mv.engine
+            g['__file__'] = dialog.path
             # Do execfile
             try:
                 # If we don't pass globals twice we get NameErrors and nope,

--- a/mayavi/scripts/mayavi2.py
+++ b/mayavi/scripts/mayavi2.py
@@ -405,6 +405,7 @@ def run_script(mayavi, script_name):
     if 'mayavi' not in g:
         g['mayavi'] = mayavi
         g['engine'] = mayavi.engine
+    g['__file__'] = script_name
     error = False
     # Do execfile
     try:


### PR DESCRIPTION
I recently faced a problem were running a script from Mayavi2 will mess-up the `__file__` attribute of the script. Using the `__file__` attribute is common for loading data so having the atrribute point to the right path is important.

The change is small and looks harmless, but I am not completely sure. I would also like ideas on how to test this.

@dmsurti  and @prabhuramachandran  please have a look 