### PR TITLE
Make array_ext optional.

### DIFF
--- a/tvtk/tests/test_array_ext.py
+++ b/tvtk/tests/test_array_ext.py
@@ -9,34 +9,35 @@ import unittest
 
 import numpy
 
-from tvtk.array_handler import ID_TYPE_CODE
+from tvtk.array_handler import ID_TYPE_CODE, set_id_type_array_py
 from tvtk.array_ext import set_id_type_array
 
+
 class TestArrayExt(unittest.TestCase):
-    def test_set_id_type_array(self):
+    def check(self, set_id_type_array):
         N = 5
-        a = numpy.zeros((N,4), ID_TYPE_CODE)
-        a[:,1] = 1
-        a[:,2] = 2
-        a[:,3] = 3
+        a = numpy.zeros((N, 4), ID_TYPE_CODE)
+        a[:, 1] = 1
+        a[:, 2] = 2
+        a[:, 3] = 3
 
         def diff_arr(x, y):
-            return numpy.sum(numpy.ravel(x) - numpy.ravel(y[:,1:]))
+            return numpy.sum(numpy.ravel(x) - numpy.ravel(y[:, 1:]))
 
         # Test contiguous arrays.
-        b = numpy.zeros((N,5), ID_TYPE_CODE)
+        b = numpy.zeros((N, 5), ID_TYPE_CODE)
         set_id_type_array(a, b)
         self.assertEqual(diff_arr(a, b), 0)
 
         # Test non-contiguous arrays.
-        b = numpy.zeros((N,3), ID_TYPE_CODE)
-        set_id_type_array(a[:,::2], b)
-        self.assertEqual(diff_arr(a[:,::2], b), 0)
+        b = numpy.zeros((N, 3), ID_TYPE_CODE)
+        set_id_type_array(a[:, ::2], b)
+        self.assertEqual(diff_arr(a[:, ::2], b), 0)
 
         # Test 1D array.
         b = numpy.zeros(N*5, ID_TYPE_CODE)
         set_id_type_array(a, b)
-        self.assertEqual(diff_arr(a, numpy.reshape(b, (N,5))), 0)
+        self.assertEqual(diff_arr(a, numpy.reshape(b, (N, 5))), 0)
 
         # Test assertions.
         d = a.astype('d')
@@ -47,7 +48,7 @@ class TestArrayExt(unittest.TestCase):
         # B should b contiguous.
         b = numpy.zeros((N, 10), ID_TYPE_CODE)
         self.assertRaises(AssertionError, set_id_type_array,
-                          a, b[:,::2])
+                          a, b[:, ::2])
 
         self.assertRaises(AssertionError, set_id_type_array,
                           a[0], b)
@@ -63,7 +64,13 @@ class TestArrayExt(unittest.TestCase):
 
         # This should work!
         set_id_type_array(a, b[:N*5])
-        self.assertEqual(diff_arr(a, numpy.reshape(b[:N*5], (N,5))), 0)
+        self.assertEqual(diff_arr(a, numpy.reshape(b[:N*5], (N, 5))), 0)
+
+    def test_set_id_type_array(self):
+        self.check(set_id_type_array)
+
+    def test_set_id_type_array_py(self):
+        self.check(set_id_type_array_py)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
On a Python environment where compilation is not possible, this
extension prevents installation via pip.  We now have a slower
alternative for such environments which allow us to continue to install
Mayavi without building the extension.  The extension is only added
conditionally, so those who can build the package correctly will get the
added performance.  This addresses #658 and should make Mayavi even
easier to install for the average user.