### PR TITLE
Allow TVTK to be used without X

### DIFF
--- a/tvtk/tests/test_tvtk.py
+++ b/tvtk/tests/test_tvtk.py
@@ -667,8 +667,10 @@ class TestTVTKModule(unittest.TestCase):
     def test_import_tvtk_does_not_import_gui(self):
         from subprocess import check_output, STDOUT
 
-        output = check_output([sys.executable, "-v", "-c",
-                               "from tvtk.api import tvtk"], stderr=STDOUT)
+        output = check_output(
+            [sys.executable, "-v", "-c",
+             "from tvtk.api import tvtk; p = tvtk.Property()"], stderr=STDOUT
+        )
         output = output.decode('ascii')
         self.assertFalse('QtCore' in output)
         self.assertFalse('wx' in output)

--- a/tvtk/tests/test_tvtk.py
+++ b/tvtk/tests/test_tvtk.py
@@ -669,6 +669,7 @@ class TestTVTKModule(unittest.TestCase):
 
         output = check_output([sys.executable, "-v", "-c",
                                "from tvtk.api import tvtk"], stderr=STDOUT)
+        output = output.decode('ascii')
         self.assertFalse('QtCore' in output)
         self.assertFalse('wx' in output)
 

--- a/tvtk/tests/test_tvtk.py
+++ b/tvtk/tests/test_tvtk.py
@@ -5,7 +5,7 @@ make sure that the generated code works well.
 
 """
 # Author: Prabhu Ramachandran
-# Copyright (c) 2004-2015, Enthought, Inc.
+# Copyright (c) 2004-2016, Enthought, Inc.
 # License: BSD Style.
 
 import unittest
@@ -664,6 +664,13 @@ class TestTVTKModule(unittest.TestCase):
             message = "Not all classes could be instantiated:\n{0}\n"
             raise AssertionError(message.format(''.join(errors)))
 
+    def test_import_tvtk_does_not_import_gui(self):
+        from subprocess import check_output, STDOUT
+
+        output = check_output([sys.executable, "-v", "-c",
+                               "from tvtk.api import tvtk"], stderr=STDOUT)
+        self.assertFalse('QtCore' in output)
+        self.assertFalse('wx' in output)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tvtk/tvtk_base.py
+++ b/tvtk/tvtk_base.py
@@ -15,11 +15,24 @@ import logging
 import vtk
 
 from traits import api as traits
-from traitsui.api import (BooleanEditor, RGBColorEditor, FileEditor)
 from . import messenger
 
 # Setup a logger for this module.
 logger = logging.getLogger(__name__)
+
+
+def BooleanEditor(*args, **kw):
+    from traitsui.api import BooleanEditor as Editor
+    return Editor(*args, **kw)
+
+def RGBColorEditor(*args, **kw):
+    from traitsui.api import RGBColorEditor as Editor
+    return Editor(*args, **kw)
+
+def FileEditor(*args, **kw):
+    from traitsui.api import FileEditor as Editor
+    return Editor(*args, **kw)
+
 
 ######################################################################
 # The TVTK object cache.

--- a/tvtk/tvtk_base_handler.py
+++ b/tvtk/tvtk_base_handler.py
@@ -1,14 +1,21 @@
 """ Handler and UI elements for tvtk objects.
 """
 # Author: Vibha Srinivasan <vibha@enthought.com>
-# Copyright (c) 2008,  Enthought, Inc.
+# Copyright (c) 2008-2016,  Enthought, Inc.
 # License: BSD Style.
 
 from traits.api import HasTraits, Str, Instance, Property, Button, List, Enum
-from traitsui.api import Handler, UIInfo, TableEditor, View, Item
-from traitsui.table_column import ObjectColumn
-from traits.trait_base \
-    import user_name_for, xgetattr
+from traitsui.handler import Handler
+from traitsui.ui_info import UIInfo
+from traitsui.item import Item
+from traitsui.view import View
+from traits.trait_base import user_name_for, xgetattr
+
+def TableEditor(*args, **kw):
+   from .value_column import ObjectColumn, ValueColumn
+   from traitsui.api import TableEditor as _E
+   return _E(columns=[ObjectColumn(name='name'), ValueColumn(name='value')])
+
 
 class TraitsViewObject(HasTraits):
    """ Wrapper for all items to be included in the full traits view of the TVTKBase
@@ -22,48 +29,6 @@ class TraitsViewObject(HasTraits):
    parent = Instance(HasTraits)
 
 
-class ValueColumn(ObjectColumn):
-   """ Column to display the trait value for each trait of a tvtk object.
-   """
-
-   def get_object ( self, object ):
-        """ Returns the actual object being edited.
-        Overridden here to return the tvtk object (which is the parent trait of object).
-
-        """
-        return object.parent
-
-
-   def target_name ( self, object ):
-        """ Returns the target object and name for the column.
-        Overridden here to return the trait name (which is the object's name trait) rather than the
-        column's name trait.
-
-        """
-        name   = object.name
-        object = self.get_object( object )
-        col    = name.rfind( '.' )
-        if col < 0:
-            return ( object, name )
-
-        return ( xgetattr( object, name[ :col ] ), name[ col + 1: ] )
-
-
-   def get_raw_value ( self, object ):
-        """ Gets the unformatted value of the column for a specified object.
-        Overridden here to return the trait name (which is the object's name trait) rather than the
-        column's name trait.
-
-        """
-        try:
-            target, name = self.target_name( object )
-            return xgetattr( target, name )
-        except:
-            return None
-
-
-""" A handler for the TVTKBase object.
-"""
 
 class TVTKBaseHandler(Handler):
    """ A handler for the TVTKBase object.
@@ -80,9 +45,7 @@ class TVTKBaseHandler(Handler):
 
    # List of TraitsViewObject items, where each item contains information
    # about the trait to display as a row in a table editor.
-   _full_traits_list = Property(List, editor = TableEditor(columns =
-                                           [ObjectColumn(name='name'),
-                                            ValueColumn(name='value')]))
+   _full_traits_list = Property(List, editor=TableEditor)
 
    def init_info(self, info):
        """ Informs the handler what the UIInfo object for a View will be.

--- a/tvtk/value_column.py
+++ b/tvtk/value_column.py
@@ -1,0 +1,43 @@
+"""Used by tvtk_base_handler to create a UI.
+"""
+from traitsui.table_column import ObjectColumn
+
+
+class ValueColumn(ObjectColumn):
+   """ Column to display the trait value for each trait of a tvtk object.
+   """
+
+   def get_object ( self, object ):
+        """ Returns the actual object being edited.
+        Overridden here to return the tvtk object (which is the parent trait of object).
+
+        """
+        return object.parent
+
+
+   def target_name ( self, object ):
+        """ Returns the target object and name for the column.
+        Overridden here to return the trait name (which is the object's name trait) rather than the
+        column's name trait.
+
+        """
+        name   = object.name
+        object = self.get_object( object )
+        col    = name.rfind( '.' )
+        if col < 0:
+            return ( object, name )
+
+        return ( xgetattr( object, name[ :col ] ), name[ col + 1: ] )
+
+
+   def get_raw_value ( self, object ):
+        """ Gets the unformatted value of the column for a specified object.
+        Overridden here to return the trait name (which is the object's name trait) rather than the
+        column's name trait.
+
+        """
+        try:
+            target, name = self.target_name( object )
+            return xgetattr( target, name )
+        except:
+            return None

--- a/tvtk/wrapper_gen.py
+++ b/tvtk/wrapper_gen.py
@@ -100,7 +100,9 @@ class WrapperGenerator:
         prelim = """
         # Automatically generated code: EDIT AT YOUR OWN RISK
         from traits import api as traits
-        from traitsui import api as traitsui
+        from traitsui.item import Item, spring
+        from traitsui.group import HGroup
+        from traitsui.view import View
 
         from tvtk import vtk_module as vtk
         from tvtk import tvtk_base
@@ -110,6 +112,11 @@ class WrapperGenerator:
         from tvtk import array_handler
         from tvtk.array_handler import deref_array
         from tvtk.tvtk_classes.tvtk_helper import wrap_vtk
+
+
+        def InstanceEditor(*args, **kw):
+            from traitsui.editors.api import InstanceEditor as Editor
+            return Editor(view_name="handler.view")
 
         try:
             long
@@ -272,8 +279,8 @@ class WrapperGenerator:
         out.write(self.indent.format(code))
         self.indent.incr()
         item_contents = (
-              'traitsui.Item("handler._full_traits_list",show_label=False)')
-        junk = 'traitsui.View((%s),'% item_contents
+              'Item("handler._full_traits_list",show_label=False)')
+        junk = 'View((%s),'% item_contents
         code = "\nfull_traits_view = \\" + \
                "\n%s\ntitle=\'%s\', scrollable=True, resizable=True,"\
                "\nhandler=TVTKBaseHandler,"\
@@ -294,7 +301,7 @@ class WrapperGenerator:
         t_g = sorted(toggle.keys())
         s_g = sorted(state.keys())
         gs_g = sorted(get_set.keys())
-        junk = textwrap.fill('traitsui.View((%s, %s, %s),'%(t_g, s_g, gs_g))
+        junk = textwrap.fill('View((%s, %s, %s),'%(t_g, s_g, gs_g))
         code = "\nview = \\" + \
                "\n%s\ntitle=\'%s\', scrollable=True, resizable=True,"\
                "\nhandler=TVTKBaseHandler,"\
@@ -309,13 +316,13 @@ class WrapperGenerator:
         out.write(self.indent.format(code))
         self.indent.incr()
         viewtype_contents = (
-            'traitsui.HGroup(traitsui.spring, "handler.view_type", ' +\
+            'HGroup(spring, "handler.view_type", ' +\
                              'show_border=True)')
         view_contents = (
-            '\ntraitsui.Item("handler.info.object", ' +\
-            'editor = traitsui.InstanceEditor(view_name="handler.view"), ' +\
+            '\nItem("handler.info.object", ' +\
+            'editor = InstanceEditor(view_name="handler.view"), ' +\
             'style = "custom", show_label=False)')
-        junk = 'traitsui.View((%s, %s),'% (viewtype_contents, view_contents)
+        junk = 'View((%s, %s),'% (viewtype_contents, view_contents)
         code = "\ntraits_view = \\" + \
                "\n%s\ntitle=\'%s\', scrollable=True, resizable=True,"\
                "\nhandler=TVTKBaseHandler,"\

--- a/tvtk/wrapper_gen.py
+++ b/tvtk/wrapper_gen.py
@@ -311,7 +311,8 @@ class WrapperGenerator:
         self.indent.decr()
 
         # Finally, we write the default traits_view which includes a field
-        # for specifying the view type (basic or advanced) and the                     # corresponding view (basic->view and advanced->full_traits_view)
+        # for specifying the view type (basic or advanced) and the
+        # corresponding view (basic->view and advanced->full_traits_view)
         code = "\nelif name in (None, 'traits_view'):"
         out.write(self.indent.format(code))
         self.indent.incr()


### PR DESCRIPTION
Currently this is not possible since there are imports to traitsui.api.
For example if one is connected to a machine via ssh and no X11
forwarded and simply does `from tvtk.api import tvtk`, the application
will close.  This should allow a user to use TVTK without a UI/X server
just as they would with VTK.