### PR TITLE
Refactor get_output to a common routine

### DIFF
--- a/integrationtests/mayavi/common.py
+++ b/integrationtests/mayavi/common.py
@@ -165,6 +165,7 @@ class MemoryAssistant(object):
 # Image comparison utility functions.
 ######################################################################
 
+
 # Much of this code is translated from `vtk.test.Testing`.
 def _print_image_error(img_err, err_index, img_base):
     """Prints out image related error information."""
@@ -233,6 +234,7 @@ def _handle_failed_image(idiff, src_img, pngr, img_fname):
     jpegw.set(file_name=f_base + ".small.jpg")
     configure_input(jpegw, shrink)
     jpegw.write()
+
 
 def _set_scale(r1, r2):
     """Given two instances of tvtk.ImageResample, this sets the scale
@@ -431,6 +433,7 @@ def compare_image(scene, img_path):
         ren.reset_camera()
         s.render()
 
+
 def is_running_with_nose():
     """Returns True if we are being run via nosetests.
 
@@ -442,6 +445,7 @@ def is_running_with_nose():
     if argv0.endswith('nosetests') or argv0.endswith(nose_core):
         return True
     return False
+
 
 ###########################################################################
 # `TestCase` class.
@@ -532,7 +536,6 @@ class TestCase(Mayavi):
             else:
                 raise type(value)
 
-
     def run(self):
         """This starts everything up and runs the test.  Call main to
         run the test."""
@@ -615,11 +618,6 @@ class TestCase(Mayavi):
     ######################################################################
     # `TestCase` interface.
     ######################################################################
-    def _get_output(self, obj):
-        if obj.is_a('vtkDataSet'):
-            return obj
-        else:
-            return obj.output
 
     def do(self):
         """Override this to do whatever you want to do as your test
@@ -709,6 +707,7 @@ def fixpath(filename):
     """
     return os.path.join(os.path.dirname(__file__), filename)
 
+
 def get_example_data(fname):
     """Given a relative path to data inside the examples directory,
     obtains the full path to the file.
@@ -716,6 +715,7 @@ def get_example_data(fname):
     p = os.path.join(os.pardir, os.pardir,
                      'examples', 'mayavi', 'data', fname)
     return os.path.abspath(fixpath(p))
+
 
 def test(function):
     """A decorator to make a simple mayavi2 script function into a

--- a/integrationtests/mayavi/test_generic_module.py
+++ b/integrationtests/mayavi/test_generic_module.py
@@ -10,6 +10,7 @@ from io import BytesIO
 import copy
 
 # Local imports.
+from mayavi.core.common import get_output
 from common import TestCase, get_example_data
 
 
@@ -70,23 +71,23 @@ class TestGenericModule(TestCase):
             ctr.enabled = True
             assert ctr.outputs[0] is c.outputs[0]
             assert ctr.outputs[0] is normals.outputs[0]
-            n_output = self._get_output(normals.outputs[0])
+            n_output = get_output(normals.outputs[0])
             rng = n_output.point_data.scalars.range
             assert (rng[1] - rng[0]) < 1e-4
             # Turn on auto-contours
             c.auto_contours = True
             # Increase number of contours and the range should change.
             c.number_of_contours = 10
-            n_output = self._get_output(normals.outputs[0])
+            n_output = get_output(normals.outputs[0])
             assert len(n_output.points) != 0
             rng = n_output.point_data.scalars.range
             assert rng[0] < rng[1]
             # Check if pipeline_changed is correctly propagated.
-            old = self._get_output(normals.outputs[0])
+            old = get_output(normals.outputs[0])
             assert a.mapper.scalar_mode == 'default'
             c.filled_contours = True
-            n_output = self._get_output(normals.outputs[0])
-            c_output = self._get_output(c.outputs[0])
+            n_output = get_output(normals.outputs[0])
+            c_output = get_output(c.outputs[0])
             assert n_output != old
             assert n_output is c_output
             # Check if the actor responds correctly to the

--- a/integrationtests/mayavi/test_set_active_attribute.py
+++ b/integrationtests/mayavi/test_set_active_attribute.py
@@ -8,6 +8,7 @@ from io import BytesIO
 import copy
 
 # Local imports.
+from mayavi.core.common import get_output
 from common import TestCase, get_example_data
 
 
@@ -21,13 +22,13 @@ class TestSetActiveAttribute(TestCase):
         src = scene.children[0]
         assert src.point_scalars_name == 'u'
         c = src.children[1]
-        sc = self._get_output(c.outputs[0]).point_data.scalars
+        sc = get_output(c.outputs[0]).point_data.scalars
         assert sc.name == 'u'
         # It is an iso-contour!
         assert sc.range[0] == sc.range[1]
         aa = c.children[0].children[0]
         assert aa.point_scalars_name == 't'
-        sc = self._get_output(aa.outputs[0]).point_data.scalars
+        sc = get_output(aa.outputs[0]).point_data.scalars
         assert sc.name == 't'
         assert abs(sc.range[0] - 308) < 1.0
         assert abs(sc.range[1] - 631) < 1.0

--- a/mayavi/core/common.py
+++ b/mayavi/core/common.py
@@ -26,10 +26,13 @@ logger = logging.getLogger(__name__)
 ######################################################################
 # Utility functions.
 ######################################################################
+
+
 def debug(msg):
     """Handle a debug message.
     """
     logger.debug(msg)
+
 
 def warning(msg, parent=None):
     """Handle a warning message.
@@ -38,12 +41,14 @@ def warning(msg, parent=None):
     if pyface is not None:
         pyface.warning(parent, msg)
 
+
 def error(msg, parent=None):
     """Handle an error message.
     """
     logger.error(msg)
     if pyface is not None:
         pyface.error(parent, msg)
+
 
 def exception(msg='Exception', parent=None):
     """This function handles any exception derived from Exception and
@@ -65,6 +70,7 @@ def exception(msg='Exception', parent=None):
     finally:
         type = value = tb = None # clean up
 
+
 def process_ui_events():
     """Process GUI events.
 
@@ -73,6 +79,7 @@ def process_ui_events():
     """
     if pyface is not None:
         pyface.GUI.process_events()
+
 
 def get_engine(obj):
     """Try and return the engine given an object in the mayavi
@@ -86,6 +93,15 @@ def get_engine(obj):
         else:
             obj = obj.parent
     return None
+
+
+def get_output(obj):
+    """Given an object, extracts the output object, hiding differences
+    between old and new pipeline."""
+    if obj.is_a('vtkDataSet'):
+        return obj
+    else:
+        return obj.output
 
 
 def get_object_path(object, parent, path='engine'):

--- a/mayavi/core/module_manager.py
+++ b/mayavi/core/module_manager.py
@@ -16,6 +16,7 @@ from apptools.persistence.state_pickler import set_state
 # Local imports
 from mayavi.core.base import Base
 from mayavi.core.module import Module
+from mayavi.core.common import get_output
 from mayavi.core.lut_manager import LUTManager
 from mayavi.core.common import handle_children_state, exception
 from mayavi.core.pipeline_info import PipelineInfo
@@ -291,7 +292,7 @@ class ModuleManager(Base):
     def _setup_scalar_data(self):
         """Computes the scalar range and an appropriate name for the
         lookup table."""
-        input = self._get_output(self.source.outputs[0])
+        input = get_output(self.source.outputs[0])
         ps = input.point_data.scalars
         cs = input.cell_data.scalars
 
@@ -314,7 +315,7 @@ class ModuleManager(Base):
         data_attr.config_lut(self.scalar_lut_manager)
 
     def _setup_vector_data(self):
-        input = self._get_output(self.source.outputs[0])
+        input = get_output(self.source.outputs[0])
         pv = input.point_data.vectors
         cv = input.cell_data.vectors
 
@@ -348,8 +349,3 @@ class ModuleManager(Base):
         from mayavi.core.traits_menu import ModuleMenuHelper
         return ModuleMenuHelper(object=self)
 
-    def _get_output(self, obj):
-        if obj.is_a('vtkDataSet'):
-            return obj
-        else:
-            return obj.output

--- a/mayavi/tests/test_mlab_integration.py
+++ b/mayavi/tests/test_mlab_integration.py
@@ -41,12 +41,6 @@ class TestMlabNullEngine(unittest.TestCase):
             registry.unregister_engine(current_engine)
             raise AssertionError("The NullEngine has been overridden")
 
-    def _get_output(self, obj):
-        if obj.is_a('vtkDataSet'):
-            return obj
-        else:
-            return obj.output
-
 
 ################################################################################
 # class `TestMlabNullEngineMisc`

--- a/mayavi/tests/test_set_active_attribute.py
+++ b/mayavi/tests/test_set_active_attribute.py
@@ -11,6 +11,7 @@ import unittest
 
 # Enthought library imports
 from mayavi.core.null_engine import NullEngine
+from mayavi.core.common import get_output
 from mayavi.sources.api import VTKXMLFileReader
 from mayavi.filters.contour import Contour
 from mayavi.filters.api import PolyDataNormals
@@ -19,6 +20,7 @@ from mayavi.modules.api import Surface, Outline
 
 # Local imports.
 from mayavi.tests.common import get_example_data
+
 
 class TestSetActiveAttribute(unittest.TestCase):
 
@@ -54,30 +56,23 @@ class TestSetActiveAttribute(unittest.TestCase):
         self.e.stop()
         return
 
-    def _get_output(self, obj):
-        if obj.is_a('vtkDataSet'):
-            return obj
-        else:
-            return obj.output
-
     def check(self):
         """Do the actual testing"""
         scene = self.scene
         src = scene.children[0]
         self.assertEqual(src.point_scalars_name,'temperature')
         c = src.children[1]
-        sc = self._get_output(c.outputs[0]).point_data.scalars
+        sc = get_output(c.outputs[0]).point_data.scalars
         self.assertEqual(sc.name,'temperature')
         # It is an iso-contour!
         self.assertEqual(sc.range[0],sc.range[1])
         aa = c.children[0].children[0]
         self.assertEqual(aa.point_scalars_name,'pressure')
-        sc = self._get_output(aa.outputs[0]).point_data.scalars
+        sc = get_output(aa.outputs[0]).point_data.scalars
         self.assertEqual(sc.name, 'pressure')
         self.assertEqual((abs(sc.range[0] - 70) < 1.0),True)
         self.assertEqual((abs(sc.range[1] - 70) < 1.0),True)
         s = aa.children[0].children[0]
-
 
     def test_set_active_attribute(self):
         "Test if the test fixture works"
@@ -86,7 +81,6 @@ class TestSetActiveAttribute(unittest.TestCase):
 
         #from mayavi.tools.show import show
         #show()
-
 
     def test_save_and_restore(self):
         """Test if saving a visualization and restoring it works."""
@@ -108,7 +102,6 @@ class TestSetActiveAttribute(unittest.TestCase):
         self.scene = engine.current_scene
 
         self.check()
-
 
     def test_deepcopied(self):
         """Test if the MayaVi2 visualization can be deep-copied."""


### PR DESCRIPTION
Refactored member _get_output to a simple subroutine. There's no need of having it as a member.
Solves issue #312 