### PR TITLE
Allow adding any tvtk.Object to pipeline.

### DIFF
--- a/mayavi/sources/vtk_object_source.py
+++ b/mayavi/sources/vtk_object_source.py
@@ -21,8 +21,8 @@ class VTKObjectSource(Source):
     # The version of this class.  Used for persistence.
     __version__ = 0
 
-    # The VTK algorithm to manage.
-    object = Instance(tvtk.Algorithm, allow_none=False)
+    # The VTK algorithm/object to manage.
+    object = Instance(tvtk.Object, allow_none=False)
 
     browser = Instance(PipelineBrowser)
 

--- a/mayavi/tests/test_vtk_object_source.py
+++ b/mayavi/tests/test_vtk_object_source.py
@@ -67,6 +67,27 @@ class TestVTKObjectSource(TestMlabNullEngine):
         # Then
         self.assertTrue(isinstance(src, VTKDataSource))
 
+    def test_vtk_object_source_works_with_any_vtk_object(self):
+        # Given
+        a = tvtk.Actor()
+
+        # When/Then
+        src = VTKObjectSource(object=a, actors=[a])
+
+        # Then
+        self.assertEqual(src.object, a)
+        self.assertEqual(src.output_info.datasets, ['none'])
+
+    def test_add_dataset_uses_vtk_object_source_for_objects(self):
+        # Given
+        a = tvtk.Actor()
+
+        # When
+        src = mlab.pipeline.add_dataset(a)
+
+        # Then
+        self.assertTrue(isinstance(src, VTKObjectSource))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/mayavi/tools/tools.py
+++ b/mayavi/tools/tools.py
@@ -76,14 +76,14 @@ def add_dataset(dataset, name='', **kwargs):
     if isinstance(dataset, (tvtk.DataSet, vtk.vtkDataSet)):
         d = VTKDataSource()
         d.data = tvtk.to_tvtk(dataset)
-    elif isinstance(dataset, (tvtk.Algorithm, vtk.vtkAlgorithm)):
-        d = VTKObjectSource()
-        d.object = tvtk.to_tvtk(dataset)
     elif isinstance(dataset, (tvtk.DataObject, vtk.vtkDataObject)):
         d = VTKObjectSource()
         tp = tvtk.TrivialProducer()
         tp.set_output(tvtk.to_tvtk(dataset))
         d.object = tp
+    elif isinstance(dataset, tvtk.Object):
+        d = VTKObjectSource()
+        d.object = tvtk.to_tvtk(dataset)
     elif isinstance(dataset, Source):
         d = dataset
     else:


### PR DESCRIPTION
This is convenient as a user can also create a full visualization and
then simply add the actor to the pipeline via
`mlab.pipeline.add_dataset(actor)`.  If the user simply appends this
actor to the resulting source's actor list it will also be rendered on
the scene.  This is handy when something is doable with VTK but not with
mayavi.