### PR TITLE
Fix a bug with array source and vectors.

### DIFF
--- a/mayavi/sources/array_source.py
+++ b/mayavi/sources/array_source.py
@@ -239,7 +239,7 @@ class ArraySource(Source):
             data_t = numpy.transpose(data, (2, 1, 0, 3))
         else:
             data_t = data
-        img_data.point_data.vectors = numpy.reshape(data_t, (sz/3, 3))
+        img_data.point_data.vectors = numpy.reshape(data_t, (sz//3, 3))
         img_data.point_data.vectors.name = self.vector_name
         if is_old_pipeline():
             img_data.update() # This sets up the extents correctly.


### PR DESCRIPTION
This bug manifests when one runs `mlab.test_flow()` with Python 3.x and
is using a recent version of NumPy where shape elements cannot be
floats.