### PR TITLE
MRG: Fix window size for screenshot on HiDPI

### DIFF
--- a/mayavi/tools/figure.py
+++ b/mayavi/tools/figure.py
@@ -300,7 +300,9 @@ def screenshot(figure=None, mode='rgb', antialiased=False):
     """
     if figure is None:
         figure = gcf()
-    x, y = tuple(figure.scene.get_size())
+    # don't use figure.scene.get_size() here because this will be incorrect
+    # for HiDPI systems
+    x, y = tuple(figure.scene.render_window.size)
 
     # Try to lift the window
     figure.scene._lift()


### PR DESCRIPTION
On macOS with HiDPI `mlab.screenshot` is broken, only rendering 1/4 of the window (as expected by the 2x logical to physical pixel ratio for the monitor):
```
>>> from mayavi import mlab
mlab.>>> mlab.test_plot3d()
<mayavi.modules.surface.Surface object at 0x128adb728>
>>> img = mlab.screenshot()
>>> import matplotlib.pyplot as plt
>>> plt.imshow(img)
<matplotlib.image.AxesImage object at 0x133546ef0>
>>> plt.show()
```
On `master`:
![figure_1](https://user-images.githubusercontent.com/2365790/41989402-32967eb0-7a0d-11e8-89ac-6fd06c4c8f70.png)

On this PR:

![figure_2](https://user-images.githubusercontent.com/2365790/41989758-5da81de2-7a0e-11e8-92bd-61a64de633e7.png)

Not 100% sure `figure.scene.render_window.size` is the right thing to use here, but it works.