### PR TITLE
Remove focus-stealing code

### DIFF
--- a/tvtk/pyface/ui/qt4/QVTKRenderWindowInteractor.py
+++ b/tvtk/pyface/ui/qt4/QVTKRenderWindowInteractor.py
@@ -154,7 +154,6 @@ class QVTKRenderWindowInteractor(QWidget):
         self._ActiveButton = Qt.NoButton
 
         # private attributes
-        self.__oldFocus = None
         self.__saveX = 0
         self.__saveY = 0
         self.__saveModifiers = Qt.NoModifier

--- a/tvtk/pyface/ui/qt4/QVTKRenderWindowInteractor.py
+++ b/tvtk/pyface/ui/qt4/QVTKRenderWindowInteractor.py
@@ -352,20 +352,12 @@ class QVTKRenderWindowInteractor(QWidget):
         return ctrl, shift
 
     def enterEvent(self, ev):
-        if not self.hasFocus():
-            self.__oldFocus = self.focusWidget()
-            self.setFocus()
-
         ctrl, shift = self._GetCtrlShift(ev)
         self._Iren.SetEventInformationFlipY(self.__saveX, self.__saveY,
                                             ctrl, shift, chr(0), 0, None)
         self._Iren.EnterEvent()
 
     def leaveEvent(self, ev):
-        if self.__saveButtons == Qt.NoButton and self.__oldFocus:
-            self.__oldFocus.setFocus()
-            self.__oldFocus = None
-
         ctrl, shift = self._GetCtrlShift(ev)
         self._Iren.SetEventInformationFlipY(self.__saveX, self.__saveY,
                                             ctrl, shift, chr(0), 0, None)


### PR DESCRIPTION
The enterEvent and leaveEvent callbacks in QVTKRenderWindowInteractor lead to focus stealing, causing problems in applications that embed a Mayavi scene,