### PR TITLE
fix upper case extension

### DIFF
--- a/tvtk/pyface/tvtk_scene.py
+++ b/tvtk/pyface/tvtk_scene.py
@@ -407,7 +407,7 @@ class TVTKScene(HasPrivateTraits):
             raise ValueError(
                 'Unable to find suitable image type for given file extension.'
             )
-        meth = getattr(self, 'save_' + meth_map[ext])
+        meth = getattr(self, 'save_' + meth_map[ext.lower()])
         if size is not None:
             orig_size = self.get_size()
             self.set_size(size)


### PR DESCRIPTION
pyface will throw a KeyError if a filename with an upper case extension like "my_image.PNG" it entered in the textbox as the extension is not in the `meth_map`.

