### PR TITLE
ENH: Use views in set_id_type_array_py

### DIFF
--- a/tvtk/array_handler.py
+++ b/tvtk/array_handler.py
@@ -76,18 +76,18 @@ def set_id_type_array_py(id_array, out_array):
         "out_array must be contiguous."
     shp = id_array.shape
     assert len(shp) == 2, "id_array must be a two dimensional array."
-    sz = numpy.size(out_array)
+    sz = out_array.size
     e_sz = shp[0]*(shp[1]+1)
     assert sz == e_sz, \
         "out_array size is incorrect, expected: %s, given: %s" % (e_sz, sz)
 
-    # numpy.insert does the trick for us albeit slower than our Cython
-    # implementation (by as much as 4x).
-    res = numpy.insert(id_array, 0, shp[1], axis=1)
-    if len(out_array.shape) > 1:
-        out_array[:] = res
-    else:
-        out_array[:] = res.ravel()
+    # we are guaranteed contiguous, so these just change the view (no copy)
+    out_shp = out_array.shape
+    out_array.shape = (shp[0], shp[1] + 1)
+    out_array[:, 0] = shp[1]
+    out_array[:, 1:] = id_array
+    out_array.shape = out_shp
+
 
 
 if not HAS_ARRAY_EXT:


### PR DESCRIPTION
Using this snippet (modified to properly set `empty(..., int)` so the C works properly):
```
from tvtk.array_handler import set_id_type_array_py
from tvtk.array_ext import set_id_type_array
import numpy as np

n = 100000
cs = 10
a = np.arange(cs*n)
a.shape = n, cs
b = np.empty(n*(cs+1), int)

%timeit set_id_type_array(a, b)
%timeit set_id_type_array_py(a, b)
```
on `master` I get roughly ~2x slower:
```
785 µs ± 6.39 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
1.4 ms ± 8.46 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```
On this PR (which only uses views which do not copy the actual data / are for the most part free) I get only ~25% slower:
```
777 µs ± 1.34 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
961 µs ± 2.18 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```
So very close in speed. This makes me think compiling might not ever be worth the hassle.

FWIW in a previous version of this (@prabhuramachandran your original snippet) there was `b = np.empty(n*(cs+1))` without specifying the type as `int`. The Python code at least gave the correct/expected output (integers stored in the `float` array `b`) whereas the C code gave garbage. But I doubt this is really done / useful in practice. There should maybe also be an `assert` statement about the dtype of `out_array` at some point.