### PR TITLE
Fix wrapping VTK's Get* methods

### DIFF
--- a/mayavi/sources/vtk_data_source.py
+++ b/mayavi/sources/vtk_data_source.py
@@ -292,7 +292,7 @@ class VTKDataSource(Source):
             self.configure_input_data(aa, new)
             self._update_data()
             aa.update()
-            self.outputs = [aa.output]
+            self.outputs = [aa]
         else:
             self.outputs = [self.data]
         self.data_changed = True

--- a/tvtk/tests/test_array_handler.py
+++ b/tvtk/tests/test_array_handler.py
@@ -162,17 +162,18 @@ class TestArrayHandler(unittest.TestCase):
 
         # Make sure the code at least runs for all the non-complex
         # numerical dtypes in numpy.
+        float_types = [x for x in numpy.sctypes['float']
+                       if x().dtype.name not in ('float16', 'float128')]
         for dtype in (numpy.sctypes['int'] + numpy.sctypes['uint'] +
-                            numpy.sctypes['float']):
+                      float_types):
             array_handler.array2vtk(numpy.zeros((1,), dtype=dtype))
-
 
     def test_arr2cell_array(self):
         """Test Numeric array to vtkCellArray conversion."""
         # Test list of lists.
         a = [[0], [1, 2], [3, 4, 5], [6, 7, 8, 9]]
         cells = array_handler.array2vtkCellArray(a)
-        z = numpy.array([1, 0, 2, 1,2, 3, 3,4,5, 4, 6,7,8,9])
+        z = numpy.array([1, 0, 2, 1, 2, 3, 3, 4, 5, 4, 6, 7, 8, 9])
         arr = array_handler.vtk2array(cells.GetData())
         self.assertEqual(numpy.sum(arr - z), 0)
         self.assertEqual(len(arr.shape), 1)
@@ -314,7 +315,7 @@ class TestArrayHandler(unittest.TestCase):
                                   args[i], sigs[i])
             else:
                 s = array_handler.get_correct_sig(args[i], sigs[i])
-                #print s, res[i]
+                #print(s, res[i])
                 self.assertEqual(s, res[i])
 
     def test_deref_array(self):

--- a/tvtk/tests/test_browser.py
+++ b/tvtk/tests/test_browser.py
@@ -1,0 +1,119 @@
+import unittest
+
+from tvtk.api import tvtk
+from tvtk.pipeline.browser import SimpleTreeGenerator, FullTreeGenerator
+
+
+class TestSimpleTreeGenerator(unittest.TestCase):
+    def setUp(self):
+        self.cs = cs = tvtk.ConeSource()
+        self.ef = ef = tvtk.ElevationFilter(input_connection=cs.output_port)
+        self.m = m = tvtk.PolyDataMapper(input_connection=ef.output_port)
+        self.a = tvtk.Actor(mapper=m)
+
+    def _make_tree_generator(self):
+        return SimpleTreeGenerator()
+
+    def test_has_children_is_correct(self):
+        # Given/When
+        tg = self._make_tree_generator()
+
+        # Then
+        self.assertEqual(tg.has_children(self.cs), True)
+        self.assertEqual(tg.has_children(self.a), True)
+        self.assertEqual(tg.has_children(self.m), True)
+        self.assertEqual(tg.has_children(self.ef), True)
+        self.assertEqual(tg.has_children(self.a.property), False)
+
+    def test_get_children(self):
+        # Given
+        tg = self._make_tree_generator()
+
+        # When/Then
+        kids = tg.get_children(self.cs)
+        self.assertEqual(len(kids), 0)
+
+        kids = tg.get_children(self.ef)
+        self.assertEqual(len(kids), 1)
+        self.assertEqual(list(kids.values()), [[self.cs]])
+
+        kids = tg.get_children(self.m)
+        self.assertEqual(len(kids), 2)
+        self.assertEqual(kids['input'], [self.ef])
+        self.assertEqual(kids['lookup_table'], self.m.lookup_table)
+
+        kids = tg.get_children(self.a)
+        self.assertEqual(len(kids), 3)
+        self.assertEqual(kids['mapper'], self.m)
+        self.assertEqual(kids['property'], self.a.property)
+        self.assertEqual(kids['texture'], None)
+
+
+class TestFullTreeGenrator(TestSimpleTreeGenerator):
+    def _make_tree_generator(self):
+        return FullTreeGenerator()
+
+    def test_has_children_is_correct(self):
+        # Given/When
+        tg = self._make_tree_generator()
+
+        # Then
+        self.assertEqual(tg.has_children(self.cs), True)
+        self.assertEqual(tg.has_children(self.a), True)
+        self.assertEqual(tg.has_children(self.m), True)
+        self.assertEqual(tg.has_children(self.ef), True)
+        self.assertEqual(tg.has_children(self.a.property), True)
+
+    def test_get_children(self):
+        # Given
+        tg = self._make_tree_generator()
+
+        # When/Then
+        kids = tg.get_children(self.cs)
+        self.assertEqual(len(kids), 0)
+
+        kids = tg.get_children(self.ef)
+        self.assertEqual(len(kids), 1)
+        self.assertEqual(list(kids.values()), [[self.cs]])
+
+        kids = tg.get_children(self.m)
+        self.assertEqual(len(kids), 3)
+        self.assertEqual(kids['input'], [self.ef])
+        self.assertEqual(kids['lookup_table'], self.m.lookup_table)
+
+        kids = tg.get_children(self.a)
+        self.assertEqual(len(kids), 7)
+        self.assertEqual(kids['mapper'], self.m)
+        self.assertEqual(kids['property'], self.a.property)
+        self.assertEqual(kids['texture'], None)
+        self.assertEqual(kids['user_transform'], None)
+        self.assertEqual(kids['user_matrix'], None)
+
+    def test_glyph_pipeline(self):
+        # Given
+        rta = tvtk.RTAnalyticSource()
+        cs = tvtk.ConeSource()
+        g = tvtk.Glyph3D(input_connection=rta.output_port)
+        g.set_source_connection(cs.output_port)
+        m = tvtk.PolyDataMapper(input_connection=g.output_port)
+
+        tg = self._make_tree_generator()
+
+        # When/Then
+        kids = tg.get_children(cs)
+        self.assertEqual(len(kids), 0)
+        kids = tg.get_children(rta)
+        self.assertEqual(len(kids), 0)
+
+        kids = tg.get_children(g)
+        self.assertEqual(len(kids), 2)
+        self.assertEqual(kids['input'], [rta, cs])
+
+        kids = tg.get_children(m)
+        self.assertEqual(len(kids), 3)
+        self.assertEqual(kids['input'], [g])
+        self.assertEqual(kids['lookup_table'], m.lookup_table)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tvtk/tests/test_tvtk.py
+++ b/tvtk/tests/test_tvtk.py
@@ -833,6 +833,13 @@ class TestTVTK(unittest.TestCase):
         self.assertTrue(hasattr(klass, 'set_matrix'))
         self.assertTrue(hasattr(klass, 'get_matrix'))
 
+    def test_algorithm_methods_are_wrapped(self):
+        x = tvtk.Algorithm()
+        self.assertTrue(hasattr(x, 'get_input_algorithm'))
+        self.assertTrue(callable(x.get_input_algorithm))
+        # It should also expose input_algorithm as a property trait.
+        self.assertTrue(hasattr(x, 'input_algorithm'))
+
 
 # This separates out any tests for the entire module that would affect
 # the functioning of the other tests.

--- a/tvtk/wrapper_gen.py
+++ b/tvtk/wrapper_gen.py
@@ -903,9 +903,9 @@ class WrapperGenerator:
         meths = parser.get_get_methods()
         for m in meths:
             vtk_get_meth = getattr(klass, m)
-            if m == 'GetOutput': # GetOutput is special.
+            if m == 'GetOutput':  # GetOutput is special.
                 self._write_get_output_method(klass, out, set=False)
-            elif m == 'GetInput': # GetInput is special.
+            elif m == 'GetInput':  # GetInput is special.
                 self._write_pure_get_input_method(klass, out)
             elif m == 'GetOutputPort':
                 # This method sometimes prints warnings so we handle
@@ -914,19 +914,22 @@ class WrapperGenerator:
             else:
                 name = self._reform_name(m[3:])
                 sig = parser.get_method_signature(vtk_get_meth)
-                simple_get = 0
+                write_prop = False
+                write_getter = False
                 if len(sig) == 1 and sig[0][1] is None:
-                    simple_get = 1
+                    write_prop = True
                 elif len(sig) > 1:
+                    # The method has multiple signatures so write the getter.
+                    write_getter = True
                     for i in sig:
                         if i[1] is None:
-                            simple_get = 1
+                            # There is a getter which takes no args too, so
+                            # expose that as a property.
+                            write_prop = True
                             break
-                if simple_get:
+                if write_prop:
                     self._write_property(out, name, vtk_get_meth, None)
-                else:
-                    # Cannot be represented as a simple property,
-                    # so we wrap it as a plain old method.
+                if write_getter:
                     self._write_tvtk_method(klass, out, vtk_get_meth, sig)
 
     def _gen_other_methods(self, klass, out):

--- a/tvtk/wrapper_gen.py
+++ b/tvtk/wrapper_gen.py
@@ -915,12 +915,12 @@ class WrapperGenerator:
                 name = self._reform_name(m[3:])
                 sig = parser.get_method_signature(vtk_get_meth)
                 write_prop = False
-                write_getter = False
+                write_getter = True
                 if len(sig) == 1 and sig[0][1] is None:
                     write_prop = True
+                    # No need for a getter in this case.
+                    write_getter = False
                 elif len(sig) > 1:
-                    # The method has multiple signatures so write the getter.
-                    write_getter = True
                     for i in sig:
                         if i[1] is None:
                             # There is a getter which takes no args too, so


### PR DESCRIPTION
- Fix array handler tests for newer numpy versions. These versions have a float16/float128 dtype which are not directly supported in VTK.
- BUG: wrap the `Get` methods correctly.  Many of the new pipeline methods were not wrapped correctly.  For example the `vtkAlgorithm.GetInputAlgorithm` has multiple signatures. TVTK was wrapping any getter which had one of its signatures with no args as a pure property and not exposing the method itself.  This means that users cannot call `obj.get_input_algorithm(0, 0)` which is broken. We now wrap the no arg call as a property but also wrap the generic method as a callable method.
- Fix the pipeline browser for the new pipeline. 
- Add a few reasonable tests for the browser