### PR TITLE
Fix QVTKRenderWindowInteractor._get_win_id()

### DIFF
--- a/tvtk/pyface/ui/qt4/QVTKRenderWindowInteractor.py
+++ b/tvtk/pyface/ui/qt4/QVTKRenderWindowInteractor.py
@@ -266,7 +266,7 @@ class QVTKRenderWindowInteractor(QWidget):
             pythonapi.PyCapsule_GetPointer.argtypes = [py_object, c_char_p]
 
             WId = pythonapi.PyCapsule_GetPointer(WId, name)
-        return str(WId)
+        return str(int(WId))
 
     def Finalize(self):
         '''


### PR DESCRIPTION
Under Python 3 and Windows, the conversion str(WId) will return
the representative string of the object instead of the integer id
as string. This fix mirrors the behaviour of VTK's own
QVTKRenderWindowInteractor.

For more information on this bug, see
 http://vtk.1045678.n5.nabble.com/OpenGL-fails-to-initialize-for-Windows-7-VTK-7-0-td5736723.html