### PR TITLE
FIX: Fix for VTKNoneArray

### DIFF
--- a/mayavi/core/utils.py
+++ b/mayavi/core/utils.py
@@ -70,11 +70,11 @@ class DataSetHelper(object):
         if x is None:
             return None, [0.0, 1.0]
         name, x = x
-        if self._composite:
+        if isinstance(x, dsa.VTKNoneArray):
+            res = [0.0, 1.0]
+        elif self._composite:
             # Don't bother with Nans for composite data for now.
-            if isinstance(x, dsa.VTKNoneArray):
-                res = [0.0, 1.0]
-            elif attr == 'scalars':
+            if attr == 'scalars':
                 res = [algs.min(x), algs.max(x)]
             else:
                 max_norm = np.sqrt(algs.max(algs.sum(x*x, axis=1)))

--- a/mayavi/tests/test_core_utils.py
+++ b/mayavi/tests/test_core_utils.py
@@ -3,6 +3,7 @@ import numpy as np
 
 from tvtk.api import tvtk
 from mayavi.core.utils import DataSetHelper
+from vtk.numpy_interface import dataset_adapter as dsa
 
 
 class TestDataSetHelper(unittest.TestCase):
@@ -72,6 +73,15 @@ class TestDataSetHelper(unittest.TestCase):
         self.assertEqual(name, 'cv')
         self.assertEqual(rng, [0.0, np.sqrt(3.0)])
 
+    def test_get_range_works_for_VTKNoneArray(self):
+        id_ = tvtk.ImageData(dimensions=(2, 2, 1), origin=(0, 0, 0),
+                             spacing=(1, 1, 1))
+        id_.point_data.scalars = np.arange(4, dtype=float)
+        dsh = DataSetHelper(id_)
+        self.assertFalse(dsh._composite)
+        self.assertEqual(dsh.get_range(), (None, [0., 1.]))
+        # XXX there is some wackiness here, no idea why this changes!
+        self.assertEqual(dsh.get_range(), ('point_scalars', [0., 3.]))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This fixes a bug I've hit because the check for `VTKNoneArray` is in the wrong spot, so you can get an error on line 83:
```
has_nan = np.isnan(x).any()
```
That looks like:
```
>>> np.isnan(None)
TypeError: ufunc 'isnan' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''
```