### PR TITLE
Fix for test failure on mayavi -t

### DIFF
--- a/mayavi/tests/runtests.py
+++ b/mayavi/tests/runtests.py
@@ -60,11 +60,17 @@ def find_tests(tests):
             try:
                 # Import the module
                 components = test.split('.')
-                modname = '.'.join(components[:-1])
-                symbol = components[-1]
-                mod = __import__(modname, globals(), locals(), [symbol])
-                s = getattr(mod, symbol)
-                d = dirname(s.__file__)
+                if len(components) > 1:
+                    modname = '.'.join(components[:-1])
+                    symbol = components[-1]
+                    mod = __import__(modname, globals(), locals(), [symbol])
+                    s = getattr(mod, symbol)
+                    d = dirname(s.__file__)
+                else:
+                    modname = components[0]
+                    mod = __import__(modname, globals(), locals(), [])
+                    d = dirname(mod.__file__)
+
                 files.extend(get_tests_in_dir(d))
             except ImportError:
                 msg = 'Warning: %s is neither a file/directory or '\

--- a/mayavi/tests/test_contour.py
+++ b/mayavi/tests/test_contour.py
@@ -19,7 +19,7 @@ from mayavi.modules.iso_surface import IsoSurface
 from mayavi.modules.contour_grid_plane import ContourGridPlane
 from mayavi.modules.scalar_cut_plane import ScalarCutPlane
 
-from . import datasets
+from mayavi.tests import datasets
 
 class TestContour(unittest.TestCase):
 

--- a/mayavi/tests/test_grid_plane.py
+++ b/mayavi/tests/test_grid_plane.py
@@ -8,7 +8,7 @@ from os.path import abspath
 from io import BytesIO
 import copy
 import unittest
-from . import datasets
+from mayavi.tests import datasets
 
 # Local imports.
 from mayavi.core.engine import Engine

--- a/mayavi/tests/test_image_data_probe.py
+++ b/mayavi/tests/test_image_data_probe.py
@@ -10,7 +10,7 @@ import copy
 import unittest
 
 # Local imports.
-from .common import get_example_data
+from mayavi.tests.common import get_example_data
 
 # Enthought library imports
 from mayavi.core.null_engine import NullEngine

--- a/mayavi/tests/test_image_data_reader.py
+++ b/mayavi/tests/test_image_data_reader.py
@@ -7,7 +7,7 @@ import unittest
 import numpy
 
 # Local imports.
-from .common import get_example_data
+from mayavi.tests.common import get_example_data
 
 # Enthought library imports
 from mayavi.sources.image_reader import ImageReader

--- a/mayavi/tests/test_mlab_scene_model.py
+++ b/mayavi/tests/test_mlab_scene_model.py
@@ -9,7 +9,7 @@ from traits.api import HasTraits, Instance
 from mayavi.tools.mlab_scene_model import MlabSceneModel
 from mayavi import mlab
 
-from .test_mlab_integration import TestMlabNullEngine
+from mayavi.tests.test_mlab_integration import TestMlabNullEngine
 
 ###############################################################################
 # class `TestMlabSceneModel`

--- a/mayavi/tests/test_optional_collection.py
+++ b/mayavi/tests/test_optional_collection.py
@@ -19,7 +19,7 @@ from mayavi.filters.api import PolyDataNormals
 from mayavi.modules.api import Surface
 from mayavi.sources.vtk_data_source import VTKDataSource
 
-from . import datasets
+from mayavi.tests import datasets
 
 class TestOptionalCollection(unittest.TestCase):
 

--- a/mayavi/tests/test_plot3d_mb_reader.py
+++ b/mayavi/tests/test_plot3d_mb_reader.py
@@ -10,7 +10,7 @@ import copy
 import unittest
 
 # Local imports.
-from .common import get_example_data
+from mayavi.tests.common import get_example_data
 
 # Enthought library imports
 from mayavi.core.null_engine import NullEngine

--- a/mayavi/tests/test_poly_data_reader.py
+++ b/mayavi/tests/test_poly_data_reader.py
@@ -6,7 +6,7 @@
 import unittest
 
 # Local imports.
-from .common import get_example_data
+from mayavi.tests.common import get_example_data
 
 # Enthought library imports
 from mayavi.sources.poly_data_reader import PolyDataReader

--- a/mayavi/tests/test_registry.py
+++ b/mayavi/tests/test_registry.py
@@ -13,7 +13,7 @@ from mayavi.core.metadata import SourceMetadata
 from mayavi.core.pipeline_info import PipelineInfo
 
 # Local Imports
-from .common import get_example_data
+from mayavi.tests.common import get_example_data
 
 class DummyReader(PLOT3DReader):
 

--- a/mayavi/tests/test_set_active_attribute.py
+++ b/mayavi/tests/test_set_active_attribute.py
@@ -18,7 +18,7 @@ from mayavi.filters.set_active_attribute import SetActiveAttribute
 from mayavi.modules.api import Surface, Outline
 
 # Local imports.
-from .common import get_example_data
+from mayavi.tests.common import get_example_data
 
 class TestSetActiveAttribute(unittest.TestCase):
 

--- a/mayavi/tests/test_unstructured_data_reader.py
+++ b/mayavi/tests/test_unstructured_data_reader.py
@@ -11,7 +11,7 @@ from mayavi.sources.unstructured_grid_reader import UnstructuredGridReader
 from mayavi.tests.data_reader_test_base import DataReaderTestBase
 
 # Local imports.
-from .common import get_example_data
+from mayavi.tests.common import get_example_data
 
 old_pipeline = is_old_pipeline()
 

--- a/mayavi/tests/test_vtk_data_source.py
+++ b/mayavi/tests/test_vtk_data_source.py
@@ -19,7 +19,7 @@ from mayavi.modules.contour_grid_plane import ContourGridPlane
 from mayavi.modules.scalar_cut_plane import ScalarCutPlane
 from tvtk.api import tvtk
 
-from . import datasets
+from mayavi.tests import datasets
 
 class TestVTKDataSource(unittest.TestCase):
 

--- a/mayavi/tests/test_vtk_file_reader.py
+++ b/mayavi/tests/test_vtk_file_reader.py
@@ -11,7 +11,7 @@ import vtk
 from mayavi.sources.vtk_file_reader import VTKFileReader
 
 # Local imports.
-from .common import get_example_data
+from mayavi.tests.common import get_example_data
 
 vtk_major_version = vtk.vtkVersion.GetVTKMajorVersion()
 vtk_minor_version = vtk.vtkVersion.GetVTKMinorVersion()

--- a/mayavi/tests/test_vtk_xml_reader.py
+++ b/mayavi/tests/test_vtk_xml_reader.py
@@ -19,7 +19,7 @@ from mayavi.modules.contour_grid_plane import ContourGridPlane
 from mayavi.modules.scalar_cut_plane import ScalarCutPlane
 
 # Local imports.
-from .common import get_example_data
+from mayavi.tests.common import get_example_data
 
 class TestVTKXMLReader(unittest.TestCase):
 


### PR DESCRIPTION
Fixed import routine, and converted relative imports incompatible with the testing strategy.

Fixes #263 