### PR TITLE
Replacing links to code. and svn.enthought.com

### DIFF
--- a/README-tvtk.txt
+++ b/README-tvtk.txt
@@ -23,14 +23,9 @@ information is available in the LICENSE.txt file in this same directory.
 Getting the package
 -------------------
 
-Source tarballs for all stable ETS packages are available at
+The source for TVTK should be acquired with the source for Mayavi here:
 
- http://code.enthought.com/enstaller/eggs/source
-
-General Build and Installation instructions for ETS are available here:
-
- https://svn.enthought.com/enthought/wiki/Build
- https://svn.enthought.com/enthought/wiki/Install
+ http://pypi.python.org/pypi/mayavi
 
 
 Documentation

--- a/README-tvtk.txt
+++ b/README-tvtk.txt
@@ -9,14 +9,15 @@ Description
 TVTK_ provides a Traits enabled version of VTK_.  TVTK objects wrap around VTK
 objects but additionally support Traits_, support numpy arrays transparently
 and provide a convenient Pythonic API. TVTK is implemented mostly in pure
-Python (except for a small extension module).  TVTK is part of the Enthought
-Tool Suite (ETS) and is distributed under a liberal BSD style license.  License
+Python (except for a small extension module).  TVTK is distributed under
+a liberal BSD style license with the Mayavi_ package, which is part of the
+Enthought Tool Suite (ETS) and is distributed.  License
 information is available in the LICENSE.txt file in this same directory.
 
 .. _VTK: http://www.vtk.org
-.. _Traits: https://svn.enthought.com/enthought/wiki/Traits
-.. _TVTK: https://svn.enthought.com/enthought/wiki/TVTK
-
+.. _Traits: https://docs.enthought.com/traits
+.. _TVTK: https://docs.enthought.com/mayavi/tvtk
+.. _Mayavi: https://docs.enthought.com/mayavi/mayavi
 
 
 Getting the package
@@ -35,12 +36,7 @@ General Build and Installation instructions for ETS are available here:
 Documentation
 --------------
 
-The TVTK home page is: http://code.enthought.com/projects/mayavi
-
-More detailed information on TVTK is available in `docs/README.txt` which
-covers installation, requirements, examples of usage etc.  This document is
-also available on the web from
-http://code.enthought.com/projects/mayavi/docs/development/html/tvtk/
+Documentation is hosted here: http://docs.enthought.com/mayavi/tvtk
 
 
 Examples
@@ -64,16 +60,12 @@ Use a similar line for your particular shell.
 Bug tracker, mailing list etc.
 -------------------------------
 
-The bug tracker is available as part of the trac interface here:
+The bug tracker is available here:
 
- https://svn.enthought.com/enthought/
+ https://github.com/enthought/mayavi
 
-To submit a bug you will necessarily have to register at the site.  Click on
-the "register" link at the top right on the above page to register.  Or login
-if you already have registered.  Once you are registered you may file a bug by
-creating a new ticket.
-
-Alternatively, you can post on the enthought-dev@mail.enthought.com mailing list.
+To submit a bug you will necessarily have to register on Github.
+Alternatively, you can post on the info@enthought.com mailing list.
 
 
 Authors and Contributors

--- a/README-tvtk.txt
+++ b/README-tvtk.txt
@@ -57,7 +57,7 @@ Bug tracker, mailing list etc.
 
 The bug tracker is available here:
 
- https://github.com/enthought/mayavi
+ https://github.com/enthought/mayavi/issues
 
 To submit a bug you will necessarily have to register on Github.
 Alternatively, you can post on the info@enthought.com mailing list.

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,8 @@
 MayaVi2: 3D visualization of scientific data in Python
 =======================================================
 
-http://github.com/enthought/mayavi
+Mayavi doc: http://docs.enthought.com/mayavi/mayavi/
+TVTK doc: http://docs.enthought.com/mayavi/tvtk
 
 .. image:: https://api.travis-ci.org/enthought/mayavi.png?branch=master
    :target: https://travis-ci.org/enthought/mayavi

--- a/docs/API.txt
+++ b/docs/API.txt
@@ -4,7 +4,7 @@ Public and private APIs in TVTK and Mayavi
 In general the following page documents the version numbers of each
 Mayavi project release:
 
-   https://svn.enthought.com/enthought/wiki/EnthoughtVersionNumbers
+   https://github.com/enthought/mayavi/releases
 
 However, not everything released as part of the project is really a
 public API that we guarantee to ensure.   Public API's are those that

--- a/docs/source/mayavi/advanced_scripting.rst
+++ b/docs/source/mayavi/advanced_scripting.rst
@@ -34,8 +34,8 @@ Traits in order to understand Mayavi's internals.  If you are unsure
 of Traits it is a good idea to get a general idea about Traits now.
 Trust me, your efforts learning Traits will not be wasted!
 
-.. _Traits: http://code.enthought.com/projects/traits
-.. _TVTK: http://code.enthought.com/projects/mayavi
+.. _Traits: http://docs.enthought.com/traits
+.. _TVTK: http://docs.enthought.com/mayavi/tvtk
 
 
 Design Overview: Mayavi as a visualization framework
@@ -168,7 +168,7 @@ application is run.  This allows a developer to create an application
 that uses mayavi but does not show its user interface.  An example of
 how this may be done is provided in ``examples/mayavi/nongui.py``.
 
-.. _Envisage: http://code.enthought.com/projects/envisage
+.. _Envisage: http://docs.enthought.com/envisage
 
 
 Scripting from the UI

--- a/docs/source/mayavi/auto/mayavi_traits_ui.py
+++ b/docs/source/mayavi/auto/mayavi_traits_ui.py
@@ -6,7 +6,7 @@ inside a Traits UI view.
 This does not use Envisage and provides a similar UI as seen in the full
 Mayavi application.
 
-This example uses `traitsUI <http://code.enthought.com/projects/traits/>`_
+This example uses `traitsUI <http://docs.enthought.com/traitsui/>`_
 to create a dialog mimicking the mayavi2 application: a scene on the
 right, and on the left a pipeline tree view, and below it a panel to
 edit the currently-selected object.

--- a/docs/source/mayavi/auto/mlab_interactive_dialog.py
+++ b/docs/source/mayavi/auto/mlab_interactive_dialog.py
@@ -3,7 +3,7 @@
 An example of how to modify the data visualized  via an interactive dialog.
 
 A dialog is created via `TraitsUI
-<http://code.enthought.com/projects/traits/>`_ from an object (MyModel).
+<http://docs.enthought.com/traitsui/>`_ from an object (MyModel).
 Some attributes of the objects are represented on the dialog: first a
 Mayavi scene, that will host our visualization, and two parameters that
 control the data plotted.

--- a/docs/source/mayavi/auto/mlab_traits_ui.py
+++ b/docs/source/mayavi/auto/mlab_traits_ui.py
@@ -2,7 +2,7 @@
 """A simple example of how to use mayavi.mlab inside a traits UI dialog.
 
 This example uses traitsUI (
-`traitsUI <http://code.enthought.com/projects/traits/>`_ ) to create a
+`traitsUI <http://docs.enthought.com/traitsui/>`_ ) to create a
 the simplest possible dialog: a single Mayavi scene in a window.
 """
 

--- a/docs/source/mayavi/data.rst
+++ b/docs/source/mayavi/data.rst
@@ -518,7 +518,7 @@ objects or data files for Mayavi and TVTK.
 
  * Presentation on TVTK and Mayavi2 for course at IIT Bombay
 
-   In source: ./docs/pdf/tvtk_mayavi2.pdf
+   https://github.com/enthought/mayavi/raw/master/docs/pdf/tvtk_mayavi2.pdf
 
    This presentation provides information on graphics in general, 3D
    data representation, creating VTK data files, creating datasets

--- a/docs/source/mayavi/data.rst
+++ b/docs/source/mayavi/data.rst
@@ -518,7 +518,7 @@ objects or data files for Mayavi and TVTK.
 
  * Presentation on TVTK and Mayavi2 for course at IIT Bombay
 
-   https://svn.enthought.com/enthought/attachment/wiki/MayaVi/tvtk_mayavi2.pdf
+   In source: ./docs/pdf/tvtk_mayavi2.pdf
 
    This presentation provides information on graphics in general, 3D
    data representation, creating VTK data files, creating datasets
@@ -526,7 +526,8 @@ objects or data files for Mayavi and TVTK.
 
  * Presentation on making TVTK datasets using numpy arrays made for SciPy07.
 
-   https://svn.enthought.com/enthought/attachment/wiki/MayaVi/tvtk_datasets.pdf
+   Prabhu Ramachandran. "TVTK and MayaVi2", SciPy'07:
+   Python for Scientific Computing, CalTech, Pasadena, CA, 16--17 August, 2007.
 
    This presentation focuses on creating TVTK datasets using numpy
    arrays.

--- a/docs/source/mayavi/installation.rst
+++ b/docs/source/mayavi/installation.rst
@@ -113,7 +113,6 @@ are described in the following.
 .. _enstaller: https://pypi.python.org/pypi/enstaller
 .. _Debian: http://www.debian.org
 .. _Ubuntu: http://www.ubuntu.com
-.. _IntelMacPython25: https://svn.enthought.com/enthought/wiki/IntelMacPython25
 .. _numpy: http://numpy.scipy.org
 .. _Enthought Canopy: https://www.enthought.com/products/canopy/
 .. _Pythonxy: https://python-xy.github.io/

--- a/docs/source/mayavi/overview.rst
+++ b/docs/source/mayavi/overview.rst
@@ -12,7 +12,7 @@ An overview of Mayavi
 Introduction
 -------------
 
-Mayavi2_ seeks to provide easy and interactive visualization of 3D
+Mayavi2 seeks to provide easy and interactive visualization of 3D
 data, or 3D plotting.  It does this by the following:
 
     * an (optional) rich user interface with dialogs to interact with
@@ -30,11 +30,9 @@ in your libraries and applications in different ways or be combined with
 the Envisage_ application-building framework to assemble domain-specific
 tools.
 
-.. _Mayavi2: https://svn.enthought.com/enthought/wiki/MayaVi
-.. _Mayavi: https://svn.enthought.com/enthought/wiki/MayaVi
 .. _Python: http://www.python.org
 .. _VTK: http://www.vtk.org
-.. _envisage: https://svn.enthought.com/enthought/wiki/Envisage
+.. _Envisage: http://docs.enthought.com/envisage
 .. _matplotlib: http://matplotlib.sf.net
 
 What is Mayavi2?
@@ -110,8 +108,8 @@ Envisage_. Here are some of its features:
 
 
 .. _ETS: http://code.enthought.com/projects/tool-suite.php
-.. _Traits: https://svn.enthought.com/enthought/wiki/Traits
-.. _TVTK: https://svn.enthought.com/enthought/wiki/TVTK
+.. _Traits: https://docs.enthought.com/traits
+.. _TVTK: https://docs.enthought.com/mayavi/tvtk
 .. _MVC: http://en.wikipedia.org/wiki/Model-view-controller
 .. _numpy: http://numpy.scipy.org
 
@@ -216,8 +214,6 @@ is available in the :ref:`data-structures-used-by-mayavi` section.
 .. _VTK file formats: http://www.vtk.org/VTK/img/file-formats.pdf 
 .. _numpy: http://numpy.scipy.org
 .. _VTK: http://www.vtk.org
-.. _envisage: https://svn.enthought.com/enthought/wiki/Envisage
-.. _TVTK: https://svn.enthought.com/enthought/wiki/TVTK
 
 ..
    Local Variables:

--- a/docs/source/mayavi/sphinxext/sphinxext/traitsdoc.py
+++ b/docs/source/mayavi/sphinxext/sphinxext/traitsdoc.py
@@ -10,7 +10,7 @@ This extension can be used as a replacement for ``numpydoc`` when support
 for Traits is required.
 
 .. [1] http://projects.scipy.org/numpy/wiki/CodingStyleGuidelines#docstring-standard
-.. [2] http://code.enthought.com/projects/traits/
+.. [2] http://docs.enthought.com/traits/
 
 """
 from __future__ import division, absolute_import, print_function

--- a/docs/source/mayavi/tips.rst
+++ b/docs/source/mayavi/tips.rst
@@ -295,7 +295,7 @@ sources/modules/filters and only registers the metadata.  This will
 avoid issues with circular imports. 
 
 
-.. _`examples/mayavi/user_mayavi.py`: https://svn.enthought.com/enthought/browser/Mayavi/trunk/examples/mayavi/user_mayavi.py
+.. _`examples/mayavi/user_mayavi.py`: https://raw.githubusercontent.com/enthought/mayavi/4.4.4/examples/mayavi/user_mayavi.py
 
 
 Customizing Mayavi2

--- a/docs/source/tvtk/README.txt
+++ b/docs/source/tvtk/README.txt
@@ -29,7 +29,7 @@ module).  Here is a list of current features.
  * tvtk is free software with a BSD style license.
 
 
-.. _traits: http://www.enthought.com/traits
+.. _traits: http://docs.enthought.com/traits
 .. _VTK: http://www.vtk.org
 
 
@@ -43,7 +43,7 @@ tvtk.
  * Python should be built with zlib support and must support ZIP file
    imports.
  * VTK-5.x, VTK-4.4 or VTK-4.2.  It is unlikely to work with VTK-3.x.
- * Traits, version 2.
+ * Traits.
  * numpy -- Any recent version should be fine.
  * To use `ivtk.py`, `mlab` you need to have `pyface` installed.
  * To use the plugins you need Envisage installed.
@@ -52,24 +52,21 @@ tvtk.
 Installation
 ============
 
-TVTK is meant to be installed as part of the `enthought` package.  The
-`setup_tvtk.py` file sets up TVTK.  So installing the `enthought`
-package should also install tvtk for you.  For an inplace build of the
-Enthought tool suite please read: `inplace build of the Enthought tool
-suite`_.
+TVTK is meant to be installed as part of the `mayavi` package.
+Please visit the installation guide on the Mayavi documentation:
 
+   http://docs.enthought.com/mayavi/mayavi/installation.html
 
 This document only covers building and using TVTK from inside a
-checkout of the the enthought SVN_ repository.  The tvtk module lives
+checkout of the the mayavi_ repository.  The tvtk module lives
 inside `tvtk`.  To build the tvtk module and use them from
-inside the `enthought` sources do the following from the base of the
-enthought source tree (we assume here that this is in
-`/home/svn/enthought/src/lib/enthought`)::
+inside the `mayavi` sources do the following from the base of the
+mayavi source tree (we assume here that this is in
+`/home/user/src/lib/mayavi`)::
 
   $ pwd
-  /home/svn/enthought/src/lib/enthought
-  $ cd tvtk
-  $ python setup_tvtk.py build_ext --inplace
+  /home/user/src/lib/mayavi
+  $ python setup.py build
 
 The code generation will take a bit of time.  On a PentiumIII machine
 at 450Mhz, generating the code takes about a minute.  If the code
@@ -81,20 +78,15 @@ This completes the installation.  The build can be tested by running
 the tests in the `tests/` directory.  This tests the built code::
 
   $ pwd
-  /home/svn/enthought/tvtk
-  $ cd tests
-  $ python test_tvtk.py
+  /home/user/src/lib/mayavi
+  $ python -m nose.core -v tvtk/tests
   [...]
 
 If the tests run fine, the build is good.  There are other tests in
 the `tests` directory that can also be run.
 
-Documentation is available in the 'doc/' directory.  The 'examples/'
+Documentation is available in the 'docs/' directory.  The 'examples/'
 directory contains a few simple examples demonstrating tvtk in action.
-
-
-.. _SVN: http://subversion.tigris.org
-.. _inplace build of the Enthought tool suite: http://enthought.com/enthought/wiki/GrabbingAndBuilding
 
 
 Basic Usage

--- a/examples/mayavi/interactive/adjust_cropping_extents.py
+++ b/examples/mayavi/interactive/adjust_cropping_extents.py
@@ -14,9 +14,11 @@ object as a dialog box. We use a callback called when these attributes
 are modified to propagate them to the filter. For more information
 on creating GUIs with Traits:
 
-    http://code.enthought.com/projects/traits/docs/html/tutorials/traits_ui_scientific_app.html
+    http://docs.enthought.com/traitsui
 
-    http://code.enthought.com/projects/traits/documentation.php
+    http://docs.enthought.com/traits
+
+    https://support.enthought.com/hc/en-us/articles/204469620-Introductory-materials-for-Traits-and-Traits-UI
 
 """
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>

--- a/examples/mayavi/interactive/mayavi_traits_ui.py
+++ b/examples/mayavi/interactive/mayavi_traits_ui.py
@@ -6,7 +6,7 @@ inside a Traits UI view.
 This does not use Envisage and provides a similar UI as seen in the full
 Mayavi application.
 
-This example uses `traitsUI <http://code.enthought.com/projects/traits/>`_
+This example uses `traitsUI <http://docs.enthought.com/traitsui/>`_
 to create a dialog mimicking the mayavi2 application: a scene on the
 right, and on the left a pipeline tree view, and below it a panel to
 edit the currently-selected object.

--- a/examples/mayavi/interactive/mlab_interactive_dialog.py
+++ b/examples/mayavi/interactive/mlab_interactive_dialog.py
@@ -3,7 +3,7 @@
 An example of how to modify the data visualized  via an interactive dialog.
 
 A dialog is created via `TraitsUI
-<http://code.enthought.com/projects/traits/>`_ from an object (MyModel).
+<http://docs.enthought.com/traitsui/>`_ from an object (MyModel).
 Some attributes of the objects are represented on the dialog: first a
 Mayavi scene, that will host our visualization, and two parameters that
 control the data plotted.

--- a/examples/mayavi/interactive/mlab_traits_ui.py
+++ b/examples/mayavi/interactive/mlab_traits_ui.py
@@ -2,7 +2,7 @@
 """A simple example of how to use mayavi.mlab inside a traits UI dialog.
 
 This example uses traitsUI (
-`traitsUI <http://code.enthought.com/projects/traits/>`_ ) to create a
+`traitsUI <http://docs.enthought.com/traitsui/>`_ ) to create a
 the simplest possible dialog: a single Mayavi scene in a window.
 """
 

--- a/mayavi/scripts/mayavi2.py
+++ b/mayavi/scripts/mayavi2.py
@@ -5,7 +5,7 @@ This script parses the command line arguments and launches Mayavi2
 suitably.  It is meant to be used by those using Mayavi2 as a
 standalone application.
 
-Mayavi2 wiki page: http://svn.enthought.com/enthought/wiki/MayaVi
+Mayavi2: http://docs.enthought.com/mayavi/mayavi/overview.html
 
 """
 # Author: Prabhu Ramachandran <prabhu@enthought.com>

--- a/setup.py
+++ b/setup.py
@@ -451,8 +451,7 @@ numpy.distutils.core.setup(
         'build_docs': BuildDocs,
         },
     description = DOCLINES[1],
-    download_url = ('http://www.enthought.com/repo/ets/mayavi-%s.tar.gz' %
-                    info['__version__']),
+    download_url=('https://www.github.com/enthought/mayavi'),
     entry_points = {
         'gui_scripts': [
             'mayavi2 = mayavi.scripts.mayavi2:main',

--- a/setup.py
+++ b/setup.py
@@ -423,7 +423,7 @@ numpy.distutils.core.setup(
     author_email = "prabhu@aero.iitb.ac.in",
     maintainer = 'ETS Developers',
     maintainer_email = 'enthought-dev@enthought.com',
-    url = 'http://code.enthought.com/projects/mayavi/',
+    url = 'http://docs.enthought.com/mayavi/mayavi/',
     classifiers = [c.strip() for c in """\
         Development Status :: 5 - Production/Stable
         Intended Audience :: Developers


### PR DESCRIPTION
Hunt down links to the code.enthought.com and svn.enthought.com domain.

Some of which are in scripts' docstrings that are invisible on the actual documentation website.

And I don't know what to do with these:
```
./docs/source/mayavi/installation.rst:.. _ETS: http://code.enthought.com/
./docs/source/mayavi/overview.rst:.. _ETS: http://code.enthought.com/projects/tool-suite.php
./examples/mayavi/mlab/chemistry.py:    'http://code.enthought.com/projects/mayavi/data/h2o-elf.cube'
./docs/source/mayavi/auto/chemistry.py:   'http://code.enthought.com/projects/mayavi/data/h2o-elf.cube'
```

Also don't know what to do with these:
```
./docs/API.txt:   https://svn.enthought.com/enthought/wiki/EnthoughtVersionNumbers
./mayavi/scripts/mayavi2.py:Mayavi2 wiki page: http://svn.enthought.com/enthought/wiki/MayaVi
```

I can't guarantee that I have done all of them, but this is a step forward.

@jdmarch can you take a look please?
