### PR TITLE
Reimplement fix savefig size and black image - step 1 [WIP]

### DIFF
--- a/tvtk/pyface/tvtk_scene.py
+++ b/tvtk/pyface/tvtk_scene.py
@@ -416,8 +416,7 @@ class TVTKScene(HasPrivateTraits):
         """Saves the rendered scene to a rasterized PostScript image.
         For vector graphics use the save_gl2ps method."""
         if len(file_name) != 0:
-            w2if = tvtk.WindowToImageFilter(read_front_buffer=
-                                              not self.off_screen_rendering)
+            w2if = tvtk.WindowToImageFilter(read_front_buffer=False)
             w2if.magnification = self.magnification
             self._lift()
             w2if.input = self._renwin
@@ -429,8 +428,7 @@ class TVTKScene(HasPrivateTraits):
     def save_bmp(self, file_name):
         """Save to a BMP image file."""
         if len(file_name) != 0:
-            w2if = tvtk.WindowToImageFilter(read_front_buffer=
-                                              not self.off_screen_rendering)
+            w2if = tvtk.WindowToImageFilter(read_front_buffer=False)
             w2if.magnification = self.magnification
             self._lift()
             w2if.input = self._renwin
@@ -442,8 +440,7 @@ class TVTKScene(HasPrivateTraits):
     def save_tiff(self, file_name):
         """Save to a TIFF image file."""
         if len(file_name) != 0:
-            w2if = tvtk.WindowToImageFilter(read_front_buffer=
-                                              not self.off_screen_rendering)
+            w2if = tvtk.WindowToImageFilter(read_front_buffer=False)
             w2if.magnification = self.magnification
             self._lift()
             w2if.input = self._renwin
@@ -455,8 +452,7 @@ class TVTKScene(HasPrivateTraits):
     def save_png(self, file_name):
         """Save to a PNG image file."""
         if len(file_name) != 0:
-            w2if = tvtk.WindowToImageFilter(read_front_buffer=
-                                              not self.off_screen_rendering)
+            w2if = tvtk.WindowToImageFilter(read_front_buffer=False)
             w2if.magnification = self.magnification
             self._lift()
             w2if.input = self._renwin
@@ -472,8 +468,7 @@ class TVTKScene(HasPrivateTraits):
         if len(file_name) != 0:
             if not quality and not progressive:
                 quality, progressive = self.jpeg_quality, self.jpeg_progressive
-            w2if = tvtk.WindowToImageFilter(read_front_buffer=
-                                              not self.off_screen_rendering)
+            w2if = tvtk.WindowToImageFilter(read_front_buffer=False)
             w2if.magnification = self.magnification
             self._lift()
             w2if.input = self._renwin


### PR DESCRIPTION
This is the next step after fixing the size of the snapshot images revealing black images (#346). 
This branch was implemented as #317 but was then reverted and superseded by (#331) 
Effectively undoing #58
As offscreen tests cannot be run on Travis, these tests had to be run locally with a headed machine.

OSX: 10.11, PySide 1.2.2, wxPython 3.0.2.0
Linux: Ubuntu 12, PySide 1.2.2, wxPython 2.8.10.1

**Linux + qt4 + this branch** All passed!

**Linux + wx + this branch** (On Travis these offscreen tests are skipped)
```
======================================================================
FAIL: test_savefig_with_size_and_magnification_offscreen (test_mlab_savefig.TestMlabSavefigUnitTest)
Test savefig with given size, mag, normal Engine and offscreen
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_mlab_savefig.py", line 183, in test_savefig_with_size_and_magnification_offscreen
    self.check_image_size(self.filename, size=(262, 434))
  File "test_mlab_savefig.py", line 82, in check_image_size
    self.assertEqual(image.shape[:2][::-1], size)
AssertionError: Tuples differ: (180, 140) != (262, 434)

First differing element 0:
180
262

- (180, 140)
+ (262, 434)

======================================================================
FAIL: test_savefig_with_size_offscreen (test_mlab_savefig.TestMlabSavefigUnitTest)
Test savefig with given size, normal Engine and offscreen
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_mlab_savefig.py", line 162, in test_savefig_with_size_offscreen
    self.check_image_size(self.filename, size=(131, 217))
  File "test_mlab_savefig.py", line 82, in check_image_size
    self.assertEqual(image.shape[:2][::-1], size)
AssertionError: Tuples differ: (90, 70) != (131, 217)

First differing element 0:
90
131

- (90, 70)
+ (131, 217)

----------------------------------------------------------------------
Ran 7 tests in 5.161s

FAILED (failures=2)
```

**OSX + qt4 + this branch**
```
======================================================================
FAIL: test_savefig_with_size (test_mlab_savefig.TestMlabSavefigUnitTest)
Test if savefig works with given size and a normal Engine
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_mlab_savefig.py", line 109, in test_savefig_with_size
    self.check_image_no_black_pixel(self.filename)
  File "test_mlab_savefig.py", line 72, in check_image_no_black_pixel
    self.fail(message)
AssertionError: The image has black spots

======================================================================
FAIL: test_savefig_with_size_and_magnification (test_mlab_savefig.TestMlabSavefigUnitTest)
Test if savefig works with given size and magnification
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_mlab_savefig.py", line 124, in test_savefig_with_size_and_magnification
    self.check_image_no_black_pixel(self.filename)
  File "test_mlab_savefig.py", line 72, in check_image_no_black_pixel
    self.fail(message)
AssertionError: The image has black spots

----------------------------------------------------------------------
Ran 7 tests in 2.204s

FAILED (failures=2)
```

**OSX + wx + this branch**
```
======================================================================
FAIL: test_savefig_with_size (test_mlab_savefig.TestMlabSavefigUnitTest)
Test if savefig works with given size and a normal Engine
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_mlab_savefig.py", line 109, in test_savefig_with_size
    self.check_image_no_black_pixel(self.filename)
  File "test_mlab_savefig.py", line 72, in check_image_no_black_pixel
    self.fail(message)
AssertionError: The image has black spots

======================================================================
FAIL: test_savefig_with_size_and_magnification (test_mlab_savefig.TestMlabSavefigUnitTest)
Test if savefig works with given size and magnification
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_mlab_savefig.py", line 124, in test_savefig_with_size_and_magnification
    self.check_image_no_black_pixel(self.filename)
  File "test_mlab_savefig.py", line 72, in check_image_no_black_pixel
    self.fail(message)
AssertionError: The image has black spots

======================================================================
FAIL: test_savefig_with_size_and_magnification_offscreen (test_mlab_savefig.TestMlabSavefigUnitTest)
Test savefig with given size, mag, normal Engine and offscreen
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_mlab_savefig.py", line 183, in test_savefig_with_size_and_magnification_offscreen
    self.check_image_size(self.filename, size=(262, 434))
  File "test_mlab_savefig.py", line 82, in check_image_size
    self.assertEqual(image.shape[:2][::-1], size)
AssertionError: Tuples differ: (180, 78) != (262, 434)

First differing element 0:
180
262

- (180, 78)
+ (262, 434)

======================================================================
FAIL: test_savefig_with_size_offscreen (test_mlab_savefig.TestMlabSavefigUnitTest)
Test savefig with given size, normal Engine and offscreen
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_mlab_savefig.py", line 162, in test_savefig_with_size_offscreen
    self.check_image_size(self.filename, size=(131, 217))
  File "test_mlab_savefig.py", line 82, in check_image_size
    self.assertEqual(image.shape[:2][::-1], size)
AssertionError: Tuples differ: (90, 39) != (131, 217)

First differing element 0:
90
131

- (90, 39)
+ (131, 217)

----------------------------------------------------------------------
Ran 7 tests in 2.764s

FAILED (failures=4)
```