### PR TITLE
Add attributes to dataset

### DIFF
--- a/mayavi/sources/array_source.py
+++ b/mayavi/sources/array_source.py
@@ -14,7 +14,7 @@ from traits.api import (Instance, Trait, Str, Bool, Button, DelegatesTo, List,
                         Int)
 from traitsui.api import View, Group, Item
 from tvtk.api import tvtk
-from tvtk import array_handler
+from tvtk.array_handler import array2vtk, get_vtk_array_type
 from tvtk.common import is_old_pipeline
 from tvtk.vtk_module import VTK_MAJOR_VERSION
 
@@ -22,37 +22,41 @@ from tvtk.vtk_module import VTK_MAJOR_VERSION
 from mayavi.core.source import Source
 from mayavi.core.pipeline_info import PipelineInfo
 
+
 def _check_scalar_array(obj, name, value):
     """Validates a scalar array passed to the object."""
     if value is None:
         return None
     arr = numpy.asarray(value)
-    assert len(arr.shape) in [2,3], "Scalar array must be 2 or 3 dimensional"
+    assert len(arr.shape) in [2, 3], "Scalar array must be 2 or 3 dimensional"
     vd = obj.vector_data
     if vd is not None:
         assert vd.shape[:-1] == arr.shape, \
                "Scalar array must match already set vector data.\n"\
-               "vector_data.shape = %s, given array shape = %s"%(vd.shape,
-                                                                 arr.shape)
+               "vector_data.shape = %s, given array shape = %s" % (vd.shape,
+                                                                   arr.shape)
     return arr
 
+
 _check_scalar_array.info = 'a 2D or 3D numpy array'
+
 
 def _check_vector_array(obj, name, value):
     """Validates a vector array passed to the object."""
     if value is None:
         return None
     arr = numpy.asarray(value)
-    assert len(arr.shape) in [3,4], "Vector array must be 3 or 4 dimensional"
+    assert len(arr.shape) in [3, 4], "Vector array must be 3 or 4 dimensional"
     assert arr.shape[-1] == 3, \
-           "The vectors must be three dimensional with `array.shape[-1] == 3`"
+        "The vectors must be three dimensional with `array.shape[-1] == 3`"
     sd = obj.scalar_data
     if sd is not None:
         assert arr.shape[:-1] == sd.shape, \
                "Vector array must match already set scalar data.\n"\
-               "scalar_data.shape = %s, given array shape = %s"%(sd.shape,
-                                                                 arr.shape)
+               "scalar_data.shape = %s, given array shape = %s" % (sd.shape,
+                                                                   arr.shape)
     return arr
+
 
 _check_vector_array.info = 'a 3D or 4D numpy array with shape[-1] = 3'
 
@@ -97,8 +101,8 @@ class ArraySource(Source):
     # Use an ImageChangeInformation filter to reliably set the
     # spacing and origin on the output
     change_information_filter = Instance(tvtk.ImageChangeInformation, args=(),
-                                         kw={'output_spacing' : (1.0, 1.0, 1.0),
-                                             'output_origin' : (0.0, 0.0, 0.0)})
+                                         kw={'output_spacing': (1.0, 1.0, 1.0),
+                                             'output_origin': (0.0, 0.0, 0.0)})
 
     # Should we transpose the input data or not.  Transposing is
     # necessary to make the numpy array compatible with the way VTK
@@ -107,7 +111,11 @@ class ArraySource(Source):
     # user explicitly requests that transpose_input_array is false
     # then we assume that the array has already been suitably
     # formatted by the user.
-    transpose_input_array = Bool(True, desc='if input array should be transposed (if on VTK will copy the input data)')
+    transpose_input_array = Bool(
+        True,
+        desc='if input array should be transposed (if True '
+        'VTK will copy the input data)'
+    )
 
     # Information about what this object can produce.
     output_info = PipelineInfo(datasets=['image_data'])
@@ -142,7 +150,7 @@ class ArraySource(Source):
         if vd is not None:
             self.vector_data = vd
 
-        self.outputs = [ self.change_information_filter.output ]
+        self.outputs = [self.change_information_filter.output]
         self.on_trait_change(self._information_changed, 'spacing,origin')
 
     def __get_pure_state__(self):
@@ -165,6 +173,50 @@ class ArraySource(Source):
             pd.vectors.modified()
         self.change_information_filter.update()
         self.data_changed = True
+
+    def add_attribute(self, array, name, category='point'):
+        """Add an attribute to the dataset to specified category ('point' or
+        'cell').
+
+        One may add a scalar, vector (3/4 components) or a tensor (9
+        components).
+
+        Note that it is the user's responsibility to set the correct size of
+        the arrays. Also no automatic transposing of the data is done.
+
+        Parameters
+        ----------
+
+        array: numpy array/list : array data to add.
+
+        name: str: name of the array.
+
+        category: 'point'/'cell': the category of the attribute data.
+
+        """
+        array = numpy.asarray(array)
+        assert len(array.shape) <= 2, "Only 2D arrays can be added."
+        data = getattr(self.image_data, '%s_data' % category)
+        if len(array.shape) == 2:
+            assert array.shape[1] in [1, 3, 4, 9], \
+                    "Only N x m arrays where (m in [1,3,4,9]) are supported"
+        va = tvtk.to_tvtk(array2vtk(array))
+        va.name = name
+        data.add_array(va)
+
+    def remove_attribute(self, name, category='point'):
+        """Remove an attribute by its name and optional category (point and
+        cell).  Returns the removed array.
+        """
+        data = getattr(self.image_data, '%s_data' % category)
+        data.remove_array(name)
+
+    def rename_attribute(self, name1, name2, category='point'):
+        """Rename a particular attribute from `name1` to `name2`.
+        """
+        data = getattr(self.image_data, '%s_data' % category)
+        arr = data.get_array(name1)
+        arr.name = name2
 
     ######################################################################
     # Non-public interface.
@@ -203,12 +255,12 @@ class ArraySource(Source):
         # This is very important and if not done can lead to a segfault!
         typecode = data.dtype
         if is_old_pipeline():
-            img_data.scalar_type = array_handler.get_vtk_array_type(typecode)
+            img_data.scalar_type = get_vtk_array_type(typecode)
             img_data.update() # This sets up the extents correctly.
         else:
             filter_out_info = self.change_information_filter.get_output_information(0)
             img_data.set_point_data_active_scalar_info(filter_out_info,
-                    array_handler.get_vtk_array_type(typecode), -1)
+                                                       get_vtk_array_type(typecode), -1)
             img_data.modified()
         img_data.update_traits()
         self.change_information_filter.update()

--- a/mayavi/sources/vtk_data_source.py
+++ b/mayavi/sources/vtk_data_source.py
@@ -267,7 +267,7 @@ class VTKDataSource(Source):
         type = self._find_array_list(name, category)
         data = getattr(self.data, '%s_data' % category)
         data.remove_array(name)
-        attr_list = getattr(self, '%s_%s_list' % (category, type))
+        attr_list = getattr(self, '_%s_%s_list' % (category, type))
         return attr_list.remove(name)
 
     def rename_attribute(self, name1, name2, category='point'):
@@ -277,7 +277,7 @@ class VTKDataSource(Source):
         data = getattr(self.data, '%s_data' % category)
         arr = data.get_array(name1)
         arr.name = name2
-        attribute = '%s_%s_list' % (category, type)
+        attribute = '_%s_%s_list' % (category, type)
         attr_list = getattr(self, attribute)
         attr_list.remove(name1)
         attr_list.append(name2)
@@ -434,7 +434,7 @@ class VTKDataSource(Source):
         specified named array in a particular category."""
         types = ['scalars', 'vectors', 'tensors']
         for type in types:
-            attr = '%s_%s_list' % (category, type)
+            attr = '_%s_%s_list' % (category, type)
             names = getattr(self, attr)
             if name in names:
                 return type

--- a/mayavi/tests/test_array_source.py
+++ b/mayavi/tests/test_array_source.py
@@ -18,32 +18,27 @@ from mayavi.modules.surface import Surface
 
 class TestArraySource(unittest.TestCase):
     def setUp(self):
-        """Initial setting up of test fixture, automatically called by TestCase before any other test method is invoked"""
         d = ArraySource()
         self.data = d
 
-    def tearDown(self):
-        """For necessary clean up, automatically called by TestCase after the test methods have been invoked"""
-        return
-
     def make_2d_data(self):
-        s = numpy.array([[0, 1],[2, 3]], 'd')
-        v = numpy.array([[[1,1,1], [1,0,0]],[[0,1,0], [0,0,1]]], 'd')
+        s = numpy.array([[0, 1], [2, 3]], 'd')
+        v = numpy.array([[[1, 1, 1], [1, 0, 0]], [[0, 1, 0], [0, 0, 1]]], 'd')
         tps = numpy.transpose
         s, v = tps(s), tps(v, (1, 0, 2))
         return s, v
 
     def make_3d_data(self):
-        s = numpy.array([[[0, 1],[2, 3]],
-                           [[4, 5],[6, 7]]], 'd')
-        v = numpy.array([[[[0,0,0],
-                             [1,0,0]],
-                            [[0,1,0],
-                             [1,1,0]]],
-                           [[[0,0,1],
-                             [1,0,1]],
-                            [[0,1,1],
-                             [1,1,1]]]], 'd')
+        s = numpy.array([[[0, 1], [2, 3]],
+                         [[4, 5], [6, 7]]], 'd')
+        v = numpy.array([[[[0, 0, 0],
+                           [1, 0, 0]],
+                          [[0, 1, 0],
+                           [1, 1, 0]]],
+                         [[[0, 0, 1],
+                           [1, 0, 1]],
+                          [[0, 1, 1],
+                           [1, 1, 1]]]], 'd')
         tps = numpy.transpose
         s, v = tps(s), tps(v, (2, 1, 0, 3))
         return s, v
@@ -52,32 +47,32 @@ class TestArraySource(unittest.TestCase):
         """Tests if only the correct forms of input arrays are supported."""
         obj = self.data
         # These should work.
-        obj.scalar_data = numpy.zeros((2,2), 'd')
-        obj.scalar_data = numpy.zeros((2,2,2), 'd')
+        obj.scalar_data = numpy.zeros((2, 2), 'd')
+        obj.scalar_data = numpy.zeros((2, 2, 2), 'd')
         obj.scalar_data = None
-        obj.vector_data = numpy.zeros((2,2,3), 'd')
-        obj.vector_data = numpy.zeros((2,2,2,3), 'd')
+        obj.vector_data = numpy.zeros((2, 2, 3), 'd')
+        obj.vector_data = numpy.zeros((2, 2, 2, 3), 'd')
         obj.vector_data = None
 
         # These should not.
-        self.assertRaises(TraitError, setattr, obj, 'scalar_data', [1,2,3])
+        self.assertRaises(TraitError, setattr, obj, 'scalar_data', [1, 2, 3])
         self.assertRaises(TraitError, setattr, obj, 'scalar_data',
-                          numpy.zeros((2,2,2,3), 'd'))
+                          numpy.zeros((2, 2, 2, 3), 'd'))
         obj.scalar_data = None
-        self.assertRaises(TraitError, setattr, obj, 'vector_data', [[1,2,3]])
+        self.assertRaises(TraitError, setattr, obj, 'vector_data', [[1, 2, 3]])
         self.assertRaises(TraitError, setattr, obj, 'vector_data',
-                          numpy.zeros((2,2,2,1), 'd'))
+                          numpy.zeros((2, 2, 2, 1), 'd'))
         obj.vector_data = None
 
-        obj.scalar_data = numpy.zeros((2,2), 'd')
+        obj.scalar_data = numpy.zeros((2, 2), 'd')
         self.assertRaises(TraitError, setattr, obj, 'vector_data',
-                          numpy.zeros((4,4,3), 'd'))
-        obj.vector_data = numpy.zeros((2,2,3), 'd')
+                          numpy.zeros((4, 4, 3), 'd'))
+        obj.vector_data = numpy.zeros((2, 2, 3), 'd')
         self.assertRaises(TraitError, setattr, obj, 'scalar_data',
-                          numpy.zeros((4,3), 'i'))
+                          numpy.zeros((4, 3), 'i'))
         self.assertRaises(TraitError, setattr, obj, 'scalar_data',
-                          numpy.zeros((2,2,2), 'i'))
-        obj.scalar_data = numpy.zeros((2,2), 'f')
+                          numpy.zeros((2, 2, 2), 'i'))
+        obj.scalar_data = numpy.zeros((2, 2), 'f')
 
         # Clean up the object so it can be used for further testing.
         obj.scalar_data = obj.vector_data = None
@@ -132,7 +127,7 @@ class TestArraySource(unittest.TestCase):
         self.assertEqual(surf.running, True)
 
         tps = numpy.transpose
-        expect = [tps(sc),  tps(vec, (2,1,0,3))]
+        expect = [tps(sc),  tps(vec, (2, 1, 0, 3))]
         sc2 = surf.actor.mapper.input.point_data.scalars.to_array()
         self.assertEqual(numpy.allclose(sc2.flatten(),
                          expect[0].flatten()), True)
@@ -149,7 +144,7 @@ class TestArraySource(unittest.TestCase):
         d.scalar_data = sc
         d.vector_data = vec
         d.spacing = [1, 2, 3]
-        d.origin  = [4, 5, 6]
+        d.origin = [4, 5, 6]
         d.start()  # Start the object so it flushes the pipeline etc.
 
         # Create an outline for the data.
@@ -178,7 +173,7 @@ class TestArraySource(unittest.TestCase):
         self.assertEqual(numpy.allclose(d.origin,  [4, 5, 6]), True)
 
         tps = numpy.transpose
-        expect = [tps(sc),  tps(vec, (2,1,0,3))]
+        expect = [tps(sc),  tps(vec, (2, 1, 0, 3))]
         sc2 = surf.actor.mapper.input.point_data.scalars.to_array()
         self.assertEqual(numpy.allclose(sc2.flatten(),
                          expect[0].flatten()), True)
@@ -186,6 +181,117 @@ class TestArraySource(unittest.TestCase):
         self.assertEqual(numpy.allclose(vec2.flatten(),
                          expect[1].flatten()), True)
 
+
+class TestArraySourceAttributes(unittest.TestCase):
+    def setUp(self):
+        s1 = numpy.ones((2, 2))
+        src = ArraySource(scalar_data=s1, scalar_name='s1')
+        self.src = src
+
+    def test_add_attribute_works_for_point_data(self):
+        # Given
+        src = self.src
+        s1 = src.scalar_data
+
+        # When
+        s2 = s1.ravel() + 1.0
+        src.add_attribute(s2, 's2')
+        v1 = numpy.ones((4, 3))
+        src.add_attribute(v1, 'v1')
+        t1 = numpy.ones((4, 9))
+        src.add_attribute(t1, 't1')
+
+        # Then
+        self.assertTrue(
+            numpy.allclose(
+                src.image_data.point_data.get_array('s2').to_array(), s2
+            )
+        )
+        self.assertTrue(
+            numpy.allclose(
+                src.image_data.point_data.get_array('v1').to_array(), v1
+            )
+        )
+        self.assertTrue(
+            numpy.allclose(
+                src.image_data.point_data.get_array('t1').to_array(), t1)
+        )
+
+    def test_add_attribute_works_for_cell_data(self):
+        # Given
+        src = self.src
+        s1 = src.scalar_data
+
+        # When
+        s2 = s1.ravel() + 1.0
+        src.add_attribute(s2, 's2', category='cell')
+        v1 = numpy.ones((4, 3))
+        src.add_attribute(v1, 'v1', category='cell')
+        t1 = numpy.ones((4, 9))
+        src.add_attribute(t1, 't1', category='cell')
+
+        # Then
+        self.assertTrue(
+            numpy.allclose(
+                src.image_data.cell_data.get_array('s2').to_array(), s2
+            )
+        )
+        self.assertTrue(
+            numpy.allclose(
+                src.image_data.cell_data.get_array('v1').to_array(), v1
+            )
+        )
+        self.assertTrue(
+            numpy.allclose(
+                src.image_data.cell_data.get_array('t1').to_array(), t1
+            )
+        )
+
+    def test_add_attribute_raises_errors(self):
+        # Given
+        src = self.src
+
+        # When/Then
+        data = numpy.ones((4, 3, 3))
+        self.assertRaises(AssertionError, src.add_attribute, data, 's2')
+
+        data = numpy.ones((4, 5))
+        self.assertRaises(AssertionError, src.add_attribute, data, 's2')
+
+    def test_remove_attribute(self):
+        # Given
+        src = self.src
+        s1 = src.scalar_data
+
+        # When
+        s2 = s1.ravel() + 1.0
+        src.add_attribute(s2, 's2')
+        src.remove_attribute('s2')
+
+        # Then
+        self.assertEqual(src.image_data.point_data.get_array('s2'), None)
+        self.assertTrue(
+            numpy.allclose(
+                src.image_data.point_data.get_array('s1').to_array(),
+                s1.ravel()
+            )
+        )
+
+    def test_rename_attribute(self):
+        # Given
+        src = self.src
+        s1 = src.scalar_data
+        s2 = s1.ravel() + 1.0
+        src.add_attribute(s2, 's2')
+
+        # When
+        src.rename_attribute('s2', 's3')
+
+        # Then
+        self.assertTrue(
+            numpy.all(src.image_data.point_data.get_array('s3') == s2)
+        )
+        self.assertEqual(src.image_data.point_data.get_array('s2'), None)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This makes it very easy to add new scalar/vector/tensor attributes to
either a VTKDataSource or to an ArraySource.  This is very convenient
while scripting.  With this we can now do `add_attribute, remove_attribute`, and `rename_attribute`.