### PR TITLE
Qt5 support

### DIFF
--- a/tvtk/code_gen.py
+++ b/tvtk/code_gen.py
@@ -132,7 +132,7 @@ class TVTKGenerator:
         specified classes.
 
         """
-        # Wrappers for the ancesors are generated in order to get the
+        # Wrappers for the accesors are generated in order to get the
         # _updateable_traits_ information correctly.
         nodes = []
         for name in names:
@@ -148,7 +148,7 @@ class TVTKGenerator:
                 if i not in nodes:
                     nodes.insert(0, i)
         # Sort them as per their level.
-        nodes.sort(lambda x, y: cmp(x.level, y.level))
+        nodes.sort(key=lambda x: x.level)
 
         # Write code.
         for node in nodes:

--- a/tvtk/pyface/ui/qt4/QVTKRenderWindowInteractor.py
+++ b/tvtk/pyface/ui/qt4/QVTKRenderWindowInteractor.py
@@ -65,7 +65,10 @@ except (ImportError, AttributeError):
 
 if PyQtImpl == "PyQt5":
     if QVTKRWIBase == "QGLWidget":
-        from PyQt5.QtOpenGL import QGLWidget
+        try:
+            from PyQt5.QtWidgets import QOpenGLWidget as QGLWidget
+        except:
+            from PyQt5.QtOpenGL import QGLWidget
     from PyQt5.QtWidgets import QWidget, QSizePolicy, QApplication
     from PyQt5.QtGui import QWheelEvent
     from PyQt5.QtCore import Qt, QTimer, QObject, QSize, QEvent

--- a/tvtk/pyface/ui/qt4/QVTKRenderWindowInteractor.py
+++ b/tvtk/pyface/ui/qt4/QVTKRenderWindowInteractor.py
@@ -244,7 +244,7 @@ class QVTKRenderWindowInteractor(QVTKRWIBaseClass):
 
         # add wheel timer to fix scrolling issue with trackpad
         self.wheel_timer = None
-        if PyQtImpl == 'PyQt4':
+        if PyQtImpl != 'PyQt5':
             self.wheel_timer = QTimer()
             self.wheel_timer.setSingleShot(True)
             self.wheel_timer.setInterval(25)

--- a/tvtk/pyface/ui/qt4/init.py
+++ b/tvtk/pyface/ui/qt4/init.py
@@ -25,6 +25,7 @@ import os
 from pyface.qt import qt_api
 if qt_api == 'pyqt':
     from PyQt4 import QtGui, QtCore
+    from PyQt4.QtGui import QApplication
 
     # Check the version numbers are late enough.
     if QtCore.QT_VERSION < 0x040200:
@@ -32,13 +33,17 @@ if qt_api == 'pyqt':
 
     if QtCore.PYQT_VERSION < 0x040100:
         raise RuntimeError("Need PyQt v4.1 or higher, but got v%s" % QtCore.PYQT_VERSION_STR)
+elif qt_api == 'pyqt5':
+    from PyQt5 import QtGui, QtCore
+    from PyQt5.QtWidgets import QApplication
 else:
     from PySide import QtGui, QtCore
+    from PySide.QtGui import QApplication
 
 # It's possible that it has already been initialised.
-_app = QtGui.QApplication.instance()
+_app = QApplication.instance()
 
 if _app is None:
-    _app = QtGui.QApplication(sys.argv)
+    _app = QApplication(sys.argv)
 
 #### EOF ######################################################################

--- a/tvtk/pyface/ui/qt4/scene.py
+++ b/tvtk/pyface/ui/qt4/scene.py
@@ -51,6 +51,10 @@ class _VTKRenderWindowInteractor(QVTKRenderWindowInteractor):
 
         self._scene = scene
         self._interacting = False
+        if hasattr(self, 'devicePixelRatio'):
+            self._pixel_ratio = self.devicePixelRatio()
+        else:
+            self._pixel_ratio = 1.0
 
     def resizeEvent(self, e):
         """ Reimplemented to refresh the traits of the render window.
@@ -118,14 +122,14 @@ class _VTKRenderWindowInteractor(QVTKRenderWindowInteractor):
             pos = self.mapFromGlobal(QtGui.QCursor.pos())
             x = pos.x()
             y = self.height() - pos.y()
-            scene.picker.pick(x, y)
+            scene.picker.pick(x*self._pixel_ratio, y*self._pixel_ratio)
             return
 
         if key in [QtCore.Qt.Key_F] and modifiers == QtCore.Qt.NoModifier:
             pos = self.mapFromGlobal(QtGui.QCursor.pos())
             x = pos.x()
             y = self.height() - pos.y()
-            data = scene.picker.pick_world(x, y)
+            data = scene.picker.pick_world(x*self._pixel_ratio, y*self._pixel_ratio)
             coord = data.coordinate
             if coord is not None:
                 camera.focal_point = coord

--- a/tvtk/util/gradient_editor.py
+++ b/tvtk/util/gradient_editor.py
@@ -279,14 +279,7 @@ class GradientTableOld:
         """Sort control points by position. Call this if the position of
         any control point was changed externally. The control point array
         always has to be sorted."""
-        def pred(x, y):
-            if x < y:
-                return -1
-            elif y < x:
-                return +1
-            else:
-                return 0
-        self.control_points.sort( lambda x, y: pred(x.pos, y.pos) )
+        self.control_points.sort(key=lambda x: x.pos)
 
     def update(self):
         """Recalculate the gradient table from the control points. The colors
@@ -684,14 +677,7 @@ class GradientTable:
         """Sort control points by position. Call this if the position of
         any control point was changed externally. The control point array
         always has to be sorted."""
-        def pred(x, y):
-            if x < y:
-                return -1
-            elif y < x:
-                return +1
-            else:
-                return 0
-        self.control_points.sort( lambda x, y: pred(x.pos, y.pos) )
+        self.control_points.sort(key=lambda x: x.pos)
 
     def update(self):
         """Recalculate the gradient table from the control points. The


### PR DESCRIPTION
- Basic support for Qt5.  This makes Mayavi compatible with PyQt5.
- This requires the latest traits, traitsui, and pyface from master.  A new release may be forthcoming for these packages soon.
- This works well with VTK-8.x which is typically not available on most Python packages but is easy to do by hand.  On older versions, on MacOS, the embedded VTK window is half the size.  
- There are some warnings about "Attempt to set a screen on a child window." which seem related to the toolbar used on the decorated scene.  This seems like a pyface issue with the toolbar.
- Mlab and traits based dialogs work fine.
- Mayavi2 works but reparenting windows seems to not work very well suggesting that there are more migration issues in the other libraries.
- This PR also sneaks in a couple of Python3 migration bugs in Mayavi.