### PR TITLE
Enforce ordering of attribute labels in VTKDataSource.

### DIFF
--- a/mayavi/sources/vtk_data_source.py
+++ b/mayavi/sources/vtk_data_source.py
@@ -341,7 +341,7 @@ class VTKDataSource(Source):
             aa = obj._assign_attribute
             data = getattr(obj.data, '%s_data'%d_type)
             for attr in attrs:
-                values = attributes[attr]
+                values = sorted(attributes[attr])
                 values.append('')
                 setattr(obj, '_%s_%s_list'%(d_type, attr), values)
                 if len(values) > 1:


### PR DESCRIPTION
Currently, the entries have no guarantee of order, as they come from a dictionary.
We enforce the sorted order for user friendliness and consistency.