### PR TITLE
Fix erroneous images when snapshot size is larger than window

### DIFF
--- a/integrationtests/mayavi/test_mlab_savefig.py
+++ b/integrationtests/mayavi/test_mlab_savefig.py
@@ -162,6 +162,11 @@ class TestMlabSavefigUnitTest(unittest.TestCase):
         if size:
             self.assertEqual(image.shape[:2], size)
 
+        # check if the image has black spots
+        if (numpy.sum(image == [0, 0, 0], axis=2) == 3).any():
+            message = "The image has black spots"
+            self.fail(message)
+
 
 class TestMlabSavefig(TestCase):
 

--- a/tvtk/pyface/tvtk_scene.py
+++ b/tvtk/pyface/tvtk_scene.py
@@ -416,8 +416,7 @@ class TVTKScene(HasPrivateTraits):
         """Saves the rendered scene to a rasterized PostScript image.
         For vector graphics use the save_gl2ps method."""
         if len(file_name) != 0:
-            w2if = tvtk.WindowToImageFilter(read_front_buffer=
-                                              not self.off_screen_rendering)
+            w2if = tvtk.WindowToImageFilter(read_front_buffer=False)
             w2if.magnification = self.magnification
             self._lift()
             w2if.input = self._renwin
@@ -429,8 +428,7 @@ class TVTKScene(HasPrivateTraits):
     def save_bmp(self, file_name):
         """Save to a BMP image file."""
         if len(file_name) != 0:
-            w2if = tvtk.WindowToImageFilter(read_front_buffer=
-                                              not self.off_screen_rendering)
+            w2if = tvtk.WindowToImageFilter(read_front_buffer=False)
             w2if.magnification = self.magnification
             self._lift()
             w2if.input = self._renwin
@@ -442,8 +440,7 @@ class TVTKScene(HasPrivateTraits):
     def save_tiff(self, file_name):
         """Save to a TIFF image file."""
         if len(file_name) != 0:
-            w2if = tvtk.WindowToImageFilter(read_front_buffer=
-                                              not self.off_screen_rendering)
+            w2if = tvtk.WindowToImageFilter(read_front_buffer=False)
             w2if.magnification = self.magnification
             self._lift()
             w2if.input = self._renwin
@@ -455,8 +452,7 @@ class TVTKScene(HasPrivateTraits):
     def save_png(self, file_name):
         """Save to a PNG image file."""
         if len(file_name) != 0:
-            w2if = tvtk.WindowToImageFilter(read_front_buffer=
-                                              not self.off_screen_rendering)
+            w2if = tvtk.WindowToImageFilter(read_front_buffer=False)
             w2if.magnification = self.magnification
             self._lift()
             w2if.input = self._renwin
@@ -472,8 +468,7 @@ class TVTKScene(HasPrivateTraits):
         if len(file_name) != 0:
             if not quality and not progressive:
                 quality, progressive = self.jpeg_quality, self.jpeg_progressive
-            w2if = tvtk.WindowToImageFilter(read_front_buffer=
-                                              not self.off_screen_rendering)
+            w2if = tvtk.WindowToImageFilter(read_front_buffer=False)
             w2if.magnification = self.magnification
             self._lift()
             w2if.input = self._renwin


### PR DESCRIPTION
Added tests looking out for black spots in an image that should not have any.
In addition to running the added test cases against the current master branch, one can see the problem on their own machine by doing this:
```
from mayavi import mlab

fig = mlab.figure(size=(90, 130))
mlab.test_contour3d()
# notice that the image size is larger than the window size
mlab.savefig("saved_file.png", size=(140, 200), magnification=2)
```
I have tested this branch with a headed machine under xvfb.

Potentially related to #75, effectively undoing #58 

OS: Ubuntu 12.04 LTS 64bit
VTK: 6.2.0
wxPython: 2.8.10
