### PR TITLE
FIX: Fix deprecated .set / .get use

### DIFF
--- a/mayavi/core/lut_manager.py
+++ b/mayavi/core/lut_manager.py
@@ -218,14 +218,14 @@ class LUTManager(Base):
 
         # Initialize the scalar bar.
         sc_bar = self.scalar_bar
-        sc_bar.set(lookup_table=self.lut,
-                   title=self.data_name,
-                   number_of_labels=self.number_of_labels,
-                   orientation='horizontal',
-                   width=0.8, height=0.17)
+        sc_bar.trait_set(lookup_table=self.lut,
+                         title=self.data_name,
+                         number_of_labels=self.number_of_labels,
+                         orientation='horizontal',
+                         width=0.8, height=0.17)
         pc = sc_bar.position_coordinate
-        pc.set(coordinate_system='normalized_viewport',
-               value=(0.1, 0.01, 0.0))
+        pc.trait_set(coordinate_system='normalized_viewport',
+                     value=(0.1, 0.01, 0.0))
         self._shadow_changed(self.shadow)
 
         # Initialize the lut.
@@ -240,8 +240,8 @@ class LUTManager(Base):
         ltp.on_trait_change(self.render)
 
         # Initialize the scalar_bar_widget
-        self.scalar_bar_widget.set(scalar_bar_actor=self.scalar_bar,
-                                   key_press_activation=False)
+        self.scalar_bar_widget.trait_set(scalar_bar_actor=self.scalar_bar,
+                                         key_press_activation=False)
         self._number_of_colors_changed(self.number_of_colors)
 
 
@@ -319,10 +319,10 @@ class LUTManager(Base):
                 saturation_range = 0.0, 0.0
                 value_range = 0.0, 1.0
         lut = self.lut
-        lut.set(hue_range=hue_range, saturation_range=saturation_range,
-                value_range=value_range,
-                number_of_table_values=self.number_of_colors,
-                ramp='sqrt')
+        lut.trait_set(hue_range=hue_range, saturation_range=saturation_range,
+                      value_range=value_range,
+                      number_of_table_values=self.number_of_colors,
+                      ramp='sqrt')
         lut.modified()
         lut.force_build()
 

--- a/mayavi/core/module_manager.py
+++ b/mayavi/core/module_manager.py
@@ -257,7 +257,7 @@ class ModuleManager(Base):
             obj.stop()
         # Setup and start the new ones.
         for obj in added:
-            obj.set(module_manager=self, scene=self.scene, parent=self)
+            obj.trait_set(module_manager=self, scene=self.scene, parent=self)
             if self.running:
                 # It makes sense to start children only if we are running.
                 # If not, the children will be started when we start.

--- a/mayavi/core/scene.py
+++ b/mayavi/core/scene.py
@@ -214,7 +214,7 @@ class Scene(Base):
         for obj in removed:
             obj.stop()
         for obj in added:
-            obj.set(scene=self.scene, parent=self)
+            obj.trait_set(scene=self.scene, parent=self)
             if self.running:
                 # It makes sense to start children only if we are running.
                 # If not, the children will be started when we start.

--- a/mayavi/core/source.py
+++ b/mayavi/core/source.py
@@ -206,7 +206,7 @@ class Source(PipelineBase):
 
         # Process the new objects.
         for obj in added:
-            obj.set(scene=self.scene, parent=self)
+            obj.trait_set(scene=self.scene, parent=self)
             if isinstance(obj, ModuleManager):
                 obj.source = self
             elif is_filter(obj):

--- a/mayavi/modules/glyph.py
+++ b/mayavi/modules/glyph.py
@@ -70,9 +70,9 @@ class Glyph(Module):
         # Create the components
         actor = self.actor = Actor()
         actor.mapper.scalar_visibility = 1
-        actor.property.set(line_width=2,
-                           backface_culling=False,
-                           frontface_culling=False)
+        actor.property.trait_set(line_width=2,
+                                 backface_culling=False,
+                                 frontface_culling=False)
 
     def update_pipeline(self):
         """Override this method so that it *updates* the tvtk pipeline

--- a/mayavi/tools/helper_functions.py
+++ b/mayavi/tools/helper_functions.py
@@ -104,7 +104,7 @@ class Pipeline(HasTraits):
                     ', '.join(
                         str(k) for k in
                         set(kwargs.keys()).difference(list(all_traits.keys()))))
-        traits = self.get(self.class_trait_names())
+        traits = self.trait_get(self.class_trait_names())
         [traits.pop(key) for key in list(traits.keys()) if key[0] == '_']
         traits.update(kwargs)
         self.kwargs = traits

--- a/mayavi/tools/pipe_base.py
+++ b/mayavi/tools/pipe_base.py
@@ -154,7 +154,7 @@ class PipeFactory(HasPrivateTraits):
             self._target.add_trait('mlab_source', Instance(ms.__class__))
             self._target.mlab_source = ms
 
-        traits = self.get(self.class_trait_names())
+        traits = self.trait_get(self.class_trait_names())
         [traits.pop(key) for key in list(traits.keys())
                                     if key[0] == '_' or key is None]
         traits.update(kwargs)
@@ -167,8 +167,8 @@ class PipeFactory(HasPrivateTraits):
     def set(self, trait_change_notify=True, **traits):
         """ Same as HasTraits.set except that notification is forced,
         unless trait_change_notify==False"""
-        HasPrivateTraits.set(self, trait_change_notify=trait_change_notify,
-                                    **traits)
+        HasPrivateTraits.trait_set(
+            self, trait_change_notify=trait_change_notify, **traits)
         if trait_change_notify == False:
             return
         for trait in traits:

--- a/mayavi/tools/sources.py
+++ b/mayavi/tools/sources.py
@@ -98,7 +98,7 @@ class MlabSource(HasTraits):
         """
         try:
             self._disable_update = True
-            super(MlabSource, self).set(trait_change_notify, **traits)
+            super(MlabSource, self).trait_set(trait_change_notify, **traits)
         finally:
             self._disable_update = False
         if trait_change_notify:
@@ -213,8 +213,8 @@ class MGlyphSource(MlabSource):
         else:
             # Modify existing one.
             pd = self.dataset
-        pd.set(points=points)
-        pd.set(polys=polys)
+        pd.trait_set(points=points)
+        pd.trait_set(polys=polys)
 
         if self.vectors is not None:
             pd.point_data.vectors = self.vectors


### PR DESCRIPTION
Closes #554.

I started replacing all of the `.set(...)` calls with `.trait_set(...)`, until I realized that (at least) the `MlabSource` class, which is the base class for a number of things, has a special / different `.set(...)` method that does some stuff before calling `self.trait_set(...)`. I suspect some of the changes here, then, are not so good because they might lead to calling `MlabSource.trait_set(...)` directly instead of `MlabSource.set(...)`.

Perhaps the correct fix is to add a `MlabSource.trait_set(...)` that just wraps to the `MlabSource.set(...)` -- then I could change all of the `.set(...)` calls to `.trait_set(...)`, but I don't know enough about the hierarchy / ramifications to know.

In the meantime, this at least gets rid of the warnings 