### PR TITLE
Fix/368 integrationtests fail with exit 1

### DIFF
--- a/integrationtests/mayavi/test_mlab_savefig.py
+++ b/integrationtests/mayavi/test_mlab_savefig.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import sys
 import unittest
 import tempfile
 
@@ -86,7 +87,11 @@ class TestMlabSavefig(TestCase):
     def do(self):
         suite = unittest.TestLoader().loadTestsFromTestCase(
             TestMlabSavefigUnitTest)
-        unittest.TextTestRunner().run(suite)
+
+        result = unittest.TextTestRunner().run(suite)
+
+        if result.errors or result.failures:
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/integrationtests/mayavi/test_text3d.py
+++ b/integrationtests/mayavi/test_text3d.py
@@ -3,6 +3,7 @@
 """
 import os
 import shutil
+import sys
 import unittest
 import tempfile
 
@@ -63,7 +64,11 @@ class TestText3D(TestCase):
     def do(self):
         suite = unittest.TestLoader().loadTestsFromTestCase(
             TestText3DUnitTest)
-        unittest.TextTestRunner().run(suite)
+
+        result = unittest.TextTestRunner().run(suite)
+
+        if result.errors or result.failures:
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/integrationtests/mayavi/test_texture.py
+++ b/integrationtests/mayavi/test_texture.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import sys
 import unittest
 import tempfile
 
@@ -126,7 +127,11 @@ class TestTexture(TestCase):
     def do(self):
         suite = unittest.TestLoader().loadTestsFromTestCase(
             TestTextureUnitTest)
-        unittest.TextTestRunner().run(suite)
+
+        result = unittest.TextTestRunner().run(suite)
+
+        if result.errors or result.failures:
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/integrationtests/mayavi/test_texture.py
+++ b/integrationtests/mayavi/test_texture.py
@@ -86,7 +86,7 @@ class TestTextureUnitTest(unittest.TestCase):
         mlab.savefig(self.filename, size=(400, 300))
 
         # Check the saved image (if texture fails, std ~ 90)
-        self.check_image_std(target_std=200.)
+        self.check_image_std(target_std=150.)
 
     def test_text3d_cylinder(self):
         """ Test texture on mlab.points3d (cylinder) """
@@ -105,7 +105,7 @@ class TestTextureUnitTest(unittest.TestCase):
         mlab.savefig(self.filename, size=(400, 300))
 
         # Check the saved image (if texture fails, std ~ 90)
-        self.check_image_std(target_std=200.)
+        self.check_image_std(target_std=150.)
 
     def check_image_std(self, target_std):
         # Check that the pixels in the image vary greatly as

--- a/integrationtests/mayavi/test_tools_camera.py
+++ b/integrationtests/mayavi/test_tools_camera.py
@@ -1,5 +1,6 @@
 """Tests for the tools.camera
 """
+import sys
 import unittest
 from contextlib import contextmanager
 
@@ -98,8 +99,11 @@ class TestCamera(TestCase):
 
     def do(self):
         suite = unittest.TestLoader().loadTestsFromTestCase(TestCameraUnitTest)
-        for test in suite:
-            test.run()
+
+        result = unittest.TextTestRunner().run(suite)
+
+        if result.errors or result.failures:
+            sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix #368 so that failed tests are properly reported.

Fortunately, only one test from test_texture whose failure was not captured and I believe it was because I set the check criteria (a standard deviation of pixels) just a bit too high (200 versus ~180 for 28000 sample points).  However I could not reproduce the small difference in the standard deviation on my local machine (OSX or Ubuntu 12) and was not able to understand it.
