### PR TITLE
Fix 8.1 issues phase 2

### DIFF
--- a/integrationtests/mayavi/test_mlab_savefig.py
+++ b/integrationtests/mayavi/test_mlab_savefig.py
@@ -65,7 +65,7 @@ class TestMlabSavefigUnitTest(unittest.TestCase):
     def test_many_savefig_offscreen(self):
         """Test if savefig works with off_screen_rendering and Engine"""
         engine = Engine()
-        for _ in xrange(5):
+        for _ in range(5):
             self.setup_engine_and_figure(engine)
 
             # Use off-screen rendering

--- a/mayavi/core/file_data_source.py
+++ b/mayavi/core/file_data_source.py
@@ -178,6 +178,7 @@ class FileDataSource(Source):
     _min_timestep = Int(0)
     _max_timestep = Int(0)
     _timer = Any
+    _in_update_files = Any(False)
 
     ######################################################################
     # `object` interface
@@ -307,11 +308,20 @@ class FileDataSource(Source):
 
     def _update_files_fired(self):
         # First get all the siblings before we change the current file list.
-        siblings = self._find_sibling_datasets() if self.sync_timestep else []
-        fname = self.base_file_name
-        file_list = get_file_list(fname)
-        if len(file_list) == 0:
-            file_list = [fname]
-        self.file_list = file_list
-        for sibling in siblings:
-            sibling.update_files = True
+        if self._in_update_files:
+            return
+        try:
+            self._in_update_files = True
+            if self.sync_timestep:
+                siblings = self._find_sibling_datasets()
+            else:
+                siblings = []
+            fname = self.base_file_name
+            file_list = get_file_list(fname)
+            if len(file_list) == 0:
+                file_list = [fname]
+            self.file_list = file_list
+            for sibling in siblings:
+                sibling.update_files = True
+        finally:
+            self._in_update_files = False

--- a/mayavi/tests/test_builtin_image.py
+++ b/mayavi/tests/test_builtin_image.py
@@ -11,11 +11,12 @@ import unittest
 from numpy import array
 
 # Enthought library imports.
-from tvtk.common import is_old_pipeline
+from tvtk.common import is_old_pipeline, vtk_major_version
 from mayavi.core.null_engine import NullEngine
 from mayavi.sources.builtin_image import BuiltinImage
 from mayavi.modules.surface import Surface
 from mayavi.modules.outline import Outline
+
 
 class TestBuiltinImageSource(unittest.TestCase):
 
@@ -23,9 +24,9 @@ class TestBuiltinImageSource(unittest.TestCase):
 
         e = NullEngine()
         # Uncomment to see visualization for debugging etc.
-        #e = Engine()
+        # e = Engine()
         e.start()
-        s=e.new_scene()
+        s = e.new_scene()
 
         image_data = BuiltinImage()
         e.add_source(image_data)
@@ -36,15 +37,15 @@ class TestBuiltinImageSource(unittest.TestCase):
         surface = Surface()
         e.add_module(surface)
 
-        image_data.data_source.radius = array([ 80.,  80.,  80.])
-        image_data.data_source.center = array([ 150.,  150.,    0.])
-        image_data.data_source.whole_extent = array([ 10, 245,  10, 245,   0,   0])
+        image_data.data_source.radius = array([80.,  80.,  80.])
+        image_data.data_source.center = array([150.,  150.,    0.])
+        image_data.data_source.whole_extent = array([10, 245, 10, 245, 0, 0])
         if is_old_pipeline():
             image_data.data_source.update_whole_extent()
-        else:
+        elif vtk_major_version < 8:
             image_data.data_source.set_update_extent_to_whole_extent()
 
-        self.e=e
+        self.e = e
         self.scene = e.current_scene
 
         return

--- a/mayavi/tests/test_mlab_integration.py
+++ b/mayavi/tests/test_mlab_integration.py
@@ -397,10 +397,11 @@ class TestMlabModules(TestMlabNullEngine):
         range1 = vol1._ctf.range[1] - vol1._ctf.range[0]
         vol2 = mlab.pipeline.volume(src, vmin=0.25, vmax=0.75)
         range2 = vol2._ctf.range[1] - vol2._ctf.range[0]
-        for value in 0.5*np.random.random(10):
+        for value in np.random.random(10):
             np.testing.assert_array_almost_equal(
-                        vol1._ctf.get_color(2*range1*value),
-                        vol2._ctf.get_color(0.25+range2*value))
+                vol1._ctf.get_color(range1*value),
+                vol2._ctf.get_color(0.25 + 0.5*range2*value)
+            )
         # Test outside the special [0, 1] range
         src = mlab.pipeline.scalar_field(2*scalars)
         vol1 = mlab.pipeline.volume(src)

--- a/mayavi/tools/modules.py
+++ b/mayavi/tools/modules.py
@@ -570,7 +570,7 @@ class VolumeFactory(PipeFactory):
 
     _target = Instance(modules.Volume, ())
 
-    __ctf_rescaled = Bool(False)
+    __last_vrange = Any(None)
 
     ######################################################################
     # Non-public interface.
@@ -616,13 +616,16 @@ class VolumeFactory(PipeFactory):
         otf.add_point(vmax, 0.2)
         self._target._otf = otf
         self._target._volume_property.set_scalar_opacity(otf)
-        if self.color is None and not self.__ctf_rescaled and \
-                        ((self.vmin is not None) or (self.vmax is not None)):
+        if self.color is None and \
+           ((self.vmin is not None) or (self.vmax is not None)):
             # FIXME: We don't use 'rescale_ctfs' because it screws up the
             # nodes.
-
+            if self.__last_vrange:
+                last_min, last_max = self.__last_vrange
+            else:
+                last_min, last_max = range_min, range_max
             def _rescale_value(x):
-                nx = (x - range_min) / (range_max - range_min)
+                nx = (x - last_min) / (last_max - last_min)
                 return vmin + nx * (vmax - vmin)
             # The range of the existing ctf can vary.
             scale_min, scale_max = self._target._ctf.range
@@ -656,12 +659,12 @@ class VolumeFactory(PipeFactory):
 
             self._target._ctf = ctf
             self._target._volume_property.set_color(ctf)
-            self.__ctf_rescaled = True
+            self.__last_vrange = vmin, vmax
 
         self._target.update_ctf = True
 
     # This is not necessary: the job is already done by _vmin_changed
-    #_vmax_changed = _vmin_changed
+    _vmax_changed = _vmin_changed
 
 volume = make_function(VolumeFactory)
 

--- a/mayavi/tools/modules.py
+++ b/mayavi/tools/modules.py
@@ -619,11 +619,14 @@ class VolumeFactory(PipeFactory):
         if self.color is None and \
            ((self.vmin is not None) or (self.vmax is not None)):
             # FIXME: We don't use 'rescale_ctfs' because it screws up the
-            # nodes.
+            # nodes, this is because, the values are actually scaled between
+            # the specified vmin/vmax and NOT the full range of values
+            # specified in the CTF or in the volume object.
             if self.__last_vrange:
                 last_min, last_max = self.__last_vrange
             else:
                 last_min, last_max = range_min, range_max
+
             def _rescale_value(x):
                 nx = (x - last_min) / (last_max - last_min)
                 return vmin + nx * (vmax - vmin)

--- a/tvtk/code_gen.py
+++ b/tvtk/code_gen.py
@@ -102,6 +102,11 @@ class TVTKGenerator:
             classes = []
             for node in wrap_gen.get_tree():
                 name = node.name
+                # This is another class we should not wrap and exists
+                # in version 8.1.0.
+                ignore = ['vtkOpenGLGL2PSHelperImpl']
+                if name in ignore:
+                    continue
                 if not name.startswith('vtk') or name.startswith('vtkQt'):
                     continue
                 if not hasattr(vtk, name) or not hasattr(getattr(vtk, name), 'IsA'):  # noqa

--- a/tvtk/tests/test_class_tree.py
+++ b/tvtk/tests/test_class_tree.py
@@ -64,19 +64,21 @@ class TestClassTree(unittest.TestCase):
                           'vtkSparseArray', 'vtkTuple',
                           'vtkTypedArray', 'vtkVector', 'vtkVector2',
                           'vtkVector3']
-            elif len(vtk.vtkObjectBase.__bases__) > 0:
+            elif len(vtk.vtkObjectBase.__bases__) == 1:
+                expect = ['object']
+            elif len(vtk.vtkObjectBase.__bases__) > 1:
                 if vtk_major_version == 7:
                     expect = ['object', 'vtkColor3', 'vtkColor4', 'vtkDenseArray',
-                            'vtkQuaternion', 'vtkRect',
-                            'vtkSparseArray', 'vtkTuple',
-                            'vtkTypedArray', 'vtkVariantStrictWeakOrderKey',
-                            'vtkVector', 'vtkVector2', 'vtkVector3']
+                              'vtkQuaternion', 'vtkRect',
+                              'vtkSparseArray', 'vtkTuple',
+                              'vtkTypedArray', 'vtkVariantStrictWeakOrderKey',
+                              'vtkVector', 'vtkVector2', 'vtkVector3']
                 else:
                     expect = ['object', 'vtkColor3', 'vtkColor4', 'vtkDenseArray',
-                            'vtkQuaternion', 'vtkRect',
-                            'vtkSparseArray', 'vtkTuple',
-                            'vtkTypedArray', 'vtkVector', 'vtkVector2',
-                            'vtkVector3']
+                              'vtkQuaternion', 'vtkRect',
+                              'vtkSparseArray', 'vtkTuple',
+                              'vtkTypedArray', 'vtkVector', 'vtkVector2',
+                              'vtkVector3']
             else:
                 expect = ['object', 'vtkColor3', 'vtkColor4', 'vtkDenseArray',
                           'vtkObjectBase', 'vtkQuaternion', 'vtkRect',

--- a/tvtk/tests/test_tvtk.py
+++ b/tvtk/tests/test_tvtk.py
@@ -14,7 +14,6 @@ import weakref
 import sys
 import gc
 import traceback
-import contextlib
 import types
 import inspect
 import re
@@ -134,7 +133,7 @@ class TestTVTK(unittest.TestCase):
         r = tvtk.XMLDataReader()
         self.assertEqual(r.f(), 'f')
         if len(vtk.vtkObjectBase.__bases__) > 0:
-            if is_version_7():
+            if vtk_major_version == 7:
                 expect = ()
             else:
                 expect = (object,)
@@ -625,7 +624,7 @@ class TestTVTK(unittest.TestCase):
     def test_parent_child_input(self):
         """Case where parent has GetInput and child SetInput."""
         if (vtk_major_version >= 6 and vtk_minor_version > 1) or \
-            vtk_major_version == 7:
+            vtk_major_version >= 7:
             vm = tvtk.SmartVolumeMapper()
         else:
             vm = tvtk.VolumeTextureMapper2D()

--- a/tvtk/tests/test_visual.py
+++ b/tvtk/tests/test_visual.py
@@ -133,7 +133,7 @@ class TestVisual(unittest.TestCase):
 
     def test_cylinder(self):
         # When
-        c = visual.cylinder(radius=0.5, length=2, pos=(1,1,1))
+        c = visual.cylinder(radius=0.5, length=2, pos=(1., 1, 1))
 
         # Then
         assert_allclose(
@@ -190,16 +190,15 @@ class TestVisual(unittest.TestCase):
         assert_allclose(a.polydata.bounds, bounds, atol=1e-3, rtol=0)
 
         # Given
-        a = visual.arrow(pos=(1,1,1))
+        a = visual.arrow(pos=(1.0, 1.0, 1.0))
         # Then
         bounds = get_bounds((1.5, 1.0, 1.0), (1.0, 0.16, 0.14))
-        assert_allclose(a.pos, (1,1,1))
+        assert_allclose(a.pos, (1., 1., 1.))
         assert_allclose(a.polydata.bounds, bounds, atol=1e-3, rtol=0)
-
 
     def test_ellipsoid(self):
         # When
-        s = visual.ellipsoid(size=(1.0, 1.0, 1.0), pos=(1,1,1))
+        s = visual.ellipsoid(size=(1.0, 1.0, 1.0), pos=(1., 1., 1.))
 
         # Then
 
@@ -232,28 +231,28 @@ class TestVisual(unittest.TestCase):
 
     def test_curve(self):
         # Given/When
-        c = visual.curve(points=[[0,0,0],[1,1,1]], pos=(1,1,1))
+        c = visual.curve(points=[[0.,0.,0.],[1.,1.,1.]], pos=(1.,1.,1.))
 
         # Then
         bounds = get_bounds((1.5, 1.5, 1.5), (1.0, 1.0, 1.0))
         assert_allclose(c.polydata.bounds, bounds)
 
         # When
-        c = visual.curve(points=[[0,0,0],[1,1,1]], axis=(0, 1, 0))
+        c = visual.curve(points=[[0.,0,0],[1.,1,1]], axis=(0., 1, 0))
         # Then
         bounds = get_bounds((-0.5, 0.5, 0.5), (1.0, 1.0, 1.0))
         assert_allclose(c.polydata.bounds, bounds)
 
     def test_helix(self):
         # Given/When
-        h = visual.helix(pos=(1,1,1))
+        h = visual.helix(pos=(1., 1.,1.))
 
         # Then
         bounds = get_bounds((1.5, 1.0, 1.0), (1.0, 0.4, 0.4))
         assert_allclose(h.polydata.bounds, bounds, atol=3e-2, rtol=0)
 
         # Given/When
-        h.axis = 0, 1, 0
+        h.axis = 0., 1., 0.
         # Then
         bounds = get_bounds((1.0, 1.5, 1.0), (0.4, 1.0, 0.4))
         assert_allclose(h.polydata.bounds, bounds, atol=3e-2, rtol=0)

--- a/tvtk/util/gradient_editor.py
+++ b/tvtk/util/gradient_editor.py
@@ -1009,7 +1009,8 @@ class FunctionControl(object):
 
     ChannelFactory = ChannelBase
 
-    def __init__(self, master, gradient_table, color_space, width, height):
+    def __init__(self, master=None, gradient_table=None, color_space=None,
+                 width=100, height=100):
         """Initialize a function control widget on tkframe master.
 
         Parameters:
@@ -1134,8 +1135,8 @@ class AbstractGradientEditor(object):
 class GradientEditorWidget(AbstractGradientEditor):
     """A Gradient Editor widget that can be used anywhere.
     """
-    def __init__(self, master, vtk_table, on_change_color_table=None,
-                 colors=None):
+    def __init__(self, master=None, vtk_table=None,
+                 on_change_color_table=None, colors=None):
         """
 
         Parameters:

--- a/tvtk/vtk_parser.py
+++ b/tvtk/vtk_parser.py
@@ -626,6 +626,9 @@ class VTKMethodParser:
             elif (klass_name == 'vtkVolumeMapper'
                   and method[3:] == 'CroppingRegionPlanes'):
                 continue
+            elif (klass_name == 'vtkContextMouseEvent'
+                  and method[3:] == 'Interactor'):
+                pass
             elif (method[:3] == 'Set') and ('Get' + method[3:]) in methods:
                 key = method[3:]
                 meths.remove('Set' + key)
@@ -650,15 +653,19 @@ class VTKMethodParser:
                         # This class breaks standard VTK conventions.
                         gsm[key] = (3, (1, 3))
                         continue
+                    elif (klass_name == 'vtkContextMouseEvent' and
+                          key == 'Interactor'):
+                        # On VTK 8.1.0 this segfaults when uninitialized.
+                        default = None
                     else:
                         try:
-                            default = getattr(obj, 'Get%s'%key)()
+                            default = getattr(obj, 'Get%s' % key)()
                         except TypeError:
                             default = None
 
                     if value:
-                        low = getattr(obj, 'Get%sMinValue'%key)()
-                        high = getattr(obj, 'Get%sMaxValue'%key)()
+                        low = getattr(obj, 'Get%sMinValue' % key)()
+                        high = getattr(obj, 'Get%sMaxValue' % key)()
                         gsm[key] = (default, (low, high))
                     else:
                         gsm[key] = (default, None)

--- a/tvtk/wrapper_gen.py
+++ b/tvtk/wrapper_gen.py
@@ -20,7 +20,8 @@ from itertools import chain
 
 # Local imports (these are relative imports because the package is not
 # installed when these modules are imported).
-from .common import get_tvtk_name, camel2enthought, is_version_58
+from .common import (get_tvtk_name, camel2enthought, is_version_58,
+                     vtk_major_version)
 
 from . import vtk_parser
 from . import indenter
@@ -261,6 +262,7 @@ class WrapperGenerator:
         """
         prelim = """
         # Automatically generated code: EDIT AT YOUR OWN RISK
+        from math import inf
         from traits import api as traits
         from traitsui.item import Item, spring
         from traitsui.group import HGroup
@@ -1592,7 +1594,14 @@ class WrapperGenerator:
         # In VTK 5.8, tolerance is initialised as 0 while the range
         # is 1-100
         'vtkAxesTransformRepresentation.Tolerance$': (
-            True, True, '_write_axes_transform_representation_tolerance')
+            True, True, '_write_axes_transform_representation_tolerance'),
+
+        # In VTK 8.x, vtkSmartVolumeMapper.Get/Set VectorComponent is
+        # supposed to be between 0 and 3 but is initialized to some random
+        # value.
+        'vtkSmartVolumeMapper.VectorComponent$': (
+            True, True, '_write_smart_volume_mapper_vector_component'
+        )
     }
 
     @classmethod
@@ -1762,6 +1771,27 @@ class WrapperGenerator:
             message = ("vtkAxesTransformRepresentation: "
                        "tolerance not updatable "
                        "(VTK 5.8 bug - value not properly initialized)")
+            print(message)
+            default = rng[0]
+        t_def = ('traits.Trait({default}, traits.Range{rng}, '
+                 'enter_set=True, auto_set=False)').format(default=default,
+                                                           rng=rng)
+        name = self._reform_name(vtk_attr_name)
+        vtk_set_meth = getattr(klass, 'Set' + vtk_attr_name)
+        self._write_trait(out, name, t_def, vtk_set_meth, mapped=False)
+
+    def _write_smart_volume_mapper_vector_component(self, klass, out,
+                                                    vtk_attr_name):
+        if vtk_attr_name != 'VectorComponent':
+            raise RuntimeError("Not sure why you ask for me! "
+                               "I only deal with VectorComponent. Panicking.")
+
+        default, rng = self.parser.get_get_set_methods()[vtk_attr_name]
+
+        if vtk_major_version >= 8:
+            message = ("vtkSmartVolumeMapper: "
+                       "VectorComponent not updatable "
+                       "(VTK 8.x bug - value not properly initialized)")
             print(message)
             default = rng[0]
         t_def = ('traits.Trait({default}, traits.Range{rng}, '

--- a/tvtk/wrapper_gen.py
+++ b/tvtk/wrapper_gen.py
@@ -262,7 +262,6 @@ class WrapperGenerator:
         """
         prelim = """
         # Automatically generated code: EDIT AT YOUR OWN RISK
-        from math import inf
         from traits import api as traits
         from traitsui.item import Item, spring
         from traitsui.group import HGroup
@@ -287,6 +286,8 @@ class WrapperGenerator:
         except NameError:
             # Silly workaround for Python3.
             long = int
+
+        inf = float('inf')
 
         """
         out.write(self.indent.format(prelim))


### PR DESCRIPTION
This is tested with VTK-8.1.0 on Python 3.6, with pyqt5 on MacOS.

- Fixes all TVTK test failures.
- Fixes some wrapping bugs specific to 8.1.x.
- Fixes all Mayavi test failures.
- All integration tests now pass (this required fixing several issues).

Am likely to merge this and disregard build failures on travis so that master at least works properly with the latest VTK.  This is for the benefit of folks who want to play with the new VTK wheels and use Mayavi with it.  I will address the long failing builds in a later PR this week and get those all cleaned up as well.