### PR TITLE
ENH: Feature to disable automatic updates.

### DIFF
--- a/tvtk/api.py
+++ b/tvtk/api.py
@@ -3,7 +3,6 @@
 
 # The external API for tvtk.
 
-
 # The version of TVTK that is installed
 from tvtk.version import version, version as __version__
 
@@ -15,3 +14,5 @@ from vtk.util import colors
 
 # Some miscellaneous functionality.
 from tvtk.misc import write_data
+
+from tvtk.tvtk_base import global_disable_update


### PR DESCRIPTION
This can be very handy at times when the automatic updates can trigger
several changes that are not desirable.  For example on certain VTK
calls, internal ModifiedEvents may be fired which will automatically
call the update_traits method which can be wired to other events
triggering problems.  In these cases one can use the
`global_disable_update` function to temporarily disable updates.

Also fix some PEP8 errors and a few places where the state of the object
could be incorrectly set due to exceptions being raised.