### PR TITLE
FIX: Remove debug print

### DIFF
--- a/mayavi/tools/camera.py
+++ b/mayavi/tools/camera.py
@@ -307,7 +307,6 @@ def view(azimuth=None, elevation=None, distance=None, focalpoint=None,
     ren.reset_camera_clipping_range()
 
     if roll is not None:
-        print("setting roll")
         _roll(roll)
     elif reset_roll:
         # Now calculate the view_up vector of the camera.  If the view up is


### PR DESCRIPTION
This appears to be a leftover debugging statement -- no other camera actions are `print`ed so this seems unnecessary. (I also get a flood of `setting roll` calls when automating view changes.)