### PR TITLE
Typo in filename for a test

### DIFF
--- a/mayavi/tests/test_vtk_file_reader.py
+++ b/mayavi/tests/test_vtk_file_reader.py
@@ -52,7 +52,7 @@ class TestVTKFileReader(unittest.TestCase):
     @unittest.skipIf(vtk_major_version == 5 and vtk_minor_version < 10,
                     "This test is probably broken in VTK < 5.10")
     def test_unstructured_grid_file(self):
-        self.src.initialize(get_example_data('UGridEx.vtk'))
+        self.src.initialize(get_example_data('uGridEx.vtk'))
         self.check(27, 12)
 
     def test_field_file(self):


### PR DESCRIPTION
After this Travis CI tests with VTK 6.3.0 should be green (#345)

Update: except for a tvtk error.
