### PR TITLE
FIX: Fix type check

### DIFF
--- a/mayavi/tools/helper_functions.py
+++ b/mayavi/tools/helper_functions.py
@@ -71,8 +71,8 @@ class Pipeline(HasTraits):
         # First retrieve the scene, if any.
         if 'figure' in kwargs:
             figure = kwargs['figure']
-            assert isinstance(figure, (Scene, None))
-            scene = figure.scene
+            assert isinstance(figure, Scene) or figure is None
+            scene = getattr(figure, 'scene', None)
         else:
             scene = tools.gcf().scene
         if scene is not None:


### PR DESCRIPTION
I just started hitting this error:
```
    def __call__(self, *args, **kwargs):
        """ Calls the logics of the factory, but only after disabling
                rendering, if needed.
            """
        # First retrieve the scene, if any.
        if 'figure' in kwargs:
            figure = kwargs['figure']
>           assert isinstance(figure, (Scene, None))
E           TypeError: isinstance() arg 2 must be a type or tuple of types
```
And then after fixing the assertion I would get:
```
    def __call__(self, *args, **kwargs):
        """ Calls the logics of the factory, but only after disabling
                rendering, if needed.
            """
        # First retrieve the scene, if any.
        if 'figure' in kwargs:
            figure = kwargs['figure']
            assert isinstance(figure, Scene) or figure is None
>           scene = figure.scene
E           AttributeError: 'NoneType' object has no attribute 'scene'
```
So this should fix both.