### PR TITLE
Fix tvtk attribute with undefined _void value

### DIFF
--- a/tvtk/wrapper_gen.py
+++ b/tvtk/wrapper_gen.py
@@ -71,7 +71,7 @@ def patch_position_default(parser, vtk_set_meth, default):
             default = (0,)*ndim
             print("We are able to patch for it with", default)
             break
-        if "int" in arg_format:
+        if "float" in arg_format:
             default = (0.,)*ndim
             print("We are able to patch for it with", default)
             break

--- a/tvtk/wrapper_gen.py
+++ b/tvtk/wrapper_gen.py
@@ -1279,6 +1279,10 @@ class WrapperGenerator:
           must be handled specially.  In this case make sure that the
           vtk_set_meth points to the 'Get' method.
 
+        - patch_with_either : `string`
+
+          If given, t_def and patch_with_either will be wrapped by
+          traits.Either
         """
         changed = '_%s_changed'%t_name
         vtk_m_name = vtk_set_meth.__name__

--- a/tvtk/wrapper_gen.py
+++ b/tvtk/wrapper_gen.py
@@ -68,16 +68,11 @@ def patch_position_default(parser, vtk_set_meth, default):
 
     for arg_format in arg_formats:
         if "int" in arg_format:
-            default = (0,)*ndim
-            print("We are able to patch for it with", default)
-            break
+            return (0,)*ndim
         if "float" in arg_format:
-            default = (0.,)*ndim
-            print("We are able to patch for it with", default)
-            break
+            return (0.,)*ndim
     else:
-        print("We could not patch for it")
-    return default
+        return default
 
 
 def clean_special_chars(s):
@@ -644,6 +639,8 @@ class WrapperGenerator:
                     default = patch_position_default(parser, vtk_set_meth, default)
 
                     if isinstance(default, tuple):
+                        print("We are able to patch for it with", default)
+
                         # We patched the default value with some tuple
                         # otherwise the `rng is None` clause carry on going
                         shape = (len(default),)
@@ -666,6 +663,8 @@ class WrapperGenerator:
                         self._write_trait(out, name, t_def % locals(), vtk_set_meth,
                                           mapped=False)
                         continue
+                    else:
+                        print("We could not patch for it")
 
                 typ = type(default)
                 if PY_VER < 3:


### PR DESCRIPTION
Fix #357 

I also realise that for VTK 6.x and VTK 7, a number of VTK classes do not initialise `*Position` attributes properly.  This would fix for them too.

Will lead to conflict with #358 upon merge, unfortunately