### PR TITLE
Fix pick_world bug with VTK >= 6

### DIFF
--- a/tvtk/pyface/picker.py
+++ b/tvtk/pyface/picker.py
@@ -29,7 +29,7 @@ from tvtk.tvtk_base import TraitRevPrefixMap, false_bool_trait
 from tvtk.common import configure_input
 from apptools.persistence import state_pickler
 
-VTK_MAJOR_VERSION = tvtk.Version().vtk_major_version
+from tvtk.common import vtk_major_version
 
 ######################################################################
 # Utility functions.
@@ -393,7 +393,7 @@ class Picker(HasTraits):
             # Need to create the probe each time because otherwise it
             # does not seem to work properly.
             probe = tvtk.ProbeFilter()
-            if VTK_MAJOR_VERSION >= 6:
+            if vtk_major_version >= 6:
                 probe.set_source_data(data)
                 probe.set_input_data(self.probe_data)
             else:

--- a/tvtk/pyface/picker.py
+++ b/tvtk/pyface/picker.py
@@ -29,6 +29,7 @@ from tvtk.tvtk_base import TraitRevPrefixMap, false_bool_trait
 from tvtk.common import configure_input
 from apptools.persistence import state_pickler
 
+VTK_MAJOR_VERSION = tvtk.Version().vtk_major_version
 
 ######################################################################
 # Utility functions.
@@ -392,8 +393,12 @@ class Picker(HasTraits):
             # Need to create the probe each time because otherwise it
             # does not seem to work properly.
             probe = tvtk.ProbeFilter()
-            probe.source = data
-            probe.input = self.probe_data
+            if VTK_MAJOR_VERSION >= 6:
+                probe.set_source_data(data)
+                probe.set_input_data(self.probe_data)
+            else:
+                probe.source = data
+                probe.input = self.probe_data            
             probe.update()
             data = probe.output.point_data
             bounds = cp.mapper.input.bounds


### PR DESCRIPTION
The pick_world function is still using the old VTK pipeline functions, added a check to that effect.