### PR TITLE
Fix for setuptools 28.0

### DIFF
--- a/tvtk/setup.py
+++ b/tvtk/setup.py
@@ -19,12 +19,17 @@ def configuration(parent_package=None, top_path=None):
 
     config.add_subpackage('custom')
     config.add_subpackage('pipeline')
+    config.add_subpackage('pyface')
+    config.add_subpackage('pyface.*')
+    config.add_subpackage('pyface.*.*')
+
     config.add_data_dir('pipeline/images')
     config.add_data_dir('pyface/images')
     config.add_data_dir('tools/images')
 
     config.add_subpackage('plugins')
     config.add_subpackage('plugins.*')
+    config.add_subpackage('plugins.*.*')
 
     config.add_subpackage('tools')
     config.add_subpackage('util')

--- a/tvtk/setup.py
+++ b/tvtk/setup.py
@@ -22,6 +22,7 @@ def configuration(parent_package=None, top_path=None):
     config.add_subpackage('pyface')
     config.add_subpackage('pyface.*')
     config.add_subpackage('pyface.*.*')
+    config.add_subpackage('view')
 
     config.add_data_dir('pipeline/images')
     config.add_data_dir('pyface/images')


### PR DESCRIPTION
Fixes #443.

With setuptools 28.0, subpackages are not added if found within an exclusion prefix.
We have to manually indicate which packages are available in the tvtk setup.py

The code is neutral for setuptools <28.0