### PR TITLE
Allow adding a vtkAlgorithm to the Mayavi pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.enamlc
 *~
 .DS_Store
+_configtest.*
 
 # ignore the build directories
 *.egg-info/

--- a/mayavi/sources/vtk_object_source.py
+++ b/mayavi/sources/vtk_object_source.py
@@ -1,0 +1,114 @@
+from traits.api import Bool, Instance, Int
+from traitsui.api import Item, Group, View
+
+import vtk
+from tvtk.common import camel2enthought
+from tvtk.api import tvtk
+from tvtk import messenger
+from tvtk.pipeline.browser import PipelineBrowser
+
+from mayavi.core.source import Source
+from mayavi.core.pipeline_info import PipelineInfo
+
+
+def _create_dataset_name_map():
+    names = ['vtkImageData', 'vtkPolyData',
+             'vtkRectilinearGrid', 'vtkStructuredGrid',
+             'vtkUnstructuredGrid']
+    mapping = {x: camel2enthought(x)[4:] for x in names}
+    mapping['vtkStructuredPoints'] = 'image_data'
+    mapping['vtkDataSet'] = 'any'
+    return mapping
+
+
+_dataset_name_map = _create_dataset_name_map()
+
+
+def tvtk_dataset_name(name):
+    return _dataset_name_map.get(name, 'none')
+
+
+def get_tvtk_dataset_name(obj):
+    v = tvtk.to_vtk(obj)
+    obj = v.GetOutputInformation(0).Get(vtk.vtkDataObject.DATA_OBJECT())
+    if obj is not None:
+        name = obj.GetClassName()
+    else:
+        name = v.GetOutputPortInformation(0).Get(
+            vtk.vtkDataObject.DATA_TYPE_NAME()
+        )
+        if name is None:
+            # Try again after calling update
+            v.Update()
+            return get_tvtk_dataset_name(v)
+    return [tvtk_dataset_name(name)]
+
+
+class VTKObjectSource(Source):
+
+    """A simple wrapper to allow us to be able to add an arbitrary VTK object as a
+    source into the Mayavi pipeline. This is convenient when one wishes to use
+    an existing VTK object which produces some output.
+
+    """
+
+    # The version of this class.  Used for persistence.
+    __version__ = 0
+
+    # The VTK algorithm to manage.
+    object = Instance(tvtk.Algorithm, allow_none=False)
+
+    browser = Instance(PipelineBrowser)
+
+    # Information about what this object can produce.
+    output_info = PipelineInfo(datasets=['any'],
+                               attribute_types=['any'],
+                               attributes=['any'])
+
+    view = View(
+        Group(
+            Item(
+                name='browser', show_label=False,
+                style='custom', resizable=True
+            )
+        )
+    )
+
+    # The ID of the observer for the data.
+    _observer_id = Int(-1)
+
+    # ## Private protocol #############################################
+
+    def _object_changed(self, old, new):
+        self.outputs = [new]
+
+        self.browser.root_object = [new]
+
+        self.output_info.datasets = get_tvtk_dataset_name(new)
+
+        if old is not None:
+            old.remove_observer(self._observer_id)
+        self._observer_id = new.add_observer(
+            'ModifiedEvent', messenger.send
+        )
+        new_vtk = tvtk.to_vtk(new)
+        messenger.connect(new_vtk, 'ModifiedEvent', self._fire_data_changed)
+
+        self.name = self._get_name()
+
+    def _fire_data_changed(self, *args):
+        self.data_changed = True
+
+    def _get_name(self):
+        result = 'VTK (uninitialized)'
+        if self.object is not None:
+            typ = self.object.__class__.__name__
+            result = "VTK (%s)" % typ
+        if '[Hidden]' in self.name:
+            result += ' [Hidden]'
+        return result
+
+    def _browser_default(self):
+        b = PipelineBrowser()
+        b.on_trait_change(self._fire_data_changed, 'object_edited')
+        return b

--- a/mayavi/tests/test_mlab_integration.py
+++ b/mayavi/tests/test_mlab_integration.py
@@ -14,6 +14,8 @@ import numpy as np
 from numpy.testing import assert_allclose
 from traits.testing.unittest_tools import UnittestTools
 
+import vtk
+
 from mayavi import mlab
 from mayavi.core.engine import Engine
 from tvtk.api import tvtk
@@ -89,9 +91,6 @@ class TestMlabNullEngineMisc(TestMlabNullEngine):
         self.assertTrue(isinstance(density.get_output_dataset(), tvtk.ImageData))
 
     def test_mlab_source(self):
-        """ Check that the different objects created by mlab have an
-            'mlab_source' attribute.
-        """
         # Test for functions taking 3D scalar data
         pipelines = (
             (mlab.pipeline.scalar_scatter, ),
@@ -123,6 +122,18 @@ class TestMlabNullEngineMisc(TestMlabNullEngine):
             for factory in pipeline[1:]:
                 obj = factory(obj)
             self.assertTrue(hasattr(obj, 'mlab_source'))
+
+    def test_add_dataset_works_with_vtk_datasets(self):
+        # Given
+        pd = vtk.vtkPolyData()
+        # When
+        mlab.pipeline.add_dataset(pd)
+        # Then
+        e = mlab.get_engine()
+        src = e.scenes[0].children[0]
+        from mayavi.sources.vtk_data_source import VTKDataSource
+        self.assertTrue(isinstance(src, VTKDataSource))
+        self.assertEqual(tvtk.to_vtk(src.data), pd)
 
     def test_figure(self):
         """ Various tests for mlab.figure().

--- a/mayavi/tests/test_vtk_object_source.py
+++ b/mayavi/tests/test_vtk_object_source.py
@@ -3,6 +3,7 @@ import unittest
 from tvtk.api import tvtk
 
 from mayavi.sources.vtk_object_source import VTKObjectSource
+from mayavi.sources.vtk_data_source import VTKDataSource
 from mayavi import mlab
 
 from .test_mlab_integration import TestMlabNullEngine
@@ -55,6 +56,16 @@ class TestVTKObjectSource(TestMlabNullEngine):
 
         # Then
         self.assertTrue(self.count > 0)
+
+    def test_add_dataset_uses_vtk_data_source_for_datasets(self):
+        # Given
+        pd = tvtk.PolyData()
+
+        # When
+        src = mlab.pipeline.add_dataset(pd)
+
+        # Then
+        self.assertTrue(isinstance(src, VTKDataSource))
 
 
 if __name__ == '__main__':

--- a/mayavi/tests/test_vtk_object_source.py
+++ b/mayavi/tests/test_vtk_object_source.py
@@ -1,0 +1,61 @@
+import unittest
+
+from tvtk.api import tvtk
+
+from mayavi.sources.vtk_object_source import VTKObjectSource
+from mayavi import mlab
+
+from .test_mlab_integration import TestMlabNullEngine
+
+
+class TestVTKObjectSource(TestMlabNullEngine):
+    def test_simple_vtk_object_source(self):
+        # Given
+        cs = tvtk.ConeSource()
+        ef = tvtk.ElevationFilter(input_connection=cs.output_port)
+        engine = self.e
+
+        # When
+        src = VTKObjectSource(object=ef)
+        engine.add_source(src)
+
+        # Then
+        self.assertEqual(src.outputs[0], ef)
+        self.assertEqual(src.browser.root_object, [ef])
+        self.assertEqual(src.output_info.datasets, ['any'])
+        self.assertEqual(src.name, 'VTK (ElevationFilter)')
+
+        # When
+        src.object = cs
+
+        # Then
+        self.assertEqual(src.outputs[0], cs)
+        self.assertEqual(src.browser.root_object, [cs])
+        self.assertEqual(src.output_info.datasets, ['poly_data'])
+        self.assertEqual(src.name, 'VTK (ConeSource)')
+
+    def test_data_changed_is_fired_when_object_is_modified(self):
+        # Given
+        cs = tvtk.ConeSource()
+
+        # When
+        src = mlab.pipeline.add_dataset(cs)
+
+        # Then
+        self.assertTrue(isinstance(src, VTKObjectSource))
+
+        # When
+        self.count = 0
+
+        def callback():
+            self.count += 1
+
+        src.on_trait_change(callback, 'data_changed')
+        cs.height = 2.0
+
+        # Then
+        self.assertTrue(self.count > 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/mayavi/tools/tools.py
+++ b/mayavi/tools/tools.py
@@ -10,6 +10,8 @@ The general purpose tools to manipulate the pipeline with the mlab interface.
 # Standard library imports.
 import numpy
 
+import vtk
+
 # Enthought library imports.
 from tvtk.api import tvtk
 
@@ -31,7 +33,7 @@ def add_dataset(dataset, name='', **kwargs):
 
     **Parameters**
 
-    :dataset: a tvtk dataset, or a Mayavi source.
+    :dataset: a tvtk/vtk dataset, or a Mayavi source.
               The dataset added to the Mayavi pipeline
     :figure: a figure identifier number or string, None or False, optionnal.
 
@@ -51,19 +53,19 @@ def add_dataset(dataset, name='', **kwargs):
 
     The corresponding Mayavi source is returned.
     """
-    if isinstance(dataset, tvtk.Object):
+    if isinstance(dataset, (tvtk.Object, vtk.vtkObjectBase)):
         d = VTKDataSource()
-        d.data = dataset
+        d.data = tvtk.to_tvtk(dataset)
     elif isinstance(dataset, Source):
         d = dataset
     else:
         raise TypeError(
-              "first argument should be either a TVTK object"\
+              "first argument should be either a TVTK object"
               " or a mayavi source")
 
     if len(name) > 0:
         d.name = name
-    if not 'figure' in kwargs:
+    if 'figure' not in kwargs:
         # No figure has been specified, retrieve the default one.
         gcf()
         engine = get_engine()

--- a/tvtk/pipeline/browser.py
+++ b/tvtk/pipeline/browser.py
@@ -626,6 +626,7 @@ class PipelineBrowser(HasTraits):
     # Private traits.
     # The root of the tree to display.
     _root = Any
+    _ui = Any
 
     ###########################################################################
     # `object` interface.
@@ -643,7 +644,7 @@ class PipelineBrowser(HasTraits):
 
         """
         super(PipelineBrowser, self).__init__(**traits)
-        self.ui = None
+        self._ui = None
         self.view = None
         if renwin:
             self.renwins.append(renwin)
@@ -685,9 +686,9 @@ class PipelineBrowser(HasTraits):
         `parent` widget is passed, the tree is displayed inside the
         passed parent widget."""
         # If UI already exists, raise it and return.
-        if self.ui and self.ui.control:
+        if self._ui and self._ui.control:
             try:
-                self.ui.control.Raise()
+                self._ui.control.Raise()
             except AttributeError:
                 pass
             else:
@@ -696,18 +697,18 @@ class PipelineBrowser(HasTraits):
             # No active ui, create one.
             view = self.default_traits_view()
             if parent:
-                self.ui = view.ui(self, parent=parent, kind='subpanel')
+                self._ui = view.ui(self, parent=parent, kind='subpanel')
             else:
-                self.ui = view.ui(self, parent=parent)
+                self._ui = view.ui(self, parent=parent)
 
     def update(self):
         """Update the tree view."""
         # This is a hack.
-        if self.ui and self.ui.control:
+        if self._ui and self._ui.control:
             try:
-                ed = self.ui._editors[0]
+                ed = self._ui._editors[0]
                 ed.update_editor()
-                self.ui.control.Refresh()
+                self._ui.control.Refresh()
             except (AttributeError, IndexError):
                 pass
     # Another name for update.

--- a/tvtk/tests/test_browser.py
+++ b/tvtk/tests/test_browser.py
@@ -109,7 +109,7 @@ class TestFullTreeGenrator(TestSimpleTreeGenerator):
         self.assertEqual(kids['user_matrix'], None)
 
         kids = tg.get_children(self.ren)
-        self.assertEqual(len(kids), 7)
+        self.assertTrue(len(kids) in [6, 7])
         self.assertEqual(kids['view_props'][0], self.a)
         self.assertEqual(len(kids['view_props']), 1)
         self.assertTrue(kids['active_camera'].is_a('vtkCamera'))

--- a/tvtk/tests/test_browser.py
+++ b/tvtk/tests/test_browser.py
@@ -115,7 +115,7 @@ class TestFullTreeGenrator(TestSimpleTreeGenerator):
         self.assertTrue(kids['active_camera'].is_a('vtkCamera'))
 
         kids = tg.get_children(self.renwin)
-        self.assertEqual(len(kids), 1)
+        self.assertTrue(len(kids) > 0 and len(kids) < 3)
         self.assertEqual(kids['renderers'][0], self.ren)
 
     def test_glyph_pipeline(self):

--- a/tvtk/tests/test_browser.py
+++ b/tvtk/tests/test_browser.py
@@ -1,7 +1,8 @@
 import unittest
 
 from tvtk.api import tvtk
-from tvtk.pipeline.browser import SimpleTreeGenerator, FullTreeGenerator
+from tvtk.pipeline.browser import (SimpleTreeGenerator, FullTreeGenerator,
+                                   PipelineBrowser)
 
 
 class TestSimpleTreeGenerator(unittest.TestCase):
@@ -10,6 +11,10 @@ class TestSimpleTreeGenerator(unittest.TestCase):
         self.ef = ef = tvtk.ElevationFilter(input_connection=cs.output_port)
         self.m = m = tvtk.PolyDataMapper(input_connection=ef.output_port)
         self.a = tvtk.Actor(mapper=m)
+        self.ren = tvtk.Renderer()
+        self.ren.add_actor(self.a)
+        self.renwin = tvtk.RenderWindow()
+        self.renwin.add_renderer(self.ren)
 
     def _make_tree_generator(self):
         return SimpleTreeGenerator()
@@ -24,6 +29,8 @@ class TestSimpleTreeGenerator(unittest.TestCase):
         self.assertEqual(tg.has_children(self.m), True)
         self.assertEqual(tg.has_children(self.ef), True)
         self.assertEqual(tg.has_children(self.a.property), False)
+        self.assertEqual(tg.has_children(self.ren), True)
+        self.assertEqual(tg.has_children(self.renwin), True)
 
     def test_get_children(self):
         # Given
@@ -48,6 +55,16 @@ class TestSimpleTreeGenerator(unittest.TestCase):
         self.assertEqual(kids['property'], self.a.property)
         self.assertEqual(kids['texture'], None)
 
+        kids = tg.get_children(self.ren)
+        self.assertEqual(len(kids), 2)
+        self.assertEqual(kids['view_props'][0], self.a)
+        self.assertEqual(len(kids['view_props']), 1)
+        self.assertTrue(kids['active_camera'].is_a('vtkCamera'))
+
+        kids = tg.get_children(self.renwin)
+        self.assertEqual(len(kids), 1)
+        self.assertEqual(kids['renderers'][0], self.ren)
+
 
 class TestFullTreeGenrator(TestSimpleTreeGenerator):
     def _make_tree_generator(self):
@@ -63,6 +80,8 @@ class TestFullTreeGenrator(TestSimpleTreeGenerator):
         self.assertEqual(tg.has_children(self.m), True)
         self.assertEqual(tg.has_children(self.ef), True)
         self.assertEqual(tg.has_children(self.a.property), True)
+        self.assertEqual(tg.has_children(self.ren), True)
+        self.assertEqual(tg.has_children(self.renwin), True)
 
     def test_get_children(self):
         # Given
@@ -89,6 +108,16 @@ class TestFullTreeGenrator(TestSimpleTreeGenerator):
         self.assertEqual(kids['user_transform'], None)
         self.assertEqual(kids['user_matrix'], None)
 
+        kids = tg.get_children(self.ren)
+        self.assertEqual(len(kids), 7)
+        self.assertEqual(kids['view_props'][0], self.a)
+        self.assertEqual(len(kids['view_props']), 1)
+        self.assertTrue(kids['active_camera'].is_a('vtkCamera'))
+
+        kids = tg.get_children(self.renwin)
+        self.assertEqual(len(kids), 1)
+        self.assertEqual(kids['renderers'][0], self.ren)
+
     def test_glyph_pipeline(self):
         # Given
         rta = tvtk.RTAnalyticSource()
@@ -113,6 +142,43 @@ class TestFullTreeGenrator(TestSimpleTreeGenerator):
         self.assertEqual(len(kids), 3)
         self.assertEqual(kids['input'], [g])
         self.assertEqual(kids['lookup_table'], m.lookup_table)
+
+
+class TestPipelineBrowser(unittest.TestCase):
+    def test_simple_usage(self):
+        # Given
+        cs = tvtk.ConeSource()
+        ef = tvtk.ElevationFilter(input_connection=cs.output_port)
+
+        # When
+        p = PipelineBrowser(root_object=[ef])
+
+        # Then
+        self.assertEqual(len(p._root.children), 1)
+        kids = list(p._root.children)
+        self.assertEqual(kids[0].name, 'ElevationFilter')
+        gk = list(kids[0].children)
+        self.assertEqual(len(gk), 1)
+        self.assertEqual(gk[0].name, 'ConeSource')
+        ggk = list(gk[0].children)
+        self.assertEqual(len(ggk), 0)
+
+        # Check if the default traits_view returns correctly.
+        p.default_traits_view()
+
+        # When
+        # Check if editing a selected object fires a ui change.
+        self.count = 0
+
+        def callback():
+            self.count += 1
+
+        p.on_trait_change(callback, 'object_edited')
+        p._on_select(gk[0])
+        cs.height = 2.0
+
+        # Then
+        self.assertTrue(self.count > 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Allow `mlab.pipeline.add_dataset` to also accept raw VTK objects.
- Generalize the TVTK pipeline browser so it can be plugged into other HasTraits objects easily.
- Add tests for the pipeline browser.
- Add a `VTKObjectSource` to Mayavi:
   - allows us to add any VTK algorithm to the mayavi pipeline and then process that with the rest of Mayavi.
   - It provides a convenient UI to configure the raw TVTK objects.
   - these can be added to the pipeline with `mlab.pipeline.add_dataset`.
   - does not yet support user-defined algorithms via subclasses of
  VTKPythonAlgorithmBase.