### PR TITLE
fixes for the tvtk_segmentation.py example

### DIFF
--- a/examples/mayavi/advanced_visualization/tvtk_segmentation.py
+++ b/examples/mayavi/advanced_visualization/tvtk_segmentation.py
@@ -49,8 +49,8 @@ data = data.T
 # scipy.stats.scoreatpercentile)
 sorted_data = np.sort(data.ravel())
 l = len(sorted_data)
-lower_thr = sorted_data[0.2*l]
-upper_thr = sorted_data[0.8*l]
+lower_thr = sorted_data[int(0.2*l)]
+upper_thr = sorted_data[int(0.8*l)]
 
 # The white matter boundary: find the densest part of the upper half
 # of histogram, and take a value 10% higher, to cut _in_ the white matter

--- a/examples/mayavi/advanced_visualization/tvtk_segmentation.py
+++ b/examples/mayavi/advanced_visualization/tvtk_segmentation.py
@@ -87,7 +87,7 @@ thresh_filter.threshold_between(lower_thr, upper_thr)
 thresh = mlab.pipeline.user_defined(src, filter=thresh_filter)
 
 median_filter = tvtk.ImageMedian3D()
-median_filter.set_kernel_size(3, 3, 3)
+median_filter.kernel_size = [3, 3, 3]
 median = mlab.pipeline.user_defined(thresh, filter=median_filter)
 
 diffuse_filter = tvtk.ImageAnisotropicDiffusion3D(


### PR DESCRIPTION
The first commit here fixes the following error:

```
Traceback (most recent call last):
  File "examples/mayavi/advanced_visualization/tvtk_segmentation.py", line 90, in <module>
    median_filter.set_kernel_size(3, 3, 3)
AttributeError: 'ImageMedian3D' object has no attribute 'set_kernel_size'
```

The second avoids the following warnings raised by numpy 1.11

```
examples/mayavi/advanced_visualization/tvtk_segmentation.py:52: VisibleDeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
  lower_thr = sorted_data[0.2*l]
examples/mayavi/advanced_visualization/tvtk_segmentation.py:53: VisibleDeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
  upper_thr = sorted_data[0.8*l]
```
