### PR TITLE
Fix traitsdoc setup and compliance with py3

### DIFF
--- a/docs/source/mayavi/sphinxext/sphinxext/comment_eater.py
+++ b/docs/source/mayavi/sphinxext/sphinxext/comment_eater.py
@@ -169,9 +169,6 @@ def get_class_traits(klass):
     # AST tree for the class
     class_ast = mod_ast.body[0]
 
-    # Source code needed for getting the right-hand side
-    source_code = source.split("\n")
-
     # All assignement nodes
     assign_nodes = [node for node in class_ast.body
                     if isinstance(node, ast.Assign)]
@@ -180,12 +177,10 @@ def get_class_traits(klass):
         # Left-hand side
         name = node.targets[0].id
 
-        # Get the type of the right-hand side
-        if isinstance(node.value, ast.Call):
-            rhs = node.value.func.id
-        else:
-            rhs = type(node.value).__name__
+        # Right-hand side
+        rhs = unparse(node.value)
 
+        # Comment
         doc = strip_comment_marker(cb.search_for_comment(node.lineno, default=''))
 
         yield name, rhs, doc

--- a/docs/source/mayavi/sphinxext/sphinxext/comment_eater.py
+++ b/docs/source/mayavi/sphinxext/sphinxext/comment_eater.py
@@ -170,8 +170,8 @@ def get_class_traits(klass):
     class_ast = mod_ast.body[0]
 
     # All assignement nodes
-    assign_nodes = [node for node in class_ast.body
-                    if isinstance(node, ast.Assign)]
+    assign_nodes = (node for node in class_ast.body
+                    if isinstance(node, ast.Assign))
 
     for node in assign_nodes:
         # Left-hand side

--- a/docs/source/mayavi/sphinxext/sphinxext/comment_eater.py
+++ b/docs/source/mayavi/sphinxext/sphinxext/comment_eater.py
@@ -3,7 +3,7 @@ from __future__ import division, absolute_import, print_function
 import sys
 from io import StringIO
 
-import compiler
+import ast
 import inspect
 import textwrap
 import tokenize
@@ -155,17 +155,37 @@ def strip_comment_marker(text):
 def get_class_traits(klass):
     """ Yield all of the documentation for trait definitions on a class object.
     """
+
     # FIXME: gracefully handle errors here or in the caller?
     source = inspect.getsource(klass)
+
+    # This collects all the comments block
     cb = CommentBlocker()
     cb.process_file(StringIO(sixu(source)))
-    mod_ast = compiler.parse(source)
-    class_ast = mod_ast.node.nodes[0]
-    for node in class_ast.code.nodes:
-        # FIXME: handle other kinds of assignments?
-        if isinstance(node, compiler.ast.Assign):
-            name = node.nodes[0].name
-            rhs = unparse(node.expr).strip()
-            doc = strip_comment_marker(cb.search_for_comment(node.lineno, default=''))
-            yield name, rhs, doc
 
+    # AST tree for the module
+    mod_ast = ast.parse(source)
+
+    # AST tree for the class
+    class_ast = mod_ast.body[0]
+
+    # Source code needed for getting the right-hand side
+    source_code = source.split("\n")
+
+    # All assignement nodes
+    assign_nodes = [node for node in class_ast.body
+                    if isinstance(node, ast.Assign)]
+
+    for node in assign_nodes:
+        # Left-hand side
+        name = node.targets[0].id
+
+        # Get the type of the right-hand side
+        if isinstance(node.value, ast.Call):
+            rhs = node.value.func.id
+        else:
+            rhs = type(node.value).__name__
+
+        doc = strip_comment_marker(cb.search_for_comment(node.lineno, default=''))
+
+        yield name, rhs, doc

--- a/docs/source/mayavi/sphinxext/sphinxext/compiler_unparse.py
+++ b/docs/source/mayavi/sphinxext/sphinxext/compiler_unparse.py
@@ -213,6 +213,11 @@ class UnparseCompilerAst:
         """
         self._dispatch(t.n)
 
+    def _NameConstant(self, t):
+        """ NameConstant such as False
+        """
+        self._dispatch(repr(t.value))
+
     def _Str(self, t):
         """ A string value such as "hello".
         """

--- a/docs/source/mayavi/sphinxext/sphinxext/numpydoc.py
+++ b/docs/source/mayavi/sphinxext/sphinxext/numpydoc.py
@@ -119,6 +119,9 @@ def setup(app, get_doc_object_=get_doc_object):
     if not hasattr(app, 'add_config_value'):
         return  # probably called by nose, better bail out
 
+    global get_doc_object
+    get_doc_object = get_doc_object_
+
     app.connect('autodoc-process-docstring', mangle_docstrings)
     app.connect('autodoc-process-signature', mangle_signature)
     app.add_config_value('numpydoc_edit_link', None, False)


### PR DESCRIPTION
Traits properties should show in the API documentation with this PR.  And doc build should work on Python3.

Although previously changes in #293 led to successful doc build, it in fact did not setup sphinx to use `traitsdoc.get_doc_object` and `traitsdoc.SphinxTraitsDoc` (my fault!).  This PR fixes this problem.

Partial fix is made to `compiler_unparse` according changes in the API of `ast`; enough for the current doc build.  In the future we may consider using customised comment syntax for documenting traits (e.g. https://github.com/enthought/trait-documenter) instead of printing the code for the traits definition, therefore removing the need for unparsing AST back to code.

Tested on OS X + Python3 + Sphinx 1.4, and Ubuntu + Python2.7 + Sphinx1.3.5

@itziakos : does this fix #228 too?
