### PR TITLE
Wrap user defined algorithm

### DIFF
--- a/tvtk/code_gen.py
+++ b/tvtk/code_gen.py
@@ -7,7 +7,7 @@
 
 from __future__ import print_function
 
-import vtk
+import vtk_module as vtk
 import os
 import os.path
 import zipfile
@@ -86,7 +86,7 @@ class TVTKGenerator:
         v = vtk.vtkVersion()
         vtk_version = v.GetVTKVersion()[:3]
         vtk_src_version = v.GetVTKSourceVersion()
-        code ="vtk_build_version = \'%s\'\n"%(vtk_version)
+        code = "vtk_build_version = \'%s\'\n"%(vtk_version)
         code += "vtk_build_src_version = \'%s\'\n"%(vtk_src_version)
 
         with open(os.path.join(out_dir, 'vtk_version.py'), 'w') as f:
@@ -100,14 +100,16 @@ class TVTKGenerator:
             tree = wrap_gen.get_tree().tree
 
             classes = []
+            # This is another class we should not wrap and exists
+            # in version 8.1.0.
+            ignore = ['vtkOpenGLGL2PSHelperImpl']
+            include = ['VTKPythonAlgorithmBase']
             for node in wrap_gen.get_tree():
                 name = node.name
-                # This is another class we should not wrap and exists
-                # in version 8.1.0.
-                ignore = ['vtkOpenGLGL2PSHelperImpl']
                 if name in ignore:
                     continue
-                if not name.startswith('vtk') or name.startswith('vtkQt'):
+                if (name not in include and not name.startswith('vtk')) or \
+                    name.startswith('vtkQt'):
                     continue
                 if not hasattr(vtk, name) or not hasattr(getattr(vtk, name), 'IsA'):  # noqa
                     # We need to wrap VTK classes that are derived

--- a/tvtk/special_gen.py
+++ b/tvtk/special_gen.py
@@ -513,6 +513,17 @@ class HelperGenerator:
                 mod = __import__('tvtk.tvtk_classes.%%s'%%fname, globals(), locals(), [fname])
             return mod
 
+        def get_nearest_base_class(obj):
+            base = None
+            cls = obj.__class__.__bases__[0]
+            while base is None:
+                try:
+                    tvtk_name = get_tvtk_name(cls.__name__)
+                    base = get_class(tvtk_name)
+                except ImportError:
+                    cls = cls.__bases__[0]
+            return base
+
         def get_class(name):
             if name in _cache:
                 return _cache[name]
@@ -532,7 +543,10 @@ class HelperGenerator:
                 if cached_obj is not None:
                     return cached_obj
                 cname = get_tvtk_name(obj.__class__.__name__)
-                tvtk_class = get_class(cname)
+                try:
+                    tvtk_class = get_class(cname)
+                except ImportError:
+                    tvtk_class = get_nearest_base_class(obj)
                 return tvtk_class(obj)
             else:
                 return obj

--- a/tvtk/tests/test_tvtk.py
+++ b/tvtk/tests/test_tvtk.py
@@ -868,6 +868,29 @@ class TestTVTK(unittest.TestCase):
         self.assertTrue(isinstance(x, tvtk.ContourFilter))
         self.assertTrue(v is x._vtk_obj)
 
+    def test_to_tvtk_wraps_subclass_of_vtk(self):
+        # Given
+        class MyAlgorithm(vtk.vtkPythonAlgorithm):
+            pass
+
+        a = MyAlgorithm()
+        # When
+        ta = tvtk.to_tvtk(a)
+
+        # Then
+        self.assertTrue(isinstance(ta, tvtk.PythonAlgorithm))
+
+        # Given
+        class B(MyAlgorithm):
+            pass
+
+        b = B()
+        # When
+        tb = tvtk.to_tvtk(b)
+
+        # Then
+        self.assertTrue(isinstance(tb, tvtk.PythonAlgorithm))
+
 
 # This separates out any tests for the entire module that would affect
 # the functioning of the other tests.

--- a/tvtk/tests/test_tvtk.py
+++ b/tvtk/tests/test_tvtk.py
@@ -840,6 +840,34 @@ class TestTVTK(unittest.TestCase):
         # It should also expose input_algorithm as a property trait.
         self.assertTrue(hasattr(x, 'input_algorithm'))
 
+    def test_vtk_python_algorithm_base_is_wrapped(self):
+        from tvtk import vtk_module
+        name = 'VTKPythonAlgorithmBase'
+        if hasattr(vtk_module, name):
+            self.assertTrue(hasattr(tvtk, name))
+            # Should be able to instantiate this wrapped class.
+            getattr(tvtk, name)()
+
+    def test_to_vtk_returns_vtk_object(self):
+        # Given
+        x = tvtk.ContourFilter()
+        # When
+        v = tvtk.to_vtk(x)
+        # Then
+        self.assertEqual(v.GetClassName(), 'vtkContourFilter')
+        self.assertTrue(v is x._vtk_obj)
+
+    def test_to_tvtk_returns_tvtk_object(self):
+        # Given
+        v = vtk.vtkContourFilter()
+        # When
+        x = tvtk.to_tvtk(v)
+        # Then
+        self.assertEqual(x.class_name, 'vtkContourFilter')
+        self.assertTrue(isinstance(x, tvtk_base.TVTKBase))
+        self.assertTrue(isinstance(x, tvtk.ContourFilter))
+        self.assertTrue(v is x._vtk_obj)
+
 
 # This separates out any tests for the entire module that would affect
 # the functioning of the other tests.

--- a/tvtk/tvtk_base.py
+++ b/tvtk/tvtk_base.py
@@ -322,7 +322,6 @@ class TVTKBase(traits.HasStrictTraits):
         # Initialize the Python attribute.
         self._in_set = 0
         if obj:
-            assert obj.IsA(klass.__name__)
             self._vtk_obj = obj
         else:
             self._vtk_obj = klass()

--- a/tvtk/vtk_module.py
+++ b/tvtk/vtk_module.py
@@ -9,10 +9,14 @@ need to be wrapped.
 """
 
 # Author: Prabhu Ramachandran <prabhu [at] aero.iitb.ac.in>
-# Copyright (c) 2007,  Enthought, Inc.
+# Copyright (c) 2007-2018,  Enthought, Inc.
 # License: BSD Style.
 
 from vtk import *
+try:
+    from vtk.util.vtkAlgorithm import VTKPythonAlgorithmBase
+except ImportError:
+    pass
 
 try:
     from tvtk_local import *


### PR DESCRIPTION
- Ensure VTKPythonAlgorithmBase is wrapped
- `tvtk.to_tvtk` now wraps VTK subclasses by using a nearest base class. This allows us to add VTK objects easily to the mayavi pipeline.