### PR TITLE
Update auto-generated html for changelog

### DIFF
--- a/mayavi/auto/changes.html
+++ b/mayavi/auto/changes.html
@@ -108,7 +108,7 @@ new viridis colormap.</li>
 <div class="section" id="fixes">
 <h2>Fixes<a class="headerlink" href="#fixes" title="Permalink to this headline">¶</a></h2>
 <dl class="docutils">
-<dt>30 Jul 2016 <a class="reference external" href="https://github.com/enthought/mayavi/pull/416">#416</a> (PR)</dt>
+<dt>01 Aug 2016 <a class="reference external" href="https://github.com/enthought/mayavi/pull/416">#416</a> (PR)</dt>
 <dd><ul class="first last simple">
 <li>Fix several bugs, <a class="reference external" href="https://github.com/enthought/mayavi/issues/397">#397</a>
 where PDF files were not saved properly. Fix issues with <code class="docutils literal"><span class="pre">tvtk.visual</span></code>
@@ -317,6 +317,10 @@ segfault when savefig is called multiple times.</li>
 </ul>
 </dd>
 </dl>
+<p>Contributions from itziakos, stefanoborini and kitchoi are funded and supported
+by the <a class="reference external" href="http://www.simphony-project.eu/">SimPhoNy</a> project, an EU-project
+funded by the 7th Framework Programme (Project number 604005) under the
+call NMP.2013.1.4-1.</p>
 </div>
 </div>
 <div class="section" id="mayavi-4-4-4">


### PR DESCRIPTION
Changelog was automatically generated from a commit not including changes from #419
Only modified the gh-pages here.