### PR TITLE
Fix mlab.move error

### DIFF
--- a/integrationtests/mayavi/test_tools_camera.py
+++ b/integrationtests/mayavi/test_tools_camera.py
@@ -79,10 +79,8 @@ class TestCameraUnitTest(unittest.TestCase):
     def test_camera_move_with_right(self):
         camera = self.engine.current_scene.scene.camera
 
-        with check_attrs_change(self, camera,
-                                ("focal_point", "position")), \
-                check_attrs_do_not_change(self, camera,
-                                          ("clipping_range",)):
+        with check_attrs_change(self, camera, ("focal_point", "position")), \
+                check_attrs_do_not_change(self, camera, ("clipping_range",)):
             camera_tools.move(right=20.)
 
     def test_camera_move_with_up(self):

--- a/integrationtests/mayavi/test_tools_camera.py
+++ b/integrationtests/mayavi/test_tools_camera.py
@@ -1,0 +1,109 @@
+"""Tests for the tools.camera
+"""
+import unittest
+from contextlib import contextmanager
+
+from numpy import array
+from mayavi import mlab
+from mayavi.sources.builtin_image import BuiltinImage
+
+from mayavi.tools import camera as camera_tools
+
+from common import TestCase
+
+
+@contextmanager
+def check_attrs_change(test_case, obj, attrs):
+    old_attrs = {attr: array(getattr(obj, attr))
+                 for attr in attrs}
+
+    try:
+        yield
+    finally:
+        unchanged = []
+
+        for attr, old_value in old_attrs.items():
+            new_value = array(getattr(obj, attr))
+
+            if all(new_value == old_value):
+                unchanged.append(attr)
+
+        if unchanged:
+            msg = "Expect {} to change.  They stayed the same."
+            test_case.fail(msg.format(", ".join(unchanged)))
+
+
+@contextmanager
+def check_attrs_do_not_change(test_case, obj, attrs):
+    old_attrs = {attr: array(getattr(obj, attr))
+                 for attr in attrs}
+
+    try:
+        yield
+    finally:
+        changed = []
+
+        for attr, old_value in old_attrs.items():
+            new_value = array(getattr(obj, attr))
+
+            if any((new_value - old_value) > 1.e-5):
+                changed.append((attr, old_value, new_value))
+
+        msg = ("'{0}' changed: \n"
+               "old value: {1}  New value: {2}")
+
+        if changed:
+            all_messages = "\n".join([msg.format(attr, old, new)
+                                      for attr, old, new in changed])
+            test_case.fail(all_messages)
+
+
+class TestCameraUnitTest(unittest.TestCase):
+
+    def setUp(self, figure=None):
+        self.engine = mlab.get_engine()
+        fig = mlab.figure()
+        mlab.pipeline.surface(BuiltinImage(), figure=fig)
+        self.camera = self.engine.current_scene.scene.camera
+
+    def tearDown(self):
+        mlab.close(all=True)
+
+    def test_move_with_forward(self):
+        camera = self.engine.current_scene.scene.camera
+
+        with check_attrs_change(self, camera,
+                                ("focal_point", "position", "clipping_range")):
+            camera_tools.move(forward=20.)
+
+    def test_camera_move_with_right(self):
+        camera = self.engine.current_scene.scene.camera
+
+        with check_attrs_change(self, camera,
+                                ("focal_point", "position")), \
+                check_attrs_do_not_change(self, camera,
+                                          ("clipping_range",)):
+            camera_tools.move(right=20.)
+
+    def test_camera_move_with_up(self):
+        camera = self.engine.current_scene.scene.camera
+
+        with check_attrs_change(self, camera,
+                                ("focal_point", "position", "clipping_range")):
+            camera_tools.move(up=20.)
+
+
+class TestCamera(TestCase):
+
+    def test(self):
+        self.main()
+
+    def do(self):
+        suite = unittest.TestLoader().loadTestsFromTestCase(TestCameraUnitTest)
+        for test in suite:
+            test.run()
+
+
+if __name__ == "__main__":
+    t = TestCamera()
+    t.test()

--- a/mayavi/tools/camera.py
+++ b/mayavi/tools/camera.py
@@ -424,7 +424,7 @@ def move(forward=None, right=None, up=None):
     v = np.zeros(3)
 
     # view plane vetor points behind viewing direction, so we invert it
-    yhat = -1 * cam.view_plane_normal
+    yhat = -1. * np.array(cam.view_plane_normal)
     zhat = cam.view_up
 
     if forward is not None:

--- a/mayavi/tools/camera.py
+++ b/mayavi/tools/camera.py
@@ -426,9 +426,9 @@ def move(forward=None, right=None, up=None):
     # view plane vetor points behind viewing direction, so we invert it
     yhat = -1. * np.array(cam.view_plane_normal)
     zhat = cam.view_up
+    xhat = np.cross(yhat, zhat)
 
     if forward is not None:
-        xhat = np.cross(yhat, zhat)
         v += forward * yhat
 
     if right is not None:


### PR DESCRIPTION
Fix #292 
`camera.view_plane_normal` is a tuple and so it needs to be converted to an array before being multiplied to -1

@dmsurti, @prabhuramachandran where should I put the tests for this?  NullEngine can't be used because a scene is required.  `integrationtests/mayavi/test_mlab_*`  or create a `test_camera.py` under `mayavi/tests` ?
