### PR TITLE
Fix bug related to SurfaceSource.scalars

### DIFF
--- a/mayavi/tests/test_mlab_source.py
+++ b/mayavi/tests/test_mlab_source.py
@@ -9,6 +9,7 @@ import unittest
 import numpy as N
 from mock import patch
 
+from tvtk.api import tvtk
 from mayavi.tools import sources
 from mayavi.sources.vtk_data_source import VTKDataSource
 
@@ -572,6 +573,19 @@ class TestMLineSource(unittest.TestCase):
         self.assertTrue(N.allclose(src.y, y + 1))
         self.assertTrue(N.allclose(src.z, z + 1))
 
+    def test_set_without_scalars_attribute_works(self):
+        # Given
+        class MySource(sources.MlabSource):
+            x = sources.ArrayNumberOrNone
+
+        src = MySource(x=1.0, dataset=tvtk.PolyData())
+        src.m_data = VTKDataSource(data=src.dataset)
+
+        # When
+        src.update()
+
+        # Then
+        N.testing.assert_almost_equal(src.x, 1.0)
 
 
 ################################################################################

--- a/mayavi/tools/sources.py
+++ b/mayavi/tools/sources.py
@@ -72,7 +72,8 @@ class MlabSource(HasTraits):
             if md is not None:
                 aa = getattr(md, '_assign_attribute', None)
                 vectors = getattr(self, 'vectors', None)
-                if aa is not None and (self.scalars is not None or
+                scalars = getattr(self, 'scalars', None)
+                if aa is not None and (scalars is not None or
                                        vectors is not None):
                     aa.update()
                 md.data_changed = True


### PR DESCRIPTION
This bug manifests when the SurfaceSource object in question does not have a scalars attribute and many of them do not have this.

This bug is related to #696  and the fix is similar to #699 