### PR TITLE
DOC: Reword docs for animator function

### DIFF
--- a/mayavi/tools/animator.py
+++ b/mayavi/tools/animator.py
@@ -127,8 +127,7 @@ class Animator(HasTraits):
 # Decorators.
 
 def animate(func=None, delay=500, ui=True, support_movie=True):
-    """A convenient decorator to animate a generator that performs an
-    animation.
+    """A convenient decorator to animate a generator performing an animation.
 
     The `delay` parameter specifies the delay (in milliseconds) between calls
     to the decorated function. If `ui` is True, then a simple UI for the


### PR DESCRIPTION
The first line was too long and broken into a second line, which causes a bad rendering in sphinx:
```
:: A convenient decorator to animate a generator that performs an

    animation.
```
The rewording saves a few characters so that is all fits on one line and shows in sphinx correctly.

[skip ci]