### PR TITLE
FIX?  shared data in testing backend

### DIFF
--- a/mayavi/tools/pipe_base.py
+++ b/mayavi/tools/pipe_base.py
@@ -134,7 +134,7 @@ class PipeFactory(HasPrivateTraits):
         if self.figure is not None and self.figure is not self._scene:
             warnings.warn('Trying to add a module on the wrong scene')
         if isinstance(parent, (Source, tvtk.DataSet)) \
-                and not isinstance(parent, Filter) and scene is not None:
+                and not isinstance(parent, Filter) and self._scene is not None:
             # Search the current scene to see if the  source is already
             # in it, if not add it.
             if not parent in self._scene.children:


### PR DESCRIPTION
When modifying PySurfer to share data between pipelines based on instructions from [here](http://docs.enthought.com/mayavi/mayavi/tips.html#sharing-the-same-data-between-scenes) 
we ran into a problem that exists only with the `test` mlab backend: a message is displayed 

<img width="504" alt="screen shot 2017-06-24 at 11 23 04 am" src="https://user-images.githubusercontent.com/145771/27509640-8437a4b6-58cf-11e7-8929-f5a9a390400b.png">

followed by this traceback:

```
Exception occurred in traits notification handler for object: <mayavi.tools.filters.SetActiveAttributeFactory object at 0x12638b650>, trait: point_scalars, old value: , new value: color
Traceback (most recent call last):
  File "/Users/christian/anaconda/envs/mayavi-dev/lib/python2.7/site-packages/traits/trait_notifiers.py", line 340, in __call__
    self.handler( *args )
  File "/Users/christian/Code/mayavi/mayavi/tools/pipe_base.py", line 198, in _anytrait_changed
    setattr(obj, components[-1], value)
  File "/Users/christian/Code/mayavi/mayavi/core/trait_defs.py", line 97, in set_value
    raise TraitError(object, name,"one of %s"%values, value)
TraitError: The 'point_scalars_name' trait of a SetActiveAttribute instance must be one of [], but a value of 'color' <type 'str'> was specified.
Traceback (most recent call last):
  File "share_data.py", line 25, in <module>
    pipe = mlab.pipeline.set_active_attribute(dataset, point_scalars='color')
  File "/Users/christian/Code/mayavi/mayavi/tools/pipe_base.py", line 38, in the_function
    factory = factory_class(*args, **kwargs)
  File "/Users/christian/Code/mayavi/mayavi/tools/pipe_base.py", line 163, in __init__
    self.set(**traits)
  File "/Users/christian/Code/mayavi/mayavi/tools/pipe_base.py", line 180, in set
    self._anytrait_changed(trait, value)
  File "/Users/christian/Code/mayavi/mayavi/tools/pipe_base.py", line 198, in _anytrait_changed
    setattr(obj, components[-1], value)
  File "/Users/christian/Code/mayavi/mayavi/core/trait_defs.py", line 97, in set_value
    raise TraitError(object, name,"one of %s"%values, value)
traits.trait_errors.TraitError: The 'point_vectors_name' trait of a SetActiveAttribute instance must be one of [], but a value of '' <type 'str'> was specified.
```

 (https://github.com/nipy/PySurfer/pull/191). Looking through the Mayavi source code (which I am not familiar with otherwise) I noticed the line modified in this PR which looks like it might be a bug (where `scene` is compared to `None` when it is not `scene` but `self._scene` that is used in the conditional). Modifying the line as in this PR fixes the issue with the testing backend for me. I was trying to look for a test to modify but could not find a test for the `mlab.pipeline.set_active_attribute` pipeline; below is a small script (based on [this](http://gael-varoquaux.info/programming/mayavi-representing-an-additional-scalar-on-surfaces.html)) that produces the error and is fixed with the change in this PR.

```
###############################################################
# Create some data
import numpy as np
x, y = np.mgrid[0:10:100j, 0:10:100j]
z = x**2 + y**2
w = np.arctan(x/y)

###############################################################
# Visualize the data
from mayavi import mlab


mlab.options.backend = 'test'

# Create the data source
src = mlab.pipeline.array2d_source(z)

# add second array
dataset = src.mlab_source.dataset
array_id = dataset.point_data.add_array(w.T.ravel())
dataset.point_data.get_array(array_id).name = 'color'
dataset.point_data.update()

# select the array from a copy
pipe = mlab.pipeline.set_active_attribute(dataset, point_scalars='color')
```