### PR TITLE
SetSize needs to be called as an unbound method (ref: Kitware/VTK)

### DIFF
--- a/integrationtests/mayavi/test_mlab_savefig.py
+++ b/integrationtests/mayavi/test_mlab_savefig.py
@@ -4,7 +4,6 @@ import unittest
 import tempfile
 
 import numpy
-from PIL import Image
 
 from mayavi import mlab
 from mayavi.core.engine import Engine

--- a/integrationtests/mayavi/test_mlab_savefig.py
+++ b/integrationtests/mayavi/test_mlab_savefig.py
@@ -1,0 +1,96 @@
+import os
+import shutil
+import unittest
+import tempfile
+
+import numpy
+from PIL import Image
+
+from mayavi import mlab
+from mayavi.core.engine import Engine
+from mayavi.core.off_screen_engine import OffScreenEngine
+from mayavi.tools.figure import savefig
+
+from common import TestCase
+
+
+def create_quiver3d():
+    x, y, z = numpy.mgrid[1:10, 1:10, 1:10]
+    u, v, w = numpy.mgrid[1:10, 1:10, 1:10]
+    s = numpy.sqrt(u**2 + v**2)
+    mlab.quiver3d(x, y, z, u, v, w, scalars=s)
+
+
+# Note: the figure(window) size is delibrately set to be smaller than
+# the required size in `savefig`, this forces the re-rendering to
+# occur and catch any potential ill rendering
+
+class TestMlabSavefigUnitTest(unittest.TestCase):
+
+    def setUp(self):
+        # Make a temporary directory for saved figures
+        self.temp_dir = tempfile.mkdtemp()
+        self.filename = os.path.join(self.temp_dir, "saved_figure.png")
+
+        # this ensures that the temporary directory is removed
+        self.addCleanup(self.remove_tempdir)
+
+    def remove_tempdir(self):
+        shutil.rmtree(self.temp_dir)
+
+    def setup_engine_and_figure(self, engine):
+        # Set up a Engine/OffScreenEngine/... for the test case
+        self.engine = engine
+
+        if not engine.running:
+            engine.start()
+
+        # figure size is set to be small to force re-rendering
+        engine.new_scene(size=(90, 100))
+        self.figure = engine.current_scene
+
+        # the clean up function will close all figures and stop the engine
+        self.addCleanup(self.cleanup_engine, self.engine)
+
+    def cleanup_engine(self, engine):
+        """ Close all scenes in the engine and stop it """
+        scenes = [scene for scene in engine.scenes]
+        for scene in scenes:
+            engine.close_scene(scene)
+        engine.stop()
+
+    @unittest.skipIf(os.environ.get("TRAVIS", False),
+                     ("Offscreen rendering is not tested on Travis "
+                      "due to lack of GLX support"))
+    def test_many_savefig_offscreen(self):
+        """Test if savefig works with off_screen_rendering and Engine"""
+        engine = Engine()
+        for _ in xrange(5):
+            self.setup_engine_and_figure(engine)
+
+            # Use off-screen rendering
+            self.figure.scene.off_screen_rendering = True
+
+            # Set up the scene
+            create_quiver3d()
+
+            # save the figure
+            savefig(self.filename, size=(131, 217),
+                    figure=self.figure)
+
+
+
+class TestMlabSavefig(TestCase):
+
+    def test(self):
+        self.main()
+
+    def do(self):
+        suite = unittest.TestLoader().loadTestsFromTestCase(
+            TestMlabSavefigUnitTest)
+        unittest.TextTestRunner().run(suite)
+
+
+if __name__ == "__main__":
+    t = TestMlabSavefig()
+    t.test()

--- a/integrationtests/mayavi/test_mlab_savefig.py
+++ b/integrationtests/mayavi/test_mlab_savefig.py
@@ -79,7 +79,6 @@ class TestMlabSavefigUnitTest(unittest.TestCase):
                     figure=self.figure)
 
 
-
 class TestMlabSavefig(TestCase):
 
     def test(self):

--- a/tvtk/pyface/ui/qt4/QVTKRenderWindowInteractor.py
+++ b/tvtk/pyface/ui/qt4/QVTKRenderWindowInteractor.py
@@ -330,7 +330,7 @@ class QVTKRenderWindowInteractor(QWidget):
         w = self.width()
         h = self.height()
 
-        self._RenderWindow.SetSize(w, h)
+        vtk.vtkRenderWindow.SetSize(self._RenderWindow, w, h)
         self._Iren.SetSize(w, h)
         self._Iren.ConfigureEvent()
         self.update()


### PR DESCRIPTION
Fix #302 
The solution is found here: https://github.com/Kitware/VTK/blob/v6.3.0/Wrapping/Python/vtk/qt4/QVTKRenderWindowInteractor.py

Should we refactor the changes we make as an extension such that we can import QVTKRenderWindowInteractor from vtk directly (and then subclass etc)?