### PR TITLE
Bug fix: solve the unicode encode error in windows

### DIFF
--- a/tvtk/code_gen.py
+++ b/tvtk/code_gen.py
@@ -7,6 +7,7 @@
 
 from __future__ import print_function
 
+import io
 import vtk
 import os
 import os.path
@@ -206,7 +207,7 @@ class TVTKGenerator:
         # The only reason this method is separate is to generate code
         # for an individual class when debugging.
         fname = camel2enthought(tvtk_name) + '.py'
-        out = open(os.path.join(self.out_dir, fname), 'w', encoding='utf-8')
+        out = io.open(os.path.join(self.out_dir, fname), 'w', encoding='utf-8')
         self.wrap_gen.generate_code(node, out)
         out.close()
 

--- a/tvtk/code_gen.py
+++ b/tvtk/code_gen.py
@@ -206,7 +206,7 @@ class TVTKGenerator:
         # The only reason this method is separate is to generate code
         # for an individual class when debugging.
         fname = camel2enthought(tvtk_name) + '.py'
-        out = open(os.path.join(self.out_dir, fname), 'w')
+        out = open(os.path.join(self.out_dir, fname), 'w', encoding='utf-8')
         self.wrap_gen.generate_code(node, out)
         out.close()
 

--- a/tvtk/code_gen.py
+++ b/tvtk/code_gen.py
@@ -7,7 +7,6 @@
 
 from __future__ import print_function
 
-import io
 import vtk
 import os
 import os.path
@@ -17,6 +16,7 @@ import shutil
 import glob
 import logging
 from optparse import OptionParser
+import sys
 
 # Local imports -- these should be relative imports since these are
 # imported before the package is installed.
@@ -207,7 +207,10 @@ class TVTKGenerator:
         # The only reason this method is separate is to generate code
         # for an individual class when debugging.
         fname = camel2enthought(tvtk_name) + '.py'
-        out = io.open(os.path.join(self.out_dir, fname), 'w', encoding='utf-8')
+        if sys.version_info[0] > 2:
+            out = open(os.path.join(self.out_dir, fname), 'w', encoding='utf-8')
+        else:
+            out = open(os.path.join(self.out_dir, fname), 'w')
         self.wrap_gen.generate_code(node, out)
         out.close()
 


### PR DESCRIPTION
The error `UnicodeEncodeError: 'cp932' codec can't encode character '\xe9' in position` appears when building the documentation in windows from master source, and it can be simply solved by telling the the write wrapper to encode the text as UTF-8.