### PR TITLE
Update notebook.py

### DIFF
--- a/mayavi/tools/notebook.py
+++ b/mayavi/tools/notebook.py
@@ -86,10 +86,7 @@ def scene_to_x3d(scene):
     ex.write()
     # Switch back
     scene.light_manager.light_mode = lm
-    if _local:
-        url_base = "/nbextensions/mayavi/x3d"
-    else:
-        url_base = "http://www.x3dom.org/download"
+    url_base = "https://www.x3dom.org/download/1.7.2/"
     x3d_elem = _fix_x3d_header(ex.output_string)
     html = '''
     %s


### PR DESCRIPTION
Always download x3dom from the website - otherwise the extension is not working with Jupyterhub. In addition the link has to be updated to https://www.x3dom.org/download/1.7.2/ instead of https://www.x3dom.org/download/ .