### PR TITLE
Import and integer division in python3

### DIFF
--- a/mayavi/tests/test_cut_plane.py
+++ b/mayavi/tests/test_cut_plane.py
@@ -6,8 +6,8 @@
 import unittest
 
 # Local imports.
-import datasets
-from common import get_example_data
+from . import datasets
+from .common import get_example_data
 
 # Enthought library imports
 from mayavi.core.null_engine import NullEngine

--- a/mayavi/tools/sources.py
+++ b/mayavi/tools/sources.py
@@ -168,7 +168,7 @@ class MGlyphSource(MlabSource):
 
         else:
             points = np.c_[x.ravel(), y.ravel(), z.ravel()].ravel()
-            points.shape = (points.size / 3, 3)
+            points.shape = (-1, 3)
             self.set(points=points, trait_change_notify=False)
 
         u, v, w = self.u, self.v, self.w
@@ -179,7 +179,7 @@ class MGlyphSource(MlabSource):
             if len(u) > 0:
                 vectors = np.c_[u.ravel(), v.ravel(),
                                 w.ravel()].ravel()
-                vectors.shape = (vectors.size / 3, 3)
+                vectors.shape = (-1, 3)
                 self.set(vectors=vectors, trait_change_notify=False)
 
         if 'vectors' in traits:
@@ -192,7 +192,7 @@ class MGlyphSource(MlabSource):
             if u is not None and len(u) > 0:
                 vectors = np.c_[u.ravel(), v.ravel(),
                                 w.ravel()].ravel()
-                vectors.shape = (vectors.size / 3, 3)
+                vectors.shape = (-1, 3)
                 self.set(vectors=vectors, trait_change_notify=False)
 
         if vectors is not None and len(vectors) > 0:
@@ -785,7 +785,7 @@ class MTriangularMeshSource(MlabSource):
 
         x, y, z = self.x, self.y, self.z
         points = np.c_[x.ravel(), y.ravel(), z.ravel()].ravel()
-        points.shape = (points.size / 3, 3)
+        points.shape = (-1, 3)
         self.set(points=points, trait_change_notify=False)
 
         triangles = self.triangles


### PR DESCRIPTION
Two small fixes in compliance with Python3

(1) Explicit relative import for a test
(2) Integer division may cause error, use `-1` to infer the size of the remaining dimension in numpy.reshape