### PR TITLE
Fix FutureWarning in numpy 1.12

### DIFF
--- a/mayavi/tools/camera.py
+++ b/mayavi/tools/camera.py
@@ -285,7 +285,7 @@ def view(azimuth=None, elevation=None, distance=None, focalpoint=None,
         r = max(bounds[1::2] - bounds[::2]) * 2.0
 
     cen = (bounds[1::2] + bounds[::2]) * 0.5
-    if focalpoint is not None and not focalpoint == 'auto':
+    if focalpoint is not None and not (isinstance(focalpoint, basestring) and focalpoint == 'auto'):
         cen = np.asarray(focalpoint)
 
     # Find camera position.

--- a/mayavi/tools/camera.py
+++ b/mayavi/tools/camera.py
@@ -285,7 +285,7 @@ def view(azimuth=None, elevation=None, distance=None, focalpoint=None,
         r = max(bounds[1::2] - bounds[::2]) * 2.0
 
     cen = (bounds[1::2] + bounds[::2]) * 0.5
-    if focalpoint is not None and not (isinstance(focalpoint, basestring) and focalpoint == 'auto'):
+    if focalpoint is not None and not (isinstance(focalpoint, str) and focalpoint == 'auto'):
         cen = np.asarray(focalpoint)
 
     # Find camera position.


### PR DESCRIPTION
Fixed FutureWarning about elementwise comparison. This could actually break when numpy 1.13 is released.

C:\WinPython-64bit-2.7.13.1\python-2.7.13.amd64\lib\site-packages\mayavi\tools\camera.py:288: FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison
  if focalpoint is not None and not focalpoint == 'auto':