### PR TITLE
Try and fix #477.

### DIFF
--- a/tvtk/pyface/tvtk_scene.py
+++ b/tvtk/pyface/tvtk_scene.py
@@ -799,6 +799,8 @@ class TVTKScene(HasPrivateTraits):
         if self.off_screen_rendering:
             if hasattr(tvtk, 'EGLRenderWindow'):
                 renwin = tvtk.EGLRenderWindow()
+            elif hasattr(tvtk, 'OSOpenGLRenderWindow'):
+                renwin = tvtk.OSOpenGLRenderWindow()
             else:
                 renwin = tvtk.RenderWindow()
                 # If we are doing offscreen rendering we set the window size to


### PR DESCRIPTION
If OSMesa is available and user requests an offscreen window, use an
OSOpenGLRenderWindow, this will not require X and can be safely used on
a remote server.