### PR TITLE
Use newer pipeline where possible

### DIFF
--- a/integrationtests/mayavi/common.py
+++ b/integrationtests/mayavi/common.py
@@ -615,6 +615,12 @@ class TestCase(Mayavi):
     ######################################################################
     # `TestCase` interface.
     ######################################################################
+    def _get_output(self, obj):
+        if obj.is_a('vtkDataSet'):
+            return obj
+        else:
+            return obj.output
+
     def do(self):
         """Override this to do whatever you want to do as your test
         code.

--- a/integrationtests/mayavi/test_generic_module.py
+++ b/integrationtests/mayavi/test_generic_module.py
@@ -70,21 +70,25 @@ class TestGenericModule(TestCase):
             ctr.enabled = True
             assert ctr.outputs[0] is c.outputs[0]
             assert ctr.outputs[0] is normals.outputs[0]
-            rng = normals.outputs[0].point_data.scalars.range
+            n_output = self._get_output(normals.outputs[0])
+            rng = n_output.point_data.scalars.range
             assert (rng[1] - rng[0]) < 1e-4
             # Turn on auto-contours
             c.auto_contours = True
             # Increase number of contours and the range should change.
             c.number_of_contours = 10
-            assert len(normals.outputs[0].points) != 0
-            rng = normals.outputs[0].point_data.scalars.range
+            n_output = self._get_output(normals.outputs[0])
+            assert len(n_output.points) != 0
+            rng = n_output.point_data.scalars.range
             assert rng[0] < rng[1]
             # Check if pipeline_changed is correctly propagated.
-            old = normals.outputs[0]
+            old = self._get_output(normals.outputs[0])
             assert a.mapper.scalar_mode == 'default'
             c.filled_contours = True
-            assert normals.outputs[0] != old
-            assert normals.outputs[0] is c.outputs[0]
+            n_output = self._get_output(normals.outputs[0])
+            c_output = self._get_output(c.outputs[0])
+            assert n_output != old
+            assert n_output is c_output
             # Check if the actor responds correctly to the
             # filled_contour change.
             assert a.mapper.scalar_mode == 'use_cell_data'

--- a/integrationtests/mayavi/test_image_data_probe.py
+++ b/integrationtests/mayavi/test_image_data_probe.py
@@ -26,9 +26,9 @@ class TestImageDataProbe(TestCase):
         idp = src.children[0]
         mm = idp.children[0]
         if not saved:
-            assert src.outputs[0].is_a('vtkUnstructuredGrid')
-            assert idp.outputs[0].is_a('vtkImageData')
-            sc = idp.outputs[0].point_data.scalars
+            assert src.get_output_dataset().is_a('vtkUnstructuredGrid')
+            assert idp.get_output_dataset().is_a('vtkImageData')
+            sc = idp.get_output_dataset().point_data.scalars
             assert sc.name == 't'
             assert mm.scalar_lut_manager.data_name == 't'
             assert abs(sc.range[0]) < 1.0
@@ -37,12 +37,12 @@ class TestImageDataProbe(TestCase):
             idp.rescale_scalars = True
             idp.dimensions = (41, 19, 19)
 
-        sc = idp.outputs[0].point_data.scalars
+        sc = idp.get_output_dataset().point_data.scalars
         assert sc.name == idp.rescaled_scalar_name
         assert mm.scalar_lut_manager.data_name == idp.rescaled_scalar_name
         assert abs(sc.range[0]) < 1e-2
         assert abs(sc.range[1] - 65535.0) < 1.e-2
-        assert (idp.outputs[0].dimensions == (41, 19, 19)).all()
+        assert (idp.get_output_dataset().dimensions == (41, 19, 19)).all()
 
     def test(self):
         self.main()
@@ -122,4 +122,3 @@ class TestImageDataProbe(TestCase):
 if __name__ == "__main__":
     t = TestImageDataProbe()
     t.test()
-

--- a/integrationtests/mayavi/test_labels.py
+++ b/integrationtests/mayavi/test_labels.py
@@ -26,7 +26,7 @@ class TestLabels(TestCase):
         mm = src.children[0]
         l = mm.children[1]
         if not saved:
-            np = l.visible_points.outputs[0].number_of_points
+            np = l.visible_points.get_output_dataset().number_of_points
             assert np < 35 and np > 20
             l.visible_points.enabled = True
             l.mapper.label_mode = 'label_scalars'
@@ -35,10 +35,10 @@ class TestLabels(TestCase):
             l.property.color = (0,0,0)
             l.property.italic = False
 
-        np = l.visible_points.outputs[0].number_of_points
+        np = l.visible_points.get_output_dataset().number_of_points
         assert np < 60  and np > 35
         assert l.visible_points.enabled == True
-        assert l.visible_points.outputs[0] == \
+        assert l.visible_points.get_output_dataset() == \
             l.visible_points.filter.filter.output
         assert l.property.color == (0,0,0)
         assert l.property.italic == False

--- a/integrationtests/mayavi/test_optional_collection.py
+++ b/integrationtests/mayavi/test_optional_collection.py
@@ -54,22 +54,22 @@ class TestOptionalCollection(TestCase):
             c, o = coll.filters
             c = c.filter
             n = o.filter
-            assert coll.outputs[0].point_data.scalars.range == (127.5, 127.5)
+            assert coll.get_output_dataset().point_data.scalars.range == (127.5, 127.5)
             # Adding a contour should create the appropriate output in
             # the collection.
             c.contours.append(200)
-            assert coll.outputs[0].point_data.scalars.range == (127.5, 200.0)
+            assert coll.get_output_dataset().point_data.scalars.range == (127.5, 200.0)
             # the collection's output should be that of the normals.
-            assert coll.outputs[0] is n.outputs[0]
+            assert coll.get_output_dataset() is n.get_output_dataset()
             # disable the optional filter and check.
             o.enabled = False
             assert 'disabled' in o.name
-            assert coll.outputs[0] is c.outputs[0]
+            assert coll.get_output_dataset() is c.get_output_dataset()
             # Set back everything to original state.
             c.contours.pop()
             o.enabled = True
-            assert coll.outputs[0].point_data.scalars.range == (127.5, 127.5)
-            assert coll.outputs[0] is n.outputs[0]
+            assert coll.get_output_dataset().point_data.scalars.range == (127.5, 127.5)
+            assert coll.get_output_dataset() is n.get_output_dataset()
             assert 'disabled' not in o.name
 
         check(coll)
@@ -121,4 +121,3 @@ class TestOptionalCollection(TestCase):
 if __name__ == "__main__":
     t = TestOptionalCollection()
     t.test()
-

--- a/integrationtests/mayavi/test_set_active_attribute.py
+++ b/integrationtests/mayavi/test_set_active_attribute.py
@@ -21,13 +21,13 @@ class TestSetActiveAttribute(TestCase):
         src = scene.children[0]
         assert src.point_scalars_name == 'u'
         c = src.children[1]
-        sc = c.outputs[0].point_data.scalars
+        sc = self._get_output(c.outputs[0]).point_data.scalars
         assert sc.name == 'u'
         # It is an iso-contour!
         assert sc.range[0] == sc.range[1]
         aa = c.children[0].children[0]
         assert aa.point_scalars_name == 't'
-        sc = aa.outputs[0].point_data.scalars
+        sc = self._get_output(aa.outputs[0]).point_data.scalars
         assert sc.name == 't'
         assert abs(sc.range[0] - 308) < 1.0
         assert abs(sc.range[1] - 631) < 1.0

--- a/integrationtests/mayavi/test_user_defined.py
+++ b/integrationtests/mayavi/test_user_defined.py
@@ -31,32 +31,32 @@ class TestUserDefined(TestCase):
         mm = o.children[0]
         if not saved:
             assert ud.filter.vector_mode == 'compute_gradient'
-            assert src.outputs[0].point_data.scalars.name == 't'
-            assert src.outputs[0].point_data.vectors.name == 'uvw'
+            assert src.get_output_dataset().point_data.scalars.name == 't'
+            assert src.get_output_dataset().point_data.vectors.name == 'uvw'
             expect = ['ScalarGradient', 'Vorticity']
             expect1 = [x +'-y' for x in expect]
             expect2 = [x + ' magnitude' for x in expect]
             # FIXME: This is really a bug in VTK, the name of the scalar
             # should really be ScalarGradient-y.  This is fixed in
             # 5.2 but earlier versions fail.
-            assert o.outputs[0].point_data.scalars.name in expect1
-            assert o.outputs[0].point_data.vectors.name in expect
+            assert o.get_output_dataset().point_data.scalars.name in expect1
+            assert o.get_output_dataset().point_data.vectors.name in expect
             assert mm.scalar_lut_manager.data_name in expect1
             # Turn of extraction.
             o.enabled = False
-            assert o.outputs[0].point_data.scalars.name in expect2
-            assert o.outputs[0].point_data.vectors.name in expect
+            assert o.get_output_dataset().point_data.scalars.name in expect2
+            assert o.get_output_dataset().point_data.vectors.name in expect
             assert mm.scalar_lut_manager.data_name in expect2
 
             # Compute the vorticity
             ud.filter.vector_mode = 'compute_vorticity'
-        assert o.outputs[0].point_data.scalars.name == 'Vorticity magnitude'
-        assert o.outputs[0].point_data.vectors.name == 'Vorticity'
+        assert o.get_output_dataset().point_data.scalars.name == 'Vorticity magnitude'
+        assert o.get_output_dataset().point_data.vectors.name == 'Vorticity'
         assert mm.scalar_lut_manager.data_name == 'Vorticity magnitude'
         # Turn on extraction.
         o.enabled = True
-        assert o.outputs[0].point_data.scalars.name == 'Vorticity-y'
-        assert o.outputs[0].point_data.vectors.name == 'Vorticity'
+        assert o.get_output_dataset().point_data.scalars.name == 'Vorticity-y'
+        assert o.get_output_dataset().point_data.vectors.name == 'Vorticity'
         assert mm.scalar_lut_manager.data_name == 'Vorticity-y'
         # Turn off extraction.
         o.enabled = False
@@ -151,4 +151,3 @@ class TestUserDefined(TestCase):
 if __name__ == "__main__":
     t = TestUserDefined()
     t.test()
-

--- a/mayavi/components/actor.py
+++ b/mayavi/components/actor.py
@@ -201,8 +201,9 @@ class Actor(Component):
 
     def _change_texture_input(self):
         if self._can_object_give_image_data(self.texture_source_object):
-            self.configure_connection(self.texture,
-                                      self.texture_source_object)
+            self.configure_connection(
+                self.texture, self.texture_source_object
+            )
             self.actor.texture = self.texture
         else:
             self.texture_source_object = None

--- a/mayavi/components/actor.py
+++ b/mayavi/components/actor.py
@@ -195,7 +195,7 @@ class Actor(Component):
             return False
         if not isinstance(source, Source):
             return False
-        if source.outputs[0].is_a('vtkImageData'):
+        if source.get_output_dataset().is_a('vtkImageData'):
             return True
         return False
 

--- a/mayavi/components/contour.py
+++ b/mayavi/components/contour.py
@@ -7,7 +7,7 @@ a convenient option to create "filled contours".
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) 2005-2016, Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.
@@ -176,7 +176,7 @@ class Contour(Component):
             self.contours = [(cr[0] + cr[1])/2]
             self.minimum_contour = cr[0]
             self.maximum_contour = cr[1]
-        self.outputs = [cf.output]
+        self.outputs = [cf]
 
     def update_data(self):
         """Override this method to do what is necessary when upstream
@@ -290,7 +290,7 @@ class Contour(Component):
         cf = self._set_contour_input()
         # This will trigger a change.
         self._auto_contours_changed(self.auto_contours)
-        self.outputs = [cf.output]
+        self.outputs = [cf]
 
     def _get_contour_filter(self):
         if self.filled_contours:

--- a/mayavi/components/custom_grid_plane.py
+++ b/mayavi/components/custom_grid_plane.py
@@ -129,7 +129,7 @@ class CustomGridPlane(Component):
         self.plane = plane
         self._update_limits()
         self._update_voi()
-        self.outputs = [plane.output]
+        self.outputs = [plane]
 
     def update_data(self):
         """Override this method to do what is necessary when upstream

--- a/mayavi/components/custom_grid_plane.py
+++ b/mayavi/components/custom_grid_plane.py
@@ -111,7 +111,7 @@ class CustomGridPlane(Component):
         """
         if len(self.inputs) == 0:
             return
-        input = self.inputs[0].outputs[0]
+        input = self.inputs[0].get_output_dataset()
         plane = None
         if input.is_a('vtkStructuredGrid'):
             plane = tvtk.StructuredGridGeometryFilter()

--- a/mayavi/components/glyph.py
+++ b/mayavi/components/glyph.py
@@ -4,7 +4,7 @@ input point data.
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
 #         KK Rai (kk.rai [at] iitb.ac.in)
 #         R. Ambareesha (ambareesha [at] iitb.ac.in)
-# Copyright (c) 2005-2007, Enthought, Inc.
+# Copyright (c) 2005-2016, Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/components/grid_plane.py
+++ b/mayavi/components/grid_plane.py
@@ -120,7 +120,7 @@ class GridPlane(Component):
         self.configure_connection(plane, self.inputs[0])
         self.plane = plane
         self.plane.update()
-        self.outputs = [plane.output]
+        self.outputs = [plane]
         self._update_limits()
         self._update_extents()
         # If the data is 2D make sure that we default to the

--- a/mayavi/components/grid_plane.py
+++ b/mayavi/components/grid_plane.py
@@ -103,7 +103,7 @@ class GridPlane(Component):
         """
         if len(self.inputs) == 0:
             return
-        input = self.inputs[0].outputs[0]
+        input = self.inputs[0].get_output_dataset()
         plane = None
         if input.is_a('vtkStructuredGrid'):
             plane = tvtk.StructuredGridGeometryFilter()

--- a/mayavi/components/implicit_plane.py
+++ b/mayavi/components/implicit_plane.py
@@ -106,14 +106,14 @@ class ImplicitPlane(Component):
         This method is invoked (automatically) when the input fires a
         `pipeline_changed` event.
         """
-        if len(self.inputs) == 0:
+        if len(self.inputs) == 0 or len(self.inputs[0].outputs) == 0:
             return
         inp = self.inputs[0].outputs[0]
         w = self.widget
         self.configure_input(w, inp)
         if self._first:
             w.place_widget()
-            self.origin = inp.center
+            self.origin = self.inputs[0].get_output_dataset().center
             self._first = False
         else:
             n = self.normal

--- a/mayavi/components/implicit_widgets.py
+++ b/mayavi/components/implicit_widgets.py
@@ -107,7 +107,7 @@ class ImplicitWidgets(Component):
         w = self.widget
         # Set the input.
         if len(self.inputs) > 0:
-            w.input = self.inputs[0].outputs[0]
+            self.configure_input(w, self.inputs[0].outputs[0])
         w.update_traits()
         mode = self.widget_mode
         if mode == 'Plane':
@@ -140,7 +140,7 @@ class ImplicitWidgets(Component):
             return
         inp = self.inputs[0].outputs[0]
         w = self.widget
-        w.input = inp
+        self.configure_input(w, inp)
 
         if self._first:
             w.place_widget()
@@ -179,7 +179,7 @@ class ImplicitWidgets(Component):
     ######################################################################
     def _widget_changed(self, old, value):
         if len(self.inputs) > 0:
-            value.input = self.inputs[0].outputs[0]
+            self.configure_input(value, self.inputs[0].outputs[0])
             value.place_widget()
         self.implicit_function = self._implicit_function_dict[self.widget_mode]
 

--- a/mayavi/components/source_widget.py
+++ b/mayavi/components/source_widget.py
@@ -163,7 +163,7 @@ class SourceWidget(Component):
 
         # If the dataset is effectively 2D switch to using the line
         # widget since that works best.
-        b = inp.bounds
+        b = self.inputs[0].get_output_dataset().bounds
         l = [(b[1]-b[0]), (b[3]-b[2]), (b[5]-b[4])]
         max_l = max(l)
         for i, x in enumerate(l):

--- a/mayavi/components/source_widget.py
+++ b/mayavi/components/source_widget.py
@@ -3,14 +3,13 @@ to be used by various modules.
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) 2005-2016, Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.
 from traits.api import Event, Instance, List, Trait, Bool, TraitPrefixList
 from traitsui.api import View, Group, Item, InstanceEditor
 from tvtk.api import tvtk
-from tvtk.common import configure_input_data
 from apptools.persistence.state_pickler import set_state
 
 # Local imports.
@@ -85,7 +84,7 @@ class SourceWidget(Component):
         w = self.widget = self.widget_list[m.index(w_c_name)]
         # Set the input.
         if len(self.inputs) > 0:
-            self.configure_input_data(w, self.inputs[0].outputs[0])
+            self.configure_input(w, self.inputs[0].outputs[0])
         # Fix for the point widget.
         if w_c_name == 'PointWidget':
             w.place_widget()
@@ -220,7 +219,7 @@ class SourceWidget(Component):
             recorder.record('%s = %s'%(lhs, rhs))
 
         if len(self.inputs) > 0:
-            configure_input_data(value, self.inputs[0].outputs[0])
+            self.configure_input(value, self.inputs[0].outputs[0])
             value.place_widget()
 
         value.on_trait_change(self.render)

--- a/mayavi/core/module_manager.py
+++ b/mayavi/core/module_manager.py
@@ -158,6 +158,8 @@ class ModuleManager(Base):
         This is invoked when the source changes or when there are
         pipeline/data changes upstream.
         """
+        if len(self.source.outputs) == 0:
+            return
         self._setup_scalar_data()
         self._setup_vector_data()
 

--- a/mayavi/core/module_manager.py
+++ b/mayavi/core/module_manager.py
@@ -289,7 +289,7 @@ class ModuleManager(Base):
     def _setup_scalar_data(self):
         """Computes the scalar range and an appropriate name for the
         lookup table."""
-        input = self.source.outputs[0]
+        input = self._get_output(self.source.outputs[0])
         ps = input.point_data.scalars
         cs = input.cell_data.scalars
 
@@ -312,7 +312,7 @@ class ModuleManager(Base):
         data_attr.config_lut(self.scalar_lut_manager)
 
     def _setup_vector_data(self):
-        input = self.source.outputs[0]
+        input = self._get_output(self.source.outputs[0])
         pv = input.point_data.vectors
         cv = input.cell_data.vectors
 
@@ -345,3 +345,9 @@ class ModuleManager(Base):
     def _menu_helper_default(self):
         from mayavi.core.traits_menu import ModuleMenuHelper
         return ModuleMenuHelper(object=self)
+
+    def _get_output(self, obj):
+        if obj.is_a('vtkDataSet'):
+            return obj
+        else:
+            return obj.output

--- a/mayavi/core/pipeline_base.py
+++ b/mayavi/core/pipeline_base.py
@@ -174,6 +174,21 @@ class PipelineBase(Base):
         As such we return the first output."""
         return self.outputs[0]
 
+    def get_output_dataset(self):
+        """ Return the output dataset of this object.
+        """
+        if self.outputs:
+            o = self.outputs[0]
+            if o.is_a('vtkDataSet'):
+                return o
+            else:
+                output = o.output
+                if output is None and hasattr(o, 'update'):
+                    o.update()
+                return o.output
+        else:
+            return None
+
     def configure_connection(self, obj, inp):
         """ Configure topology for vtk pipeline obj."""
         tvtk_common.configure_connection(obj, inp)

--- a/mayavi/core/pipeline_info.py
+++ b/mayavi/core/pipeline_info.py
@@ -3,7 +3,7 @@
  outputs of an object in the pipeline.
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008, Prabhu Ramachandran Enthought, Inc.
+# Copyright (c) 2008-2016, Prabhu Ramachandran Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.
@@ -29,6 +29,9 @@ def get_tvtk_dataset_name(dataset):
     """
     result = 'none'
     if hasattr(dataset, 'is_a'):
+        if not dataset.is_a('vtkDataSet') and hasattr(dataset, 'output'):
+            # FIXME: Use pipeline information to do this correctly.
+            dataset = dataset.output
         if dataset.is_a('vtkStructuredPoints') or \
            dataset.is_a('vtkImageData'):
                result = 'image_data'
@@ -65,4 +68,3 @@ class PipelineInfo(HasTraits):
 
     # The attributes the object can use/produce.
     attributes = List(Attribute)
-

--- a/mayavi/filters/cell_to_point_data.py
+++ b/mayavi/filters/cell_to_point_data.py
@@ -46,6 +46,7 @@ class CellToPointData(FilterBase):
         input = inputs[0].outputs[0]
         self.configure_connection(fil, inputs[0])
         fil.update()
+        dataset = self.inputs[0].get_output_dataset()
         # This filter creates different outputs depending on the
         # input.
         out_map = {'vtkStructuredGrid': 'structured_grid_output',
@@ -56,7 +57,6 @@ class CellToPointData(FilterBase):
                    'vtkImageData': 'image_data_output'}
         # Find the input data type and pass that to our output..
         for type in out_map:
-            if input.is_a(type):
+            if dataset.is_a(type):
                 self._set_outputs([getattr(fil, out_map[type])])
                 break
-

--- a/mayavi/filters/data_set_clipper.py
+++ b/mayavi/filters/data_set_clipper.py
@@ -3,7 +3,7 @@ using various Implicit Widgets.
 """
 # Author: Suyog Dutt Jain <suyog.jain@aero.iitb.ac.in>
 #         Prabhu Ramachandran <prabhu at aero.iitb.ac.in>
-# Copyright (c) 2009-2015, Enthought, Inc.
+# Copyright (c) 2009-2016, Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.
@@ -118,7 +118,7 @@ class DataSetClipper(Filter):
         widget.update_implicit_function()
         filter.clip_function = widget.implicit_function
         filter.update()
-        self._set_outputs([filter.output])
+        self._set_outputs([filter])
 
         self.pipeline_changed = True
 
@@ -165,7 +165,7 @@ class DataSetClipper(Filter):
         new.on_trait_change(self.render)
         if len(self.inputs) > 0:
             self.configure_connection(new, self.inputs[0])
-            self.outputs = [new.output]
+            self.outputs = [new]
 
     def _reset_button_fired(self):
         self.widget.widget.place_widget()

--- a/mayavi/filters/extract_grid.py
+++ b/mayavi/filters/extract_grid.py
@@ -152,7 +152,7 @@ class ExtractGrid(FilterBase):
         if len(inputs) == 0:
             return
 
-        input = inputs[0].outputs[0]
+        input = inputs[0].get_output_dataset()
         mapping = {'vtkStructuredGrid': tvtk.ExtractGrid,
                    'vtkRectilinearGrid': tvtk.ExtractRectilinearGrid,
                    'vtkImageData': tvtk.ExtractVOI}
@@ -170,7 +170,7 @@ class ExtractGrid(FilterBase):
         self.configure_connection(fil, inputs[0])
         fil.update_whole_extent()
         fil.update()
-        self._set_outputs([fil.output])
+        self._set_outputs([fil])
         self._update_limits()
         self._update_voi()
         self._update_sample_rate()

--- a/mayavi/filters/extract_vector_components.py
+++ b/mayavi/filters/extract_vector_components.py
@@ -46,7 +46,7 @@ class ExtractVectorComponents(FilterBase):
     def update_pipeline(self):
         # Do nothing if there is no input.
         inputs = self.inputs
-        if len(inputs) == 0:
+        if len(inputs) == 0 or len(inputs[0].outputs) == 0:
             return
 
         fil = self.filter
@@ -61,7 +61,7 @@ class ExtractVectorComponents(FilterBase):
         # Obtain output from the TVTK ExtractVectorComponents filter
         # corresponding to the selected vector component
 
-        if len(self.inputs) == 0:
+        if len(self.inputs) == 0 or len(self.inputs[0].outputs) == 0:
             return
 
         if value == 'x-component':

--- a/mayavi/filters/extract_vector_norm.py
+++ b/mayavi/filters/extract_vector_norm.py
@@ -40,7 +40,7 @@ class ExtractVectorNorm(FilterBase):
     def update_pipeline(self):
         # Do nothing if there is no input.
         inputs = self.inputs
-        if len(inputs) == 0:
+        if len(inputs) == 0 or len(inputs[0].outputs) == 0:
             return
 
         # By default we set the input to the first output of the first
@@ -49,7 +49,7 @@ class ExtractVectorNorm(FilterBase):
         self.configure_connection(fil, inputs[0])
         fil.update()
         self._set_array_name(fil)
-        self._set_outputs([fil.output])
+        self._set_outputs([fil])
 
     def update_data(self):
         """Override this method to do what is necessary when upstream
@@ -60,7 +60,7 @@ class ExtractVectorNorm(FilterBase):
         """
         # Do nothing if there is no input.
         inputs = self.inputs
-        if len(inputs) == 0:
+        if len(inputs) == 0 or len(inputs[0].outputs) == 0:
             return
 
         self.filter.update()
@@ -73,7 +73,7 @@ class ExtractVectorNorm(FilterBase):
     ######################################################################
     def _set_array_name(self, filter):
         # Do nothing if there is no input.
-        if len(self.inputs) == 0:
+        if len(self.inputs) == 0 or len(self.inputs[0].outputs) == 0:
             return
 
         o = filter.output
@@ -85,4 +85,3 @@ class ExtractVectorNorm(FilterBase):
             ps.name = pd.vectors.name + ' magnitude'
         elif (cs is not None) and (not cs.name):
             cs.name = cd.vectors.name + ' magnitude'
-

--- a/mayavi/filters/filter_base.py
+++ b/mayavi/filters/filter_base.py
@@ -71,7 +71,7 @@ class FilterBase(Filter):
         # input.
         self.configure_connection(fil, inputs[0])
         fil.update()
-        self._set_outputs([fil.output])
+        self._set_outputs([fil])
 
     def update_data(self):
         """Override this method to do what is necessary when upstream
@@ -96,6 +96,3 @@ class FilterBase(Filter):
 
         if old is not None:
             self.update_pipeline()
-
-
-

--- a/mayavi/filters/mask_points.py
+++ b/mayavi/filters/mask_points.py
@@ -52,8 +52,7 @@ class MaskPoints(FilterBase):
     ######################################################################
     def _find_number_of_points_in_input(self):
         inp = self.inputs[0].outputs[0]
-        if not inp.is_a('vtkDataSet'):
-            inp = inp.output
         if hasattr(inp, 'update'):
             inp.update()
+        inp = self.inputs[0].get_output_dataset()
         return inp.number_of_points

--- a/mayavi/filters/poly_data_filter_base.py
+++ b/mayavi/filters/poly_data_filter_base.py
@@ -30,4 +30,4 @@ class PolyDataFilterBase(FilterBase):
         fil = self.filter
         self.configure_input(fil, convert_to_poly_data(inputs[0].outputs[0]))
         fil.update()
-        self._set_outputs([fil.output])
+        self._set_outputs([fil])

--- a/mayavi/filters/set_active_attribute.py
+++ b/mayavi/filters/set_active_attribute.py
@@ -131,7 +131,7 @@ class SetActiveAttribute(Filter):
         aa = self._assign_attribute
         self.configure_connection(aa, self.inputs[0])
         self._update()
-        self._set_outputs([aa.output])
+        self._set_outputs([aa])
 
     ######################################################################
     # Non-public interface.
@@ -147,7 +147,9 @@ class SetActiveAttribute(Filter):
         if self._first and is_old_pipeline():
             # Force all attributes to be defined and computed
             input.update()
-        pnt_attr, cell_attr = get_all_attributes(input)
+        pnt_attr, cell_attr = get_all_attributes(
+            self.inputs[0].get_output_dataset()
+        )
 
         self._setup_data_traits(cell_attr, 'cell')
         self._setup_data_traits(pnt_attr, 'point')
@@ -161,7 +163,7 @@ class SetActiveAttribute(Filter):
         """
         attrs = ['scalars', 'vectors', 'tensors']
         aa = self._assign_attribute
-        input = self.inputs[0].outputs[0]
+        input = self.inputs[0].get_output_dataset()
         data = getattr(input, '%s_data'%d_type)
         for attr in attrs:
             values = attributes[attr]
@@ -183,7 +185,7 @@ class SetActiveAttribute(Filter):
         if value is None or len(self.inputs) == 0:
             return
 
-        input = self.inputs[0].outputs[0]
+        input = self.inputs[0].get_output_dataset()
         if len(value) == 0:
             # If the value is empty then we deactivate that attribute.
             d = getattr(input, attr_type + '_data')
@@ -223,4 +225,3 @@ class SetActiveAttribute(Filter):
 
     def _cell_tensors_name_changed(self, value):
         self._set_data_name('tensors', 'cell', value)
-

--- a/mayavi/filters/threshold.py
+++ b/mayavi/filters/threshold.py
@@ -142,7 +142,7 @@ class Threshold(Filter):
         fil = self.threshold_filter
         self.configure_connection(fil, self.inputs[0])
         self._update_ranges()
-        self._set_outputs([self.threshold_filter.output])
+        self._set_outputs([self.threshold_filter])
 
     def update_data(self):
         """Override this method to do what is necessary when upstream
@@ -282,7 +282,7 @@ class Threshold(Filter):
         fil.threshold_between(self.lower_threshold,
                               self.upper_threshold)
         fil.update()
-        self._set_outputs([fil.output])
+        self._set_outputs([fil])
 
     def _threshold_filter_edited(self):
         self.threshold_filter.update()

--- a/mayavi/filters/transform_data.py
+++ b/mayavi/filters/transform_data.py
@@ -121,7 +121,7 @@ class TransformData(Filter):
         if len(inputs) == 0:
             return
 
-        inp = inputs[0].outputs[0]
+        inp = inputs[0].get_output_dataset()
         if inp.is_a('vtkImageData') or inp.is_a('vtkRectilinearGrid'):
             error('Transformation not supported for '\
                   'ImageData/StructuredPoints/RectilinearGrid')
@@ -141,7 +141,7 @@ class TransformData(Filter):
         self.configure_connection(fil, inputs[0])
         fil.transform = self._transform
         fil.update()
-        self._set_outputs([fil.output])
+        self._set_outputs([fil])
 
     def update_data(self):
         # Do nothing if there is no input.
@@ -186,7 +186,7 @@ class TransformData(Filter):
                                              self._on_interaction_event)
         self.widgets.append(new)
         if len(self.inputs) > 0:
-            self.configure_input_data(new, self.inputs[0].outputs[0])
+            self.configure_input(new, self.inputs[0].outputs[0])
 
     def _filter_changed(self, old, new):
         if old is not None:
@@ -197,7 +197,7 @@ class TransformData(Filter):
             new.transform = transform
         if len(self.inputs) > 0:
             self.configure_connection(new, self.inputs[0])
-            self.outputs = [new.output]
+            self.outputs = [new]
 
     def _reset_fired(self):
         self._transform.identity()

--- a/mayavi/modules/streamline.py
+++ b/mayavi/modules/streamline.py
@@ -173,7 +173,7 @@ class Streamline(Module):
         # Setup the radius/width of the tube/ribbon filters based on
         # given input.
         if self._first:
-            b = src.outputs[0].bounds
+            b = src.get_output_dataset().bounds
             l = [(b[1]-b[0]), (b[3]-b[2]), (b[5]-b[4])]
             length = sqrt(l[0]*l[0] + l[1]*l[1] + l[2]*l[2])
             self.ribbon_filter.width = length*0.0075
@@ -239,7 +239,7 @@ class Streamline(Module):
 
         # A default output so there are no pipeline errors.  The
         # update_pipeline call corrects this if needed.
-        self.outputs = [new.output]
+        self.outputs = [new]
 
         self.update_pipeline()
 

--- a/mayavi/tests/test_image_data_probe.py
+++ b/mayavi/tests/test_image_data_probe.py
@@ -57,17 +57,17 @@ class TestImageDataProbe(unittest.TestCase):
         idp = src.children[0]
         mm = idp.children[0]
 
-        self.assertEqual(src.outputs[0].is_a('vtkUnstructuredGrid'),True)
-        self.assertEqual(idp.outputs[0].is_a('vtkImageData'),True)
-        sc = idp.outputs[0].point_data.scalars
-        vc = idp.outputs[0].point_data.vectors
+        self.assertEqual(src.get_output_dataset().is_a('vtkUnstructuredGrid'),True)
+        self.assertEqual(idp.get_output_dataset().is_a('vtkImageData'),True)
+        sc = idp.get_output_dataset().point_data.scalars
+        vc = idp.get_output_dataset().point_data.vectors
         self.assertEqual(sc.name,idp.rescaled_scalar_name)
         self.assertEqual(vc.name,'velocity')
         self.assertEqual(mm.scalar_lut_manager.data_name,
                                                 idp.rescaled_scalar_name)
         self.assertEqual((abs(sc.range[0]) < 1e-2),True)
         self.assertEqual( abs(sc.range[1] - 65535.0) < 1.e-2,True)
-        self.assertEqual((idp.outputs[0].dimensions == (3, 3, 2)).all(),True)
+        self.assertEqual((idp.get_output_dataset().dimensions == (3, 3, 2)).all(),True)
 
 
 

--- a/mayavi/tests/test_mlab_integration.py
+++ b/mayavi/tests/test_mlab_integration.py
@@ -40,6 +40,12 @@ class TestMlabNullEngine(unittest.TestCase):
             registry.unregister_engine(current_engine)
             raise AssertionError("The NullEngine has been overridden")
 
+    def _get_output(self, obj):
+        if obj.is_a('vtkDataSet'):
+            return obj
+        else:
+            return obj.output
+
 
 ################################################################################
 # class `TestMlabNullEngineMisc`
@@ -54,7 +60,7 @@ class TestMlabNullEngineMisc(TestMlabNullEngine):
         src = mlab.pipeline.scalar_field(a)
         filter = mlab.pipeline.contour(src)
 
-        x, y, z = filter.outputs[0].points.to_array().T
+        x, y, z = self._get_output(filter.outputs[0]).points.to_array().T
 
         # Check that the contour filter indeed did its work:
         np.testing.assert_almost_equal(x, [ 2. ,  2. ,  1.5,  2.5,  2. ,  2. ])

--- a/mayavi/tests/test_mlab_integration.py
+++ b/mayavi/tests/test_mlab_integration.py
@@ -60,7 +60,7 @@ class TestMlabNullEngineMisc(TestMlabNullEngine):
         src = mlab.pipeline.scalar_field(a)
         filter = mlab.pipeline.contour(src)
 
-        x, y, z = self._get_output(filter.outputs[0]).points.to_array().T
+        x, y, z = filter.get_output_dataset().points.to_array().T
 
         # Check that the contour filter indeed did its work:
         np.testing.assert_almost_equal(x, [ 2. ,  2. ,  1.5,  2.5,  2. ,  2. ])
@@ -77,7 +77,7 @@ class TestMlabNullEngineMisc(TestMlabNullEngine):
         density = mlab.pipeline.user_defined(src, filter='GaussianSplatter')
 
         self.assertEqual(len(density.outputs), 1)
-        self.assertTrue(isinstance(density.outputs[0], tvtk.ImageData))
+        self.assertTrue(isinstance(density.get_output_dataset(), tvtk.ImageData))
 
     def test_mlab_source(self):
         """ Check that the different objects created by mlab have an

--- a/mayavi/tests/test_optional_collection.py
+++ b/mayavi/tests/test_optional_collection.py
@@ -61,7 +61,7 @@ class TestOptionalCollection(unittest.TestCase):
         c = c.filter
         n = o.filter
 
-        r = coll.outputs[0].point_data.scalars.range
+        r = coll.get_output_dataset().point_data.scalars.range
 
         self.assertEqual(np.allclose(r, (6.09,6.09), atol=1.01e-03), True)
         # Adding a contour should create the appropriate output in

--- a/mayavi/tests/test_set_active_attribute.py
+++ b/mayavi/tests/test_set_active_attribute.py
@@ -54,19 +54,25 @@ class TestSetActiveAttribute(unittest.TestCase):
         self.e.stop()
         return
 
+    def _get_output(self, obj):
+        if obj.is_a('vtkDataSet'):
+            return obj
+        else:
+            return obj.output
+
     def check(self):
         """Do the actual testing"""
         scene = self.scene
         src = scene.children[0]
         self.assertEqual(src.point_scalars_name,'temperature')
         c = src.children[1]
-        sc = c.outputs[0].point_data.scalars
+        sc = self._get_output(c.outputs[0]).point_data.scalars
         self.assertEqual(sc.name,'temperature')
         # It is an iso-contour!
         self.assertEqual(sc.range[0],sc.range[1])
         aa = c.children[0].children[0]
         self.assertEqual(aa.point_scalars_name,'pressure')
-        sc = aa.outputs[0].point_data.scalars
+        sc = self._get_output(aa.outputs[0]).point_data.scalars
         self.assertEqual(sc.name, 'pressure')
         self.assertEqual((abs(sc.range[0] - 70) < 1.0),True)
         self.assertEqual((abs(sc.range[1] - 70) < 1.0),True)

--- a/mayavi/tests/test_threshold_filter.py
+++ b/mayavi/tests/test_threshold_filter.py
@@ -50,15 +50,18 @@ class TestThresholdFilter(unittest.TestCase):
         self.e.add_source(src)
         threshold = Threshold()
         self.e.add_filter(threshold)
-        self.assertEqual(np.nanmin(src.scalar_data),
-                         np.nanmin(
-                            threshold.outputs[0].point_data.scalars.to_array()
-                         ))
-        self.assertEqual(np.nanmax(src.scalar_data),
-                         np.nanmax(
-                            threshold.outputs[0].point_data.scalars.to_array()
-                         ))
-
+        self.assertEqual(
+            np.nanmin(src.scalar_data),
+            np.nanmin(
+                threshold.get_output_dataset().point_data.scalars.to_array()
+            )
+        )
+        self.assertEqual(
+            np.nanmax(src.scalar_data),
+            np.nanmax(
+                threshold.get_output_dataset().point_data.scalars.to_array()
+            )
+        )
 
     def test_threshold_filter_threhsold(self):
         src = self.make_src()
@@ -66,10 +69,11 @@ class TestThresholdFilter(unittest.TestCase):
         threshold = Threshold()
         self.e.add_filter(threshold)
         threshold.upper_threshold = 20.
-        self.assertTrue(20 >=
-                         np.nanmax(
-                            threshold.outputs[0].point_data.scalars.to_array()
-                         ))
+        self.assertTrue(
+            20 >= np.nanmax(
+                threshold.get_output_dataset().point_data.scalars.to_array()
+            )
+        )
         return
 
     def test_threshold_filter_data_range_changes(self):

--- a/mayavi/tests/test_user_defined.py
+++ b/mayavi/tests/test_user_defined.py
@@ -19,7 +19,7 @@ from mayavi.sources.vtk_xml_file_reader import VTKXMLFileReader
 from tvtk.api import tvtk
 
 # Local imports.
-from .common import get_example_data
+from mayavi.tests.common import get_example_data
 
 class TestUserDefined(unittest.TestCase):
 
@@ -68,36 +68,34 @@ class TestUserDefined(unittest.TestCase):
         o = ud.children[0].children[0].children[0]
         mm = o.children[0]
 
-        assert src.outputs[0].point_data.scalars.name == 'temperature'
-        assert src.outputs[0].point_data.vectors.name == 'velocity'
+        assert src.get_output_dataset().point_data.scalars.name == 'temperature'
+        assert src.get_output_dataset().point_data.vectors.name == 'velocity'
         expect = ['ScalarGradient', 'Vorticity']
         expect1 = [x +'-y' for x in expect]
         expect2 = [x + ' magnitude' for x in expect]
 
         o.enabled = True
-        assert o.outputs[0].point_data.scalars.name in expect1
-        assert o.outputs[0].point_data.vectors.name in expect
+        assert o.get_output_dataset().point_data.scalars.name in expect1
+        assert o.get_output_dataset().point_data.vectors.name in expect
         assert mm.scalar_lut_manager.data_name in expect1
         # Turn of extraction.
         o.enabled = False
-        assert o.outputs[0].point_data.scalars.name in expect2
-        assert o.outputs[0].point_data.vectors.name in expect
+        assert o.get_output_dataset().point_data.scalars.name in expect2
+        assert o.get_output_dataset().point_data.vectors.name in expect
         assert mm.scalar_lut_manager.data_name in expect2
 
         # Compute the vorticity
         ud.filter.vector_mode = 'compute_vorticity'
-        assert o.outputs[0].point_data.scalars.name == 'Vorticity magnitude'
-        assert o.outputs[0].point_data.vectors.name == 'Vorticity'
+        assert o.get_output_dataset().point_data.scalars.name == 'Vorticity magnitude'
+        assert o.get_output_dataset().point_data.vectors.name == 'Vorticity'
         assert mm.scalar_lut_manager.data_name == 'Vorticity magnitude'
         # Turn on extraction.
         o.enabled = True
-        assert o.outputs[0].point_data.scalars.name == 'Vorticity-y'
-        assert o.outputs[0].point_data.vectors.name == 'Vorticity'
+        assert o.get_output_dataset().point_data.scalars.name == 'Vorticity-y'
+        assert o.get_output_dataset().point_data.vectors.name == 'Vorticity'
         assert mm.scalar_lut_manager.data_name == 'Vorticity-y'
         # Turn off extraction.
         o.enabled = False
-
-
 
     def test_user_defined(self):
         "Test if the test fixture works"
@@ -107,9 +105,6 @@ class TestUserDefined(unittest.TestCase):
 
         #from mayavi.tools.show import show
         #show()
-
-
-
 
     def test_save_and_restore(self):
         """Test if saving a visualization and restoring it works."""
@@ -131,7 +126,6 @@ class TestUserDefined(unittest.TestCase):
         self.scene = engine.current_scene
         s = self.scene
         self.check()
-
 
     def test_deepcopied(self):
         """Test if the MayaVi2 visualization can be deep-copied."""
@@ -158,9 +152,6 @@ class TestUserDefined(unittest.TestCase):
         self.check()
         #from mayavi.tools.show import show
         #show()
-
-
-
 
 
 if __name__ == '__main__':

--- a/tvtk/common.py
+++ b/tvtk/common.py
@@ -109,6 +109,8 @@ def configure_source_data(obj, data):
     else:
         if data.is_a('vtkAlgorithmOutput'):
             obj.set_source_connection(data)
+        elif hasattr(data, 'output_port'):
+            obj.set_source_connection(data.output_port)
         else:
             obj.set_source_data(data)
 

--- a/tvtk/common.py
+++ b/tvtk/common.py
@@ -85,7 +85,10 @@ def configure_input(inp, op):
             inp.input = op.output
     else:
         if hasattr(op, 'output_port'):
-            inp.input_connection = op.output_port
+            if hasattr(inp, 'input_connection'):
+                inp.input_connection = op.output_port
+            elif hasattr(inp, 'set_input_connection'):
+                inp.set_input_connection(op.output_port)
         elif op.is_a('vtkAlgorithmOutput'):
             inp.input_connection = op
         elif op.is_a('vtkDataSet'):


### PR DESCRIPTION
(Giant?) Baby step towards using the new pipeline. This means removing any explicit calls to `vtk_obj.output` (where possible) and instead setting up pipeline connections.  This still needs cleanup but seems to be the bare minimum changes needed for all the tests to pass.  There are some places where the output is explicitly used to get information about the datasets but these could eventually be modified/refactored to use the `vtkInformation` classes.