### PR TITLE
Fix bug in mouse_pick_dispatcher

### DIFF
--- a/mayavi/core/mouse_pick_dispatcher.py
+++ b/mayavi/core/mouse_pick_dispatcher.py
@@ -183,7 +183,7 @@ class MousePickDispatcher(HasTraits):
                     if ( type == event_type
                                     and button == self._current_button):
                         callback(picker)
-            break
+                break
 
     #--------------------------------------------------------------------------
     # Private methods


### PR DESCRIPTION
Wrong indentation level causes only first registered picker to be checked