### PR TITLE
Updating for a 4.6.2 release.

### DIFF
--- a/docs/CHANGES.txt
+++ b/docs/CHANGES.txt
@@ -1,3 +1,80 @@
+Mayavi 4.6.2
+============
+
+Thanks to the following who contributed to this release (in alphabetical
+order): solarjoe, François Boulogne, Prabhu Ramachandran (PR), and Ioannis
+Tziakos.
+
+11 pull requests were merged.
+
+This is largely a bugfix release with a few useful enhancements. This will be
+the last release to properly support VTK versions less than 7.0.
+
+Enhancements
+------------
+
+03 Aug 2018 `#695 <https://github.com/enthought/mayavi/pull/695>`_ (PR)
+   - Wrap user defined algorithm
+   - Ensure VTKPythonAlgorithmBase is wrapped
+   - `tvtk.to_tvtk` now wraps VTK subclasses by using a nearest base class.
+     This allows us to add VTK objects easily to the mayavi pipeline.
+
+02 Aug 2018 `#694 <https://github.com/enthought/mayavi/pull/694>`_ (PR)
+   - Allow adding a vtkAlgorithm to the Mayavi pipeline
+   - Allow `mlab.pipeline.add_dataset` to also accept raw VTK objects.
+   - Generalize the TVTK pipeline browser so it can be plugged into other
+     HasTraits objects easily.
+   - Add a `VTKObjectSource` to Mayavi:
+      - allows us to add any VTK algorithm to the mayavi pipeline and then
+        process that with the rest of Mayavi.
+      - It provides a convenient UI to configure the raw TVTK objects.
+      - these can be added to the pipeline with `mlab.pipeline.add_dataset`.
+      - does not yet support user-defined algorithms via subclasses of
+        VTKPythonAlgorithmBase.
+
+25 Jul 2018 `#687 <https://github.com/enthought/mayavi/pull/687>`_ (PR)
+   - Add smart volume mapper
+   - This is a much nicer volume mapper.
+   - Also fix an issue with the tvtk_doc and the recent change to use desc
+     instead of help for the trait metadata.
+
+24 Jul 2018 `#684 <https://github.com/enthought/mayavi/pull/684>`_ (PR)
+   - Use `desc` instead of `help` for traits. This is much more useful than
+     `help` as it shows up nicely as a tooltip for each trait on the UI.
+
+Fixes
+-----
+
+01 Aug 2018 `#693 <https://github.com/enthought/mayavi/pull/693>`_ (PR)
+   - Fix wrapping VTK's Get* methods
+   - Fix array handler tests for newer numpy versions. These versions have a
+     float16/float128 dtype which are not directly supported in VTK.
+   - BUG: wrap the `Get` methods correctly. Many of the new pipeline methods
+     were not wrapped correctly. For example the
+     `vtkAlgorithm.GetInputAlgorithm` has multiple signatures. TVTK was
+     wrapping any getter which had one of its signatures with no args as a
+     pure property and not exposing the method itself. This means that users
+     cannot call `obj.get_input_algorithm(0, 0)` which is broken. We now wrap
+     the no arg call as a property but also wrap the generic method as a
+     callable method.
+   - Fix the pipeline browser for the new pipeline.
+   - Add a few reasonable tests for the browser
+
+30 Jul 2018 `#691 <https://github.com/enthought/mayavi/pull/691>`_ (PR)
+   - Fix issue `#689 <https://github.com/enthought/mayavi/issues/689>`_.
+     The error was because the example uses the old pipeline.
+
+24 Jul 2018 `#683 <https://github.com/enthought/mayavi/pull/683>`_ (PR)
+   - Fix compiler check on windows. The check does not work when msvc is not
+     installed and this should fix it. This allows us to install Mayavi on
+     windows without having a compiler setup!
+
+24 Jul 2018 `#680 <https://github.com/enthought/mayavi/pull/680>`_ (solarjoe)
+   - fix upper case extension pyface will throw a KeyError if a filename with
+     an upper case extension like "my_image.PNG" it entered in the textbox as
+     the extension is not in the `meth_map`.
+
+
 Mayavi 4.6.1
 ============
 

--- a/docs/source/mayavi/auto/changes.rst
+++ b/docs/source/mayavi/auto/changes.rst
@@ -1,3 +1,80 @@
+Mayavi 4.6.2
+============
+
+Thanks to the following who contributed to this release (in alphabetical
+order): solarjoe, François Boulogne, Prabhu Ramachandran (PR), and Ioannis
+Tziakos.
+
+11 pull requests were merged.
+
+This is largely a bugfix release with a few useful enhancements. This will be
+the last release to properly support VTK versions less than 7.0.
+
+Enhancements
+------------
+
+03 Aug 2018 `#695 <https://github.com/enthought/mayavi/pull/695>`_ (PR)
+   - Wrap user defined algorithm
+   - Ensure VTKPythonAlgorithmBase is wrapped
+   - `tvtk.to_tvtk` now wraps VTK subclasses by using a nearest base class.
+     This allows us to add VTK objects easily to the mayavi pipeline.
+
+02 Aug 2018 `#694 <https://github.com/enthought/mayavi/pull/694>`_ (PR)
+   - Allow adding a vtkAlgorithm to the Mayavi pipeline
+   - Allow `mlab.pipeline.add_dataset` to also accept raw VTK objects.
+   - Generalize the TVTK pipeline browser so it can be plugged into other
+     HasTraits objects easily.
+   - Add a `VTKObjectSource` to Mayavi:
+      - allows us to add any VTK algorithm to the mayavi pipeline and then
+        process that with the rest of Mayavi.
+      - It provides a convenient UI to configure the raw TVTK objects.
+      - these can be added to the pipeline with `mlab.pipeline.add_dataset`.
+      - does not yet support user-defined algorithms via subclasses of
+        VTKPythonAlgorithmBase.
+
+25 Jul 2018 `#687 <https://github.com/enthought/mayavi/pull/687>`_ (PR)
+   - Add smart volume mapper
+   - This is a much nicer volume mapper.
+   - Also fix an issue with the tvtk_doc and the recent change to use desc
+     instead of help for the trait metadata.
+
+24 Jul 2018 `#684 <https://github.com/enthought/mayavi/pull/684>`_ (PR)
+   - Use `desc` instead of `help` for traits. This is much more useful than
+     `help` as it shows up nicely as a tooltip for each trait on the UI.
+
+Fixes
+-----
+
+01 Aug 2018 `#693 <https://github.com/enthought/mayavi/pull/693>`_ (PR)
+   - Fix wrapping VTK's Get* methods
+   - Fix array handler tests for newer numpy versions. These versions have a
+     float16/float128 dtype which are not directly supported in VTK.
+   - BUG: wrap the `Get` methods correctly. Many of the new pipeline methods
+     were not wrapped correctly. For example the
+     `vtkAlgorithm.GetInputAlgorithm` has multiple signatures. TVTK was
+     wrapping any getter which had one of its signatures with no args as a
+     pure property and not exposing the method itself. This means that users
+     cannot call `obj.get_input_algorithm(0, 0)` which is broken. We now wrap
+     the no arg call as a property but also wrap the generic method as a
+     callable method.
+   - Fix the pipeline browser for the new pipeline.
+   - Add a few reasonable tests for the browser
+
+30 Jul 2018 `#691 <https://github.com/enthought/mayavi/pull/691>`_ (PR)
+   - Fix issue `#689 <https://github.com/enthought/mayavi/issues/689>`_.
+     The error was because the example uses the old pipeline.
+
+24 Jul 2018 `#683 <https://github.com/enthought/mayavi/pull/683>`_ (PR)
+   - Fix compiler check on windows. The check does not work when msvc is not
+     installed and this should fix it. This allows us to install Mayavi on
+     windows without having a compiler setup!
+
+24 Jul 2018 `#680 <https://github.com/enthought/mayavi/pull/680>`_ (solarjoe)
+   - fix upper case extension pyface will throw a KeyError if a filename with
+     an upper case extension like "my_image.PNG" it entered in the textbox as
+     the extension is not in the `meth_map`.
+
+
 Mayavi 4.6.1
 ============
 

--- a/docs/source/mayavi/auto/mlab_helper_functions.rst
+++ b/docs/source/mayavi/auto/mlab_helper_functions.rst
@@ -125,7 +125,7 @@ see :ref:`running-mlab-scripts` for more info)::
     def test_barchart():
         """ Demo the bar chart plot with a 2D array.
         """
-        s = numpy.abs(numpy.random.random((3, 3)))
+        s = np.abs(np.random.random((3, 3)))
         return barchart(s)
     
                 
@@ -205,7 +205,7 @@ see :ref:`running-mlab-scripts` for more info)::
     from mayavi.mlab import *
     
     def test_contour3d():
-        x, y, z = numpy.ogrid[-5:5:64j, -5:5:64j, -5:5:64j]
+        x, y, z = np.ogrid[-5:5:64j, -5:5:64j, -5:5:64j]
     
         scalars = x * x * 0.5 + y * y + z * z * 2.0
     
@@ -303,10 +303,10 @@ see :ref:`running-mlab-scripts` for more info)::
     def test_contour_surf():
         """Test contour_surf on regularly spaced co-ordinates like MayaVi."""
         def f(x, y):
-            sin, cos = numpy.sin, numpy.cos
+            sin, cos = np.sin, np.cos
             return sin(x + y) + sin(2 * x - y) + cos(3 * x + 4 * y)
     
-        x, y = numpy.mgrid[-7.:7.05:0.1, -5.:5.05:0.05]
+        x, y = np.mgrid[-7.:7.05:0.1, -5.:5.05:0.05]
         s = contour_surf(x, y, f)
         return s
     
@@ -416,11 +416,11 @@ see :ref:`running-mlab-scripts` for more info)::
     from mayavi.mlab import *
     
     def test_flow():
-        x, y, z = numpy.mgrid[-4:4:40j, -4:4:40j, 0:4:20j]
-        r = numpy.sqrt(x ** 2 + y ** 2 + z ** 2 + 0.1)
-        u = y * numpy.sin(r) / r
-        v = -x * numpy.sin(r) / r
-        w = numpy.ones_like(z)*0.05
+        x, y, z = np.mgrid[-4:4:40j, -4:4:40j, 0:4:20j]
+        r = np.sqrt(x ** 2 + y ** 2 + z ** 2 + 0.1)
+        u = y * np.sin(r) / r
+        v = -x * np.sin(r) / r
+        w = np.ones_like(z)*0.05
         obj = flow(u, v, w)
         return obj
     
@@ -494,7 +494,7 @@ see :ref:`running-mlab-scripts` for more info)::
     def test_imshow():
         """ Use imshow to visualize a 2D 10x10 random array.
         """
-        s = numpy.random.random((10, 10))
+        s = np.random.random((10, 10))
         return imshow(s, colormap='gist_earth')
     
                 
@@ -611,12 +611,12 @@ see :ref:`running-mlab-scripts` for more info)::
     def test_mesh():
         """A very pretty picture of spherical harmonics translated from
         the octaviz example."""
-        pi = numpy.pi
-        cos = numpy.cos
-        sin = numpy.sin
+        pi = np.pi
+        cos = np.cos
+        sin = np.sin
         dphi, dtheta = pi / 250.0, pi / 250.0
-        [phi, theta] = numpy.mgrid[0:pi + dphi * 1.5:dphi,
-                                   0:2 * pi + dtheta * 1.5:dtheta]
+        [phi, theta] = np.mgrid[0:pi + dphi * 1.5:dphi,
+                                0:2 * pi + dtheta * 1.5:dtheta]
         m0 = 4
         m1 = 3
         m2 = 2
@@ -713,15 +713,14 @@ see :ref:`running-mlab-scripts` for more info)::
     def test_plot3d():
         """Generates a pretty set of lines."""
         n_mer, n_long = 6, 11
-        pi = numpy.pi
-        dphi = pi / 1000.0
-        phi = numpy.arange(0.0, 2 * pi + 0.5 * dphi, dphi)
+        dphi = np.pi / 1000.0
+        phi = np.arange(0.0, 2 * np.pi + 0.5 * dphi, dphi)
         mu = phi * n_mer
-        x = numpy.cos(mu) * (1 + numpy.cos(n_long * mu / n_mer) * 0.5)
-        y = numpy.sin(mu) * (1 + numpy.cos(n_long * mu / n_mer) * 0.5)
-        z = numpy.sin(n_long * mu / n_mer) * 0.5
+        x = np.cos(mu) * (1 + np.cos(n_long * mu / n_mer) * 0.5)
+        y = np.sin(mu) * (1 + np.cos(n_long * mu / n_mer) * 0.5)
+        z = np.sin(n_long * mu / n_mer) * 0.5
     
-        l = plot3d(x, y, z, numpy.sin(mu), tube_radius=0.025, colormap='Spectral')
+        l = plot3d(x, y, z, np.sin(mu), tube_radius=0.025, colormap='Spectral')
         return l
     
                 
@@ -823,14 +822,12 @@ see :ref:`running-mlab-scripts` for more info)::
     from mayavi.mlab import *
     
     def test_points3d():
-        t = numpy.linspace(0, 4 * numpy.pi, 20)
-        cos = numpy.cos
-        sin = numpy.sin
+        t = np.linspace(0, 4 * np.pi, 20)
     
-        x = sin(2 * t)
-        y = cos(t)
-        z = cos(2 * t)
-        s = 2 + sin(t)
+        x = np.sin(2 * t)
+        y = np.cos(t)
+        z = np.cos(2 * t)
+        s = 2 + np.sin(t)
     
         return points3d(x, y, z, s, colormap="copper", scale_factor=.25)
     
@@ -938,11 +935,11 @@ see :ref:`running-mlab-scripts` for more info)::
     from mayavi.mlab import *
     
     def test_quiver3d():
-        x, y, z = numpy.mgrid[-2:3, -2:3, -2:3]
-        r = numpy.sqrt(x ** 2 + y ** 2 + z ** 4)
-        u = y * numpy.sin(r) / (r + 0.001)
-        v = -x * numpy.sin(r) / (r + 0.001)
-        w = numpy.zeros_like(z)
+        x, y, z = np.mgrid[-2:3, -2:3, -2:3]
+        r = np.sqrt(x ** 2 + y ** 2 + z ** 4)
+        u = y * np.sin(r) / (r + 0.001)
+        v = -x * np.sin(r) / (r + 0.001)
+        w = np.zeros_like(z)
         obj = quiver3d(x, y, z, u, v, w, line_width=3, scale_factor=1)
         return obj
     
@@ -1060,10 +1057,10 @@ see :ref:`running-mlab-scripts` for more info)::
     def test_surf():
         """Test surf on regularly spaced co-ordinates like MayaVi."""
         def f(x, y):
-            sin, cos = numpy.sin, numpy.cos
+            sin, cos = np.sin, np.cos
             return sin(x + y) + sin(2 * x - y) + cos(3 * x + 4 * y)
     
-        x, y = numpy.mgrid[-7.:7.05:0.1, -5.:5.05:0.05]
+        x, y = np.mgrid[-7.:7.05:0.1, -5.:5.05:0.05]
         s = surf(x, y, f)
         #cs = contour_surf(x, y, f, contour_z=0)
         return s
@@ -1184,17 +1181,17 @@ see :ref:`running-mlab-scripts` for more info)::
             triangles.
         """
         n = 8
-        t = numpy.linspace(-numpy.pi, numpy.pi, n)
-        z = numpy.exp(1j * t)
+        t = np.linspace(-np.pi, np.pi, n)
+        z = np.exp(1j * t)
         x = z.real.copy()
         y = z.imag.copy()
-        z = numpy.zeros_like(x)
+        z = np.zeros_like(x)
     
         triangles = [(0, i, i + 1) for i in range(1, n)]
-        x = numpy.r_[0, x]
-        y = numpy.r_[0, y]
-        z = numpy.r_[1, z]
-        t = numpy.r_[0, t]
+        x = np.r_[0, x]
+        y = np.r_[0, y]
+        z = np.r_[1, z]
+        t = np.r_[0, t]
     
         return triangular_mesh(x, y, z, triangles, scalars=t)
     
@@ -1281,7 +1278,7 @@ see :ref:`running-mlab-scripts` for more info)::
     from mayavi.mlab import *
     
     def test_volume_slice():
-        x, y, z = numpy.ogrid[-5:5:64j, -5:5:64j, -5:5:64j]
+        x, y, z = np.ogrid[-5:5:64j, -5:5:64j, -5:5:64j]
     
         scalars = x * x * 0.5 + y * y + z * z * 2.0
     

--- a/docs/source/mayavi/auto/mlab_pipeline_sources.rst
+++ b/docs/source/mayavi/auto/mlab_pipeline_sources.rst
@@ -62,7 +62,7 @@ array2d_source
 builtin_image
 ~~~~~~~~~~~~~
 
-.. function:: builtin_image(metadata=<mayavi.core.metadata.SourceMetadata object at 0x1213bff68>)
+.. function:: builtin_image(metadata=<mayavi.core.metadata.SourceMetadata object at 0x12b7793b8>)
 
     Create a vtk image data source
     
@@ -73,7 +73,7 @@ builtin_image
 builtin_surface
 ~~~~~~~~~~~~~~~
 
-.. function:: builtin_surface(metadata=<mayavi.core.metadata.SourceMetadata object at 0x1213bfeb8>)
+.. function:: builtin_surface(metadata=<mayavi.core.metadata.SourceMetadata object at 0x12bb9b200>)
 
     Create a vtk poly data source
     
@@ -84,7 +84,7 @@ builtin_surface
 chaco_file
 ~~~~~~~~~~
 
-.. function:: chaco_file(metadata=<mayavi.core.metadata.SourceMetadata object at 0x121396ca8>)
+.. function:: chaco_file(metadata=<mayavi.core.metadata.SourceMetadata object at 0x12b6e1938>)
 
     Open a Chaco file
     
@@ -178,7 +178,7 @@ open
 parametric_surface
 ~~~~~~~~~~~~~~~~~~
 
-.. function:: parametric_surface(metadata=<mayavi.core.metadata.SourceMetadata object at 0x1213bfd00>)
+.. function:: parametric_surface(metadata=<mayavi.core.metadata.SourceMetadata object at 0x12bb9b048>)
 
     Create a parametric surface source
     
@@ -189,7 +189,7 @@ parametric_surface
 point_load
 ~~~~~~~~~~
 
-.. function:: point_load(metadata=<mayavi.core.metadata.SourceMetadata object at 0x1213bfe08>)
+.. function:: point_load(metadata=<mayavi.core.metadata.SourceMetadata object at 0x12bb9b150>)
 
     Simulates a point load on a cube of data (for tensors)
     
@@ -429,7 +429,7 @@ vertical_vectors_source
 volume_file
 ~~~~~~~~~~~
 
-.. function:: volume_file(metadata=<mayavi.core.metadata.SourceMetadata object at 0x1213bf0a0>)
+.. function:: volume_file(metadata=<mayavi.core.metadata.SourceMetadata object at 0x12b779048>)
 
     Open a Volume file
     

--- a/docs/source/mayavi/auto/mlab_pipeline_tools.rst
+++ b/docs/source/mayavi/auto/mlab_pipeline_tools.rst
@@ -23,8 +23,9 @@ add_dataset
     
     **Parameters**
     
-    :dataset: a tvtk dataset, or a Mayavi source.
-              The dataset added to the Mayavi pipeline
+    :dataset: a tvtk/vtk dataset/tvtk/VTK Algorithm, or a Mayavi source. The
+              dataset added to the Mayavi pipeline
+    
     :figure: a figure identifier number or string, None or False, optionnal.
     
             If no `figure` keyword argument is given, the data
@@ -42,6 +43,7 @@ add_dataset
     **Returns**
     
     The corresponding Mayavi source is returned.
+    
     
 
     

--- a/mayavi/__init__.py
+++ b/mayavi/__init__.py
@@ -5,7 +5,7 @@
     Part of the Mayavi project of the Enthought Tool Suite.
 """
 
-__version__ = '4.6.2'
+__version__ = '4.7.0.dev0'
 
 __requires__ = [
     'apptools',

--- a/mayavi/__init__.py
+++ b/mayavi/__init__.py
@@ -5,7 +5,7 @@
     Part of the Mayavi project of the Enthought Tool Suite.
 """
 
-__version__ = '4.6.2.dev0'
+__version__ = '4.6.2'
 
 __requires__ = [
     'apptools',


### PR DESCRIPTION
Pushing a 4.6.2 with several fixes most important of which is that it now truly will be pip installable without a compiler on windows.