### PR TITLE
Unicode trait handling for those vtk methods returning unicode data

### DIFF
--- a/tvtk/tests/test_tvtk.py
+++ b/tvtk/tests/test_tvtk.py
@@ -43,7 +43,8 @@ To generate tvtk_classes.zip you must do the following::
 # Only used for testing.
 from tvtk.tvtk_classes import tvtk_helper
 
-if sys.version_info[0] > 2:
+PY_VER = sys.version_info[0]
+if PY_VER > 2:
     long = int
 
 
@@ -678,6 +679,13 @@ class TestTVTKModule(unittest.TestCase):
         output = output.decode('ascii')
         self.assertFalse('QtCore' in output)
         self.assertFalse('wx' in output)
+
+    @unittest.skipIf(PY_VER > 2, "Irrelevant for python 3")
+    def test_unicode_traits(self):
+        reader = tvtk.DelimitedTextReader()
+        self.assertIsInstance(reader.unicode_record_delimiters, unicode)
+        self.assertIsInstance(reader.unicode_string_delimiters, unicode)
+        self.assertIsInstance(reader.unicode_field_delimiters, unicode)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tvtk/tests/test_wrapper_gen.py
+++ b/tvtk/tests/test_wrapper_gen.py
@@ -8,6 +8,7 @@ wrapper_gen directly.
 # Copyright (c) 2004, Prabhu Ramachandran,  Enthought, Inc.
 # License: BSD Style.
 
+import sys
 import unittest
 import vtk
 
@@ -60,9 +61,10 @@ class TestWrapperGenerator(unittest.TestCase):
 
     def test_unicode_return_value(self):
         wg = self.wg
+
         meth = vtk.vtkDelimitedTextReader.GetUnicodeRecordDelimiters
         sig = wg.parser.get_method_signature(meth)
-        print sig
+        self.assertEqual(sig[0][0][0], 'unicode')
 
 if __name__ == "__main__":
     unittest.main()

--- a/tvtk/tests/test_wrapper_gen.py
+++ b/tvtk/tests/test_wrapper_gen.py
@@ -58,5 +58,11 @@ class TestWrapperGenerator(unittest.TestCase):
                (['vtkStructuredPoints'], ['vtkFooClass'])]
         self.assertEqual(('vtk', 'vtk'), wg._find_sig_type(sig))
 
+    def test_unicode_return_value(self):
+        wg = self.wg
+        meths = [vtk.vtkDelimitedTextReader.GetUnicodeRecordDelimiters]
+        sig = wg.parser.get_method_signature(meth)
+        self.assertEqual( ('', None), wg._find_sig_type(sig))
+
 if __name__ == "__main__":
     unittest.main()

--- a/tvtk/tests/test_wrapper_gen.py
+++ b/tvtk/tests/test_wrapper_gen.py
@@ -60,9 +60,9 @@ class TestWrapperGenerator(unittest.TestCase):
 
     def test_unicode_return_value(self):
         wg = self.wg
-        meths = [vtk.vtkDelimitedTextReader.GetUnicodeRecordDelimiters]
+        meth = vtk.vtkDelimitedTextReader.GetUnicodeRecordDelimiters
         sig = wg.parser.get_method_signature(meth)
-        self.assertEqual( ('', None), wg._find_sig_type(sig))
+        print sig
 
 if __name__ == "__main__":
     unittest.main()

--- a/tvtk/tests/test_wrapper_gen.py
+++ b/tvtk/tests/test_wrapper_gen.py
@@ -8,7 +8,6 @@ wrapper_gen directly.
 # Copyright (c) 2004, Prabhu Ramachandran,  Enthought, Inc.
 # License: BSD Style.
 
-import sys
 import unittest
 import vtk
 

--- a/tvtk/vtk_parser.py
+++ b/tvtk/vtk_parser.py
@@ -18,9 +18,6 @@ from . import vtk_module as vtk
 from .common import is_version_62
 
 
-PY_VER = sys.version_info[0]
-
-
 class VTKMethodParser:
     """This class provides useful methods for parsing methods of a VTK
     class or instance.
@@ -658,12 +655,6 @@ class VTKMethodParser:
                             default = getattr(obj, 'Get%s'%key)()
                         except TypeError:
                             default = None
-
-                        # We want to guarantee, for python 2, that we handle
-                        # pure ascii strings. Some routines may return a unicode
-                        # object instead, so we encode it ascii.
-                        if PY_VER < 3:
-                            default = default.encode('ascii')
 
                     if value:
                         low = getattr(obj, 'Get%sMinValue'%key)()

--- a/tvtk/vtk_parser.py
+++ b/tvtk/vtk_parser.py
@@ -17,6 +17,10 @@ from . import class_tree
 from . import vtk_module as vtk
 from .common import is_version_62
 
+
+PY_VER = sys.version_info[0]
+
+
 class VTKMethodParser:
     """This class provides useful methods for parsing methods of a VTK
     class or instance.
@@ -654,6 +658,13 @@ class VTKMethodParser:
                             default = getattr(obj, 'Get%s'%key)()
                         except TypeError:
                             default = None
+
+                        # We want to guarantee, for python 2, that we handle
+                        # pure ascii strings. Some routines may return a unicode
+                        # object instead, so we encode it ascii.
+                        if PY_VER < 3:
+                            default = default.encode('ascii')
+
                     if value:
                         low = getattr(obj, 'Get%sMinValue'%key)()
                         high = getattr(obj, 'Get%sMaxValue'%key)()

--- a/tvtk/wrapper_gen.py
+++ b/tvtk/wrapper_gen.py
@@ -599,16 +599,16 @@ class WrapperGenerator:
                     if default == '\x00':
                         default = ''
 
-                    t_def = 'traits.String({0!r}, '.format(default)
-                    t_def += 'enter_set=True, auto_set=False)'
+                    t_def = ('traits.String({0!r}, '
+                             'enter_set=True, auto_set=False)'.format(default))
                     self._write_trait(out, name, t_def, vtk_set_meth, mapped=False)
 
                 elif PY_VER < 3 and typ is unicode:
                     if default == u'\x00':
                         default = ''
 
-                    t_def = 'traits.Unicode({0!r}, '.format(default)
-                    t_def += 'enter_set=True, auto_set=False)'
+                    t_def = ('traits.Unicode({0!r}, '
+                             'enter_set=True, auto_set=False)'.format(default))
                     self._write_trait(out, name, t_def, vtk_set_meth, mapped=False)
 
                 elif typ in (tuple,):

--- a/tvtk/wrapper_gen.py
+++ b/tvtk/wrapper_gen.py
@@ -605,7 +605,7 @@ class WrapperGenerator:
 
                 elif PY_VER < 3 and typ is unicode:
                     if default == u'\x00':
-                        default = ''
+                        default = u''
 
                     t_def = ('traits.Unicode({0!r}, '
                              'enter_set=True, auto_set=False)'.format(default))

--- a/tvtk/wrapper_gen.py
+++ b/tvtk/wrapper_gen.py
@@ -620,6 +620,22 @@ class WrapperGenerator:
                     t_def += 'enter_set=True, auto_set=False)'
                     self._write_trait(out, name, t_def, vtk_set_meth,
                                       mapped=False)
+                elif PY_VER < 3 and typ is unicode:
+                    default = default.encode("unicode_escape")
+                    if '\n' in default or '\r' in default:
+                        default = clean_special_chars(default)
+
+                    if default == '\x00':
+                        t_def = 'traits.Unicode(u"", '
+                    elif default == '"':
+                        t_def = "traits.Unicode(u'%(default)s', " % locals()
+                    elif default == "'":
+                        t_def = '''traits.Unicode(u"%(default)s", ''' % locals()
+                    else:
+                        t_def = 'traits.String(u"%(default)s", ' % locals()
+                    t_def += 'enter_set=True, auto_set=False)'
+                    self._write_trait(out, name, t_def, vtk_set_meth,
+                                      mapped=False)
                 elif typ in (tuple,):
                     if (name.find('color') > -1 or \
                         name.find('bond_color') > -1 or \

--- a/tvtk/wrapper_gen.py
+++ b/tvtk/wrapper_gen.py
@@ -632,7 +632,7 @@ class WrapperGenerator:
                     elif default == "'":
                         t_def = '''traits.Unicode(u"%(default)s", ''' % locals()
                     else:
-                        t_def = 'traits.String(u"%(default)s", ' % locals()
+                        t_def = 'traits.Unicode(u"%(default)s", ' % locals()
                     t_def += 'enter_set=True, auto_set=False)'
                     self._write_trait(out, name, t_def, vtk_set_meth,
                                       mapped=False)

--- a/tvtk/wrapper_gen.py
+++ b/tvtk/wrapper_gen.py
@@ -26,15 +26,6 @@ from . import special_gen
 PY_VER = sys.version_info[0]
 
 
-def clean_special_chars(s):
-    """Given a string with a '\n' or '\r' it replaces it with a suitably
-    escaped string.
-    """
-    s1 = s.replace('\n', '\\n')
-    s2 = s1.replace('\r', '\\r')
-    return s2
-
-
 ######################################################################
 # `WrapperGenerator` class.
 ######################################################################
@@ -605,37 +596,21 @@ class WrapperGenerator:
                     self._write_trait(out, name, t_def, vtk_set_meth,
                                       mapped=False)
                 elif typ is str:
-                    if '\n' in default or '\r' in default:
-                        default = clean_special_chars(default)
-
                     if default == '\x00':
                         default = ''
-                        t_def = 'traits.String("%(default)s", '%locals()
-                    elif default == '"':
-                        t_def = "traits.String('%(default)s', "%locals()
-                    elif default == "'":
-                        t_def = '''traits.String("%(default)s", '''%locals()
-                    else:
-                        t_def = 'traits.String(r"%(default)s", '%locals()
-                    t_def += 'enter_set=True, auto_set=False)'
-                    self._write_trait(out, name, t_def, vtk_set_meth,
-                                      mapped=False)
-                elif PY_VER < 3 and typ is unicode:
-                    default = default.encode("unicode_escape")
-                    if '\n' in default or '\r' in default:
-                        default = clean_special_chars(default)
 
-                    if default == '\x00':
-                        t_def = 'traits.Unicode(u"", '
-                    elif default == '"':
-                        t_def = "traits.Unicode(u'%(default)s', " % locals()
-                    elif default == "'":
-                        t_def = '''traits.Unicode(u"%(default)s", ''' % locals()
-                    else:
-                        t_def = 'traits.Unicode(u"%(default)s", ' % locals()
+                    t_def = 'traits.String({0!r}, '.format(default)
                     t_def += 'enter_set=True, auto_set=False)'
-                    self._write_trait(out, name, t_def, vtk_set_meth,
-                                      mapped=False)
+                    self._write_trait(out, name, t_def, vtk_set_meth, mapped=False)
+
+                elif PY_VER < 3 and typ is unicode:
+                    if default == u'\x00':
+                        default = ''
+
+                    t_def = 'traits.Unicode({0!r}, '.format(default)
+                    t_def += 'enter_set=True, auto_set=False)'
+                    self._write_trait(out, name, t_def, vtk_set_meth, mapped=False)
+
                 elif typ in (tuple,):
                     if (name.find('color') > -1 or \
                         name.find('bond_color') > -1 or \


### PR DESCRIPTION
The generator code did not handle unicode, but some vtk routines do return them. Although never able to reproduce it, issue #354 shows a situation where it does matter.

I am unsure about potential side effects of this change on client code, but I am surprised it worked until now, and I expect the method was simply not generated, or it was but it returned an empty string.