### PR TITLE
Fix for unexpected test code

### DIFF
--- a/mayavi/tests/test_mlab_integration.py
+++ b/mayavi/tests/test_mlab_integration.py
@@ -233,7 +233,7 @@ class TestMlabPipeline(TestMlabNullEngine):
         if self.less_than_or_equal_to_vtk_5_10:
             super(TestMlabPipeline, self).tearDown()
         else:
-            for engine in registry.engines.keys():
+            for engine in list(registry.engines.keys()):
                 registry.unregister_engine(engine)
 
     def test_probe_data(self):

--- a/mayavi/tests/test_mlab_integration.py
+++ b/mayavi/tests/test_mlab_integration.py
@@ -211,18 +211,18 @@ class TestMlabNullEngineMisc(TestMlabNullEngine):
 ################################################################################
 class TestMlabPipeline(TestMlabNullEngine):
     """ Test the pipeline functions.
-        For vtk versions greater than 5.6 (5.10.1 onwards), widgets need
+        For vtk versions greater than 5.10.1, widgets need
         a render window interactor to be set, otherwise an error is raised.
         As such this test checks for the current VTK version and setups a real
-        engine for vtk > 5.6 and null engine otherwise.
+        engine for vtk > 5.10 and null engine otherwise.
     """
 
     def setUp(self):
         ver = tvtk.Version()
-        self.less_than_vtk_5_6 = True
+        self.less_than_or_equal_to_vtk_5_10 = True
         if ver.vtk_major_version >= 5 and ver.vtk_minor_version >= 10:
-            self.less_than_vtk_5_6 = False
-        if self.less_than_vtk_5_6:
+            self.less_than_or_equal_to_vtk_5_10 = False
+        if self.less_than_or_equal_to_vtk_5_10:
             super(TestMlabPipeline, self).setUp()
         else:
             e = Engine()
@@ -230,7 +230,7 @@ class TestMlabPipeline(TestMlabNullEngine):
             mlab.set_engine(e)
 
     def tearDown(self):
-        if self.less_than_vtk_5_6:
+        if self.less_than_or_equal_to_vtk_5_10:
             super(TestMlabPipeline, self).tearDown()
         else:
             for engine in registry.engines.keys():

--- a/mayavi/tests/test_mlab_integration.py
+++ b/mayavi/tests/test_mlab_integration.py
@@ -211,7 +211,7 @@ class TestMlabNullEngineMisc(TestMlabNullEngine):
 ################################################################################
 class TestMlabPipeline(TestMlabNullEngine):
     """ Test the pipeline functions.
-        For vtk versions greater than 5.10.1, widgets need
+        For vtk versions greater than 5.10, widgets need
         a render window interactor to be set, otherwise an error is raised.
         As such this test checks for the current VTK version and setups a real
         engine for vtk > 5.10 and null engine otherwise.

--- a/mayavi/tests/test_mlab_integration.py
+++ b/mayavi/tests/test_mlab_integration.py
@@ -220,7 +220,7 @@ class TestMlabPipeline(TestMlabNullEngine):
     def setUp(self):
         ver = tvtk.Version()
         self.less_than_or_equal_to_vtk_5_10 = True
-        if ver.vtk_major_version >= 5 and ver.vtk_minor_version >= 10:
+        if ver.vtk_major_version >= 5 and ver.vtk_minor_version > 10:
             self.less_than_or_equal_to_vtk_5_10 = False
         if self.less_than_or_equal_to_vtk_5_10:
             super(TestMlabPipeline, self).setUp()

--- a/mayavi/tests/test_mlab_integration.py
+++ b/mayavi/tests/test_mlab_integration.py
@@ -231,9 +231,9 @@ class TestMlabPipeline(TestMlabNullEngine):
 
     def tearDown(self):
         if self.less_than_vtk_5_6:
-            super(TestMlabPipeline, self).setUp()
+            super(TestMlabPipeline, self).tearDown()
         else:
-            for engine in registry.engines:
+            for engine in registry.engines[:]:
                 registry.unregister_engine(engine)
 
     def test_probe_data(self):

--- a/mayavi/tests/test_mlab_integration.py
+++ b/mayavi/tests/test_mlab_integration.py
@@ -233,7 +233,7 @@ class TestMlabPipeline(TestMlabNullEngine):
         if self.less_than_vtk_5_6:
             super(TestMlabPipeline, self).tearDown()
         else:
-            for engine in registry.engines[:]:
+            for engine in registry.engines.keys():
                 registry.unregister_engine(engine)
 
     def test_probe_data(self):


### PR DESCRIPTION
Fix for a few strange things. The dictionary is changed in place, so it must be copied.
Additionally, it's probably supposed to call tearDown, not setUp()