### PR TITLE
Fix Text3D in VTK 6.0+

### DIFF
--- a/integrationtests/mayavi/test_text3d.py
+++ b/integrationtests/mayavi/test_text3d.py
@@ -1,0 +1,70 @@
+"""Tests for the Text3D module
+
+"""
+import os
+import shutil
+import unittest
+import tempfile
+
+import numpy
+from PIL import Image
+
+from mayavi import mlab
+
+from common import TestCase
+
+
+class TestText3DUnitTest(unittest.TestCase):
+
+    def setUp(self):
+        # Make a temporary directory for saved figures
+        self.temp_dir = tempfile.mkdtemp()
+        self.filename = os.path.join(self.temp_dir, "saved_figure.png")
+
+        # this ensures that the temporary directory is removed
+        self.addCleanup(self.remove_tempdir)
+
+    def remove_tempdir(self):
+        shutil.rmtree(self.temp_dir)
+
+    def mlab_close_all(self):
+        mlab.close(all=True)
+
+    def test_text3d(self):
+        # the points3d is there to provide data for
+        # attaching the text3d module.  Opacity is set to
+        # zero so that the image should only show
+        # the text3d and we look for the pixels
+        mlab.points3d(0., 0., 0., opacity=0.)
+
+        self.addCleanup(self.mlab_close_all)
+
+        mlab.text3d(0., 0., 0., "X")
+        mlab.savefig(self.filename)
+
+        self.check()
+
+    def check(self):
+        image = numpy.array(Image.open(self.filename))[:, :, :3]
+
+        # Check that the image has pixel different from the background
+        # Supposedly the first pixel is the background color
+        if not (numpy.sum(image != image[0, 0], axis=2) == 3).any():
+            message = "Looks like the Text3D is not shown"
+            self.fail(message)
+
+
+class TestText3D(TestCase):
+
+    def test(self):
+        self.main()
+
+    def do(self):
+        suite = unittest.TestLoader().loadTestsFromTestCase(
+            TestText3DUnitTest)
+        unittest.TextTestRunner().run(suite)
+
+
+if __name__ == "__main__":
+    t = TestText3D()
+    t.test()

--- a/integrationtests/mayavi/test_text3d.py
+++ b/integrationtests/mayavi/test_text3d.py
@@ -31,6 +31,7 @@ class TestText3DUnitTest(unittest.TestCase):
         mlab.close(all=True)
 
     def test_text3d(self):
+        """Test if Text3D shows"""
         # the points3d is there to provide data for
         # attaching the text3d module.  Opacity is set to
         # zero so that the image should only show

--- a/mayavi/modules/text3d.py
+++ b/mayavi/modules/text3d.py
@@ -113,6 +113,12 @@ class Text3D(Module):
         """
         self.pipeline_changed = True
 
+    def has_output_port(self):
+        """ Return True as the text3d has output port. """
+        return True
+
+    def get_output_object(self):
+        return self.vector_text.output_port
 
     ######################################################################
     # Non-public interface

--- a/travis-requirements.txt
+++ b/travis-requirements.txt
@@ -1,3 +1,4 @@
+pillow
 mock
 Sphinx
 coverage


### PR DESCRIPTION
To see the problem, try the following with VTK 6.0+
```
from mayavi import mlab

mlab.points3d(0, 0, 0, opacity=0.)  # just for attaching the text3d
mlab.text3d(0., 0., 0., "X")

```
