### PR TITLE
Reimplement fix savefig with size and magnification - step 0 [WIP]

### DIFF
--- a/integrationtests/mayavi/test_mlab_savefig.py
+++ b/integrationtests/mayavi/test_mlab_savefig.py
@@ -123,6 +123,57 @@ class TestMlabSavefigUnitTest(unittest.TestCase):
         self.check_image_size(self.filename, size=(262, 434))
         self.check_image_no_black_pixel(self.filename)
 
+    def test_savefig_offscreen(self):
+        """Test savefig with auto size, mag, normal Engine and offscreen"""
+        self.setup_engine_and_figure(Engine())
+
+        # Use offscreen rendering
+        self.figure.scene.off_screen_rendering = True
+
+        # Set up the scene
+        create_quiver3d(figure=self.figure)
+
+        # save the figure (magnification is default "auto")
+        savefig(self.filename, figure=self.figure)
+
+        # check
+        self.check_image_no_black_pixel(self.filename)
+
+    def test_savefig_with_size_offscreen(self):
+        """Test savefig with given size, normal Engine and offscreen"""
+        self.setup_engine_and_figure(Engine())
+
+        # Use offscreen rendering
+        self.figure.scene.off_screen_rendering = True
+
+        # Set up the scene
+        create_quiver3d(figure=self.figure)
+
+        # save the figure (magnification is default = 1)
+        savefig(self.filename, size=(131, 217), figure=self.figure)
+
+        # check
+        self.check_image_size(self.filename, size=(131, 217))
+        self.check_image_no_black_pixel(self.filename)
+
+    def test_savefig_with_size_and_magnification_offscreen(self):
+        """Test savefig with given size, mag, normal Engine and offscreen"""
+        self.setup_engine_and_figure(Engine())
+
+        # Use offscreen rendering
+        self.figure.scene.off_screen_rendering = True
+
+        # Set up the scene
+        create_quiver3d(figure=self.figure)
+
+        # save the figure
+        savefig(self.filename, size=(131, 217), magnification=2,
+                figure=self.figure)
+
+        # check if the image size is twice as big
+        self.check_image_size(self.filename, size=(262, 434))
+        self.check_image_no_black_pixel(self.filename)
+
     @unittest.skipIf(os.environ.get("TRAVIS", False),
                      ("Offscreen rendering is not tested on Travis "
                       "due to lack of GLX support"))

--- a/integrationtests/mayavi/test_mlab_savefig.py
+++ b/integrationtests/mayavi/test_mlab_savefig.py
@@ -123,6 +123,9 @@ class TestMlabSavefigUnitTest(unittest.TestCase):
         self.check_image_size(self.filename, size=(262, 434))
         self.check_image_no_black_pixel(self.filename)
 
+    @unittest.skipIf(os.environ.get("TRAVIS", False),
+                     ("Offscreen rendering is not tested on Travis "
+                      "due to lack of GLX support"))
     def test_savefig_offscreen(self):
         """Test savefig with auto size, mag, normal Engine and offscreen"""
         self.setup_engine_and_figure(Engine())
@@ -139,6 +142,9 @@ class TestMlabSavefigUnitTest(unittest.TestCase):
         # check
         self.check_image_no_black_pixel(self.filename)
 
+    @unittest.skipIf(os.environ.get("TRAVIS", False),
+                     ("Offscreen rendering is not tested on Travis "
+                      "due to lack of GLX support"))
     def test_savefig_with_size_offscreen(self):
         """Test savefig with given size, normal Engine and offscreen"""
         self.setup_engine_and_figure(Engine())
@@ -156,6 +162,9 @@ class TestMlabSavefigUnitTest(unittest.TestCase):
         self.check_image_size(self.filename, size=(131, 217))
         self.check_image_no_black_pixel(self.filename)
 
+    @unittest.skipIf(os.environ.get("TRAVIS", False),
+                     ("Offscreen rendering is not tested on Travis "
+                      "due to lack of GLX support"))
     def test_savefig_with_size_and_magnification_offscreen(self):
         """Test savefig with given size, mag, normal Engine and offscreen"""
         self.setup_engine_and_figure(Engine())

--- a/integrationtests/mayavi/test_mlab_savefig.py
+++ b/integrationtests/mayavi/test_mlab_savefig.py
@@ -4,6 +4,7 @@ import unittest
 import tempfile
 
 import numpy
+from PIL import Image
 
 from mayavi import mlab
 from mayavi.core.engine import Engine
@@ -13,7 +14,7 @@ from mayavi.tools.figure import savefig
 from common import TestCase
 
 
-def create_quiver3d():
+def create_quiver3d(figure):
     x, y, z = numpy.mgrid[1:10, 1:10, 1:10]
     u, v, w = numpy.mgrid[1:10, 1:10, 1:10]
     s = numpy.sqrt(u**2 + v**2)
@@ -58,6 +59,70 @@ class TestMlabSavefigUnitTest(unittest.TestCase):
             engine.close_scene(scene)
         engine.stop()
 
+    def check_image_no_black_pixel(self, filename):
+        """ The image setup for this test case should have absolutely
+        no black pixels.  This function checks and fails the test if
+        black pixels are found.
+        """
+        with open(filename) as fh:
+            image = numpy.array(Image.open(fh))[:, :, :3]
+
+            if (numpy.sum(image == [0, 0, 0], axis=2) == 3).any():
+                message = "The image has black spots"
+                self.fail(message)
+
+    def check_image_size(self, filename, size):
+        """ Check if the image saved in the filename has the desired
+        size
+        """
+        with open(filename) as fh:
+            image = numpy.array(Image.open(fh))[:, :, :3]
+            # check the size is correct
+            # The width and height dimensions are swapped
+            self.assertEqual(image.shape[:2][::-1], size)
+
+    def test_savefig(self):
+        """Test if savefig works with auto size, mag and a normal Engine"""
+        self.setup_engine_and_figure(Engine())
+
+        # Set up the scene
+        create_quiver3d(figure=self.figure)
+
+        # save the figure (magnification is default "auto")
+        savefig(self.filename, figure=self.figure)
+
+        # check
+        self.check_image_no_black_pixel(self.filename)
+
+    def test_savefig_with_size(self):
+        """Test if savefig works with given size and a normal Engine"""
+        self.setup_engine_and_figure(Engine())
+
+        # Set up the scene
+        create_quiver3d(figure=self.figure)
+
+        # save the figure (magnification is default = 1)
+        savefig(self.filename, size=(131, 217), figure=self.figure)
+
+        # check
+        self.check_image_size(self.filename, size=(131, 217))
+        self.check_image_no_black_pixel(self.filename)
+
+    def test_savefig_with_size_and_magnification(self):
+        """Test if savefig works with given size and magnification"""
+        self.setup_engine_and_figure(Engine())
+
+        # Set up the scene
+        create_quiver3d(figure=self.figure)
+
+        # save the figure
+        savefig(self.filename, size=(131, 217), magnification=2,
+                figure=self.figure)
+
+        # check if the image size is twice as big
+        self.check_image_size(self.filename, size=(262, 434))
+        self.check_image_no_black_pixel(self.filename)
+
     @unittest.skipIf(os.environ.get("TRAVIS", False),
                      ("Offscreen rendering is not tested on Travis "
                       "due to lack of GLX support"))
@@ -71,7 +136,7 @@ class TestMlabSavefigUnitTest(unittest.TestCase):
             self.figure.scene.off_screen_rendering = True
 
             # Set up the scene
-            create_quiver3d()
+            create_quiver3d(figure=self.figure)
 
             # save the figure
             savefig(self.filename, size=(131, 217),

--- a/tvtk/pyface/ui/wx/scene.py
+++ b/tvtk/pyface/ui/wx/scene.py
@@ -658,21 +658,22 @@ class Scene(TVTKScene, Widget):
         # messed up when the application window is shown.  To work
         # around this a dynamic IDLE event handler is added and
         # immediately removed once it executes.  This event handler
-        # simply forces a resize to occur.  The _idle_count allows us
-        # to execute the idle function a few times (this seems to work
-        # better).
+        # simply forces a resize to occur.  Previously this event
+        # handler is excecuted for the first two idle events.
+        # However this causes the first resizing event after
+        # initialization to be effectively ignored: the idle handler
+        # simply resizes it back to the old size.
+        # Since resizing once seems to be efficient, the idle handler
+        # is only called for the first idle event.
         def _do_idle(event, window=window):
             w = wx.GetTopLevelParent(window)
             # Force a resize
             sz = w.GetSize()
             w.SetSize((sz[0]-1, sz[1]-1))
             w.SetSize(sz)
-            window._idle_count -= 1
-            if window._idle_count < 1:
-                wx.EVT_IDLE(window, None)
-                del window._idle_count
+            # Remove the handler
+            wx.EVT_IDLE(window, None)
 
-        window._idle_count = 2
         wx.EVT_IDLE(window, _do_idle)
 
         self._interactor = tvtk.to_tvtk(window._Iren)


### PR DESCRIPTION
Reimplement part of #331 
Tests fail as the fix is incomplete.  I aim at making a new branch from this one for fixing those new problems, so that we know what was attempted and what does not work.  This issue is complicated.

Running `integratedtests/mayavi/test_mlab_savefig.py` against **master** leads to the following errors on *both Ubuntu 12 and OSX 10.11*

OSX: 10.11, PySide 1.2.2, wxPython 3.0.2.0
Linux: Ubuntu 12, PySide 1.2.2, wxPython 2.8.10.1

**Linux/OSX + qt4 + master branch**
```
======================================================================
FAIL: test_savefig_with_size (test_mlab_savefig.TestMlabSavefigUnitTest)
Test if savefig works with given size and a normal Engine
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_mlab_savefig.py", line 108, in test_savefig_with_size
    self.check_image_size(self.filename, size=(131, 217))
  File "test_mlab_savefig.py", line 82, in check_image_size
    self.assertEqual(image.shape[:2][::-1], size)
AssertionError: Tuples differ: (128, 216) != (131, 217)

First differing element 0:
128
131

- (128, 216)
+ (131, 217)

======================================================================
FAIL: test_savefig_with_size_and_magnification (test_mlab_savefig.TestMlabSavefigUnitTest)
Test if savefig works with given size and magnification
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_mlab_savefig.py", line 124, in test_savefig_with_size_and_magnification
    self.check_image_no_black_pixel(self.filename)
  File "test_mlab_savefig.py", line 72, in check_image_no_black_pixel
    self.fail(message)
AssertionError: The image has black spots

======================================================================
FAIL: test_savefig_with_size_offscreen (test_mlab_savefig.TestMlabSavefigUnitTest)
Test savefig with given size, normal Engine and offscreen
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_mlab_savefig.py", line 156, in test_savefig_with_size_offscreen
    self.check_image_size(self.filename, size=(131, 217))
  File "test_mlab_savefig.py", line 82, in check_image_size
    self.assertEqual(image.shape[:2][::-1], size)
AssertionError: Tuples differ: (128, 216) != (131, 217)

First differing element 0:
128
131

- (128, 216)
+ (131, 217)

----------------------------------------------------------------------
Ran 7 tests in 4.762s

FAILED (failures=3)
```

**Linux/OSX + wx + master branch**
```
======================================================================
FAIL: test_savefig_with_size (test_mlab_savefig.TestMlabSavefigUnitTest)
Test if savefig works with given size and a normal Engine
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_mlab_savefig.py", line 108, in test_savefig_with_size
    self.check_image_size(self.filename, size=(131, 217))
  File "test_mlab_savefig.py", line 82, in check_image_size
    self.assertEqual(image.shape[:2][::-1], size)
AssertionError: Tuples differ: (540, 234) != (131, 217)

First differing element 0:
540
131

- (540, 234)
+ (131, 217)

======================================================================
FAIL: test_savefig_with_size_and_magnification (test_mlab_savefig.TestMlabSavefigUnitTest)
Test if savefig works with given size and magnification
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_mlab_savefig.py", line 123, in test_savefig_with_size_and_magnification
    self.check_image_size(self.filename, size=(262, 434))
  File "test_mlab_savefig.py", line 82, in check_image_size
    self.assertEqual(image.shape[:2][::-1], size)
AssertionError: Tuples differ: (180, 78) != (262, 434)

First differing element 0:
180
262

- (180, 78)
+ (262, 434)

======================================================================
FAIL: test_savefig_with_size_and_magnification_offscreen (test_mlab_savefig.TestMlabSavefigUnitTest)
Test savefig with given size, mag, normal Engine and offscreen
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_mlab_savefig.py", line 174, in test_savefig_with_size_and_magnification_offscreen
    self.check_image_size(self.filename, size=(262, 434))
  File "test_mlab_savefig.py", line 82, in check_image_size
    self.assertEqual(image.shape[:2][::-1], size)
AssertionError: Tuples differ: (180, 78) != (262, 434)

First differing element 0:
180
262

- (180, 78)
+ (262, 434)

======================================================================
FAIL: test_savefig_with_size_offscreen (test_mlab_savefig.TestMlabSavefigUnitTest)
Test savefig with given size, normal Engine and offscreen
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_mlab_savefig.py", line 156, in test_savefig_with_size_offscreen
    self.check_image_size(self.filename, size=(131, 217))
  File "test_mlab_savefig.py", line 82, in check_image_size
    self.assertEqual(image.shape[:2][::-1], size)
AssertionError: Tuples differ: (540, 234) != (131, 217)

First differing element 0:
540
131

- (540, 234)
+ (131, 217)

----------------------------------------------------------------------
Ran 7 tests in 9.848s

FAILED (failures=4)
```


On Linux + wx, I get addition errors.  But they might just be because of the version of wxpython (2.8.10.1)
```
  File "/home/kit/.jaguar/envs/test-mayavi-2/lib/python2.7/site-packages/vtk/wx/wxVTKRenderWindowInteractor.py", line 381, in OnPaint
    self._Iren.GetRenderWindow().SetSize(self.GetSizeTuple())
AttributeError: 'NoneType' object has no attribute 'SetSize'
FTraceback (most recent call last):
  File "/home/kit/.jaguar/envs/test-mayavi-2/lib/python2.7/site-packages/vtk/wx/wxVTKRenderWindowInteractor.py", line 381, in OnPaint
    self._Iren.GetRenderWindow().SetSize(self.GetSizeTuple())
AttributeError: 'NoneType' object has no attribute 'SetSize'
```


The following runs integratedtests/mayavi/test_mlab_savefig.py against **this branch** which unveil new errors:

**Linux/OSX + wx + this branch**
```
======================================================================
FAIL: test_savefig_with_size (test_mlab_savefig.TestMlabSavefigUnitTest)
Test if savefig works with given size and a normal Engine
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_mlab_savefig.py", line 109, in test_savefig_with_size
    self.check_image_no_black_pixel(self.filename)
  File "test_mlab_savefig.py", line 72, in check_image_no_black_pixel
    self.fail(message)
AssertionError: The image has black spots

======================================================================
FAIL: test_savefig_with_size_and_magnification (test_mlab_savefig.TestMlabSavefigUnitTest)
Test if savefig works with given size and magnification
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_mlab_savefig.py", line 124, in test_savefig_with_size_and_magnification
    self.check_image_no_black_pixel(self.filename)
  File "test_mlab_savefig.py", line 72, in check_image_no_black_pixel
    self.fail(message)
AssertionError: The image has black spots

======================================================================
FAIL: test_savefig_with_size_and_magnification_offscreen (test_mlab_savefig.TestMlabSavefigUnitTest)
Test savefig with given size, mag, normal Engine and offscreen
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_mlab_savefig.py", line 174, in test_savefig_with_size_and_magnification_offscreen
    self.check_image_size(self.filename, size=(262, 434))
  File "test_mlab_savefig.py", line 82, in check_image_size
    self.assertEqual(image.shape[:2][::-1], size)
AssertionError: Tuples differ: (180, 78) != (262, 434)

First differing element 0:
180
262

- (180, 78)
+ (262, 434)

======================================================================
FAIL: test_savefig_with_size_offscreen (test_mlab_savefig.TestMlabSavefigUnitTest)
Test savefig with given size, normal Engine and offscreen
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_mlab_savefig.py", line 156, in test_savefig_with_size_offscreen
    self.check_image_size(self.filename, size=(131, 217))
  File "test_mlab_savefig.py", line 82, in check_image_size
    self.assertEqual(image.shape[:2][::-1], size)
AssertionError: Tuples differ: (90, 39) != (131, 217)

First differing element 0:
90
131

- (90, 39)
+ (131, 217)

----------------------------------------------------------------------
Ran 7 tests in 2.673s

FAILED (failures=4)
```

**Linux/OSX + qt4 + this branch**
```
======================================================================
FAIL: test_savefig_with_size (test_mlab_savefig.TestMlabSavefigUnitTest)
Test if savefig works with given size and a normal Engine
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_mlab_savefig.py", line 109, in test_savefig_with_size
    self.check_image_no_black_pixel(self.filename)
  File "test_mlab_savefig.py", line 72, in check_image_no_black_pixel
    self.fail(message)
AssertionError: The image has black spots

======================================================================
FAIL: test_savefig_with_size_and_magnification (test_mlab_savefig.TestMlabSavefigUnitTest)
Test if savefig works with given size and magnification
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_mlab_savefig.py", line 124, in test_savefig_with_size_and_magnification
    self.check_image_no_black_pixel(self.filename)
  File "test_mlab_savefig.py", line 72, in check_image_no_black_pixel
    self.fail(message)
AssertionError: The image has black spots

----------------------------------------------------------------------
Ran 7 tests in 2.275s

FAILED (failures=2)
```