### PR TITLE
Fix get_engine options agreement

### DIFF
--- a/mayavi/tests/test_engine_manager.py
+++ b/mayavi/tests/test_engine_manager.py
@@ -32,37 +32,49 @@ class TestEngineManager(unittest.TestCase):
     @patch_backend("envisage")
     @patch_registry_engines({"EnvisageEngine1": EnvisageEngine()})
     def test_get_engine_backend_envisage(self):
-        self.assertIsInstance(get_engine(), EnvisageEngine)
+        self.assertIs(type(get_engine()), EnvisageEngine)
 
     @patch_backend("simple")
     @patch_registry_engines({"Engine1": NullEngine()})
     def test_get_engine_backend_simple_with_existing_engine(self):
-        self.assertIsInstance(get_engine(), Engine)
+        self.assertIs(type(get_engine()), Engine)
 
     @patch_backend("auto")
     @patch_registry_engines({"Engine1": EnvisageEngine()})
     def test_get_engine_backend_auto_with_existing_engine(self):
-        self.assertIsInstance(get_engine(), EnvisageEngine)
+        self.assertIs(type(get_engine()), EnvisageEngine)
 
     @patch_backend("envisage")
     @patch_registry_engines({"EnvisageEngine1": EnvisageEngine()})
     @patch_offscreen(True)
     def test_get_engine_offscreen_backend_envisage(self):
-        self.assertIsInstance(get_engine(), EnvisageEngine)
+        self.assertIs(type(get_engine()), EnvisageEngine)
 
     @patch_backend("test")
     @patch_offscreen(True)
     def test_get_engine_offscreen_backend_test(self):
-        self.assertIsInstance(get_engine(), NullEngine)
+        self.assertIs(type(get_engine()), NullEngine)
 
     @patch_backend("auto")
     @patch_offscreen(True)
     @patch_registry_engines({"Engine1": Engine()})
     def test_get_engine_offscreen_backend_auto_with_existing_engine(self):
-        self.assertIsInstance(get_engine(), OffScreenEngine)
+        self.assertIs(type(get_engine()), OffScreenEngine)
+
+    @patch_backend("auto")
+    @patch_offscreen(True)
+    @patch_registry_engines({"Engine1": Engine()})
+    def test_get_engine_offscreen_backend_auto_switched_twice(self):
+        self.assertIs(type(get_engine()), OffScreenEngine)
+        # Now OffScreenEngine is the last used engine
+        # if offscreen is switched back to False
+        # get_engine should not return an OffScreenEngine
+        from mayavi.tools.engine_manager import options
+        options.offscreen = False
+        self.assertIs(type(get_engine()), Engine)
 
     @patch_backend("simple")
     @patch_offscreen(True)
     @patch_registry_engines({"Engine1": Engine()})
     def test_get_engine_offscreen_backend_simple_with_started_engine(self):
-        self.assertIsInstance(get_engine(), OffScreenEngine)
+        self.assertIs(type(get_engine()), OffScreenEngine)

--- a/mayavi/tools/engine_manager.py
+++ b/mayavi/tools/engine_manager.py
@@ -92,7 +92,8 @@ class EngineManager(HasTraits):
                                 if e.__class__.__name__ == 'OffScreenEngine']
         elif options.backend == 'auto':
             suitable = [e for e in engines
-                                if e.__class__.__name__ != 'NullEngine']
+                        if e.__class__.__name__ not in ('NullEngine',
+                                                        'OffScreenEngine')]
         else:
             suitable = [e for e in engines
                                 if e.__class__.__name__ == 'Engine']


### PR DESCRIPTION
- If someone switches `offscreen` on, gets an OffScreenEngine created and registered, then switches `offscreen` off again, `get_engine` would still return `OffScreenEngine` if `backend=="auto".  This doesn't make sense (or should it?).  So here I implemented a fix for this special case.

- Test for `get_engine` is made more robust by using `assertIs` instead of `assertIsInstance` as NullEngine, EnvisageEngine, OffScreenEngine are all subclass of Engine (so only L40 of the master `test_engine_manager.py` is dubious).  But this is a crucial distinction for the new test added in this PR