### PR TITLE
FIX: Fix set_range

### DIFF
--- a/mayavi/core/lut_manager.py
+++ b/mayavi/core/lut_manager.py
@@ -429,6 +429,8 @@ class LUTManager(Base):
         self._default_data_range_changed(self.default_data_range)
 
     def _data_range_changed(self, value):
+        # should be guaranteed by callers, otherwise VTK will print an error
+        assert value[0] <= value[1]
         try:
             self.lut.set_range(value[0], value[1])
         except TypeError:

--- a/mayavi/tests/test_mlab_integration.py
+++ b/mayavi/tests/test_mlab_integration.py
@@ -13,6 +13,7 @@ import mock
 import numpy as np
 from numpy.testing import assert_allclose
 from traits.testing.unittest_tools import UnittestTools
+from traits.api import push_exception_handler
 
 import vtk
 
@@ -22,6 +23,8 @@ from tvtk.api import tvtk
 from mayavi.tools.engine_manager import engine_manager
 from mayavi.core.registry import registry
 from mayavi.tests.common import get_example_data
+
+push_exception_handler(reraise_exceptions=True)  # XXX should probably be elsewhere
 
 
 ################################################################################
@@ -122,6 +125,12 @@ class TestMlabNullEngineMisc(TestMlabNullEngine):
             for factory in pipeline[1:]:
                 obj = factory(obj)
             self.assertTrue(hasattr(obj, 'mlab_source'))
+
+    def test_strange_vmin_vmax(self):
+        tris = [[0, 1, 2]]
+        x, y, z = np.random.random((3, 3, 3))
+        mesh = mlab.pipeline.triangular_mesh_source(x, y, z, tris)
+        surf = mlab.pipeline.surface(mesh, vmin=100, vmax=101)
 
     def test_add_dataset_works_with_vtk_datasets(self):
         # Given

--- a/mayavi/tools/modules.py
+++ b/mayavi/tools/modules.py
@@ -143,10 +143,16 @@ class DataModuleFactory(ModuleFactory):
                     = False
         vmin, vmax = \
                 self._target.module_manager.scalar_lut_manager.data_range
+        # This takes care of pathological cases where vmin is changed
+        # before vmax is changed, but vmin is greater than data_range[1]
         if self.vmin is not None:
             vmin = self.vmin
+            if self.vmax is None:
+                vmax = max(vmax, vmin)
         if self.vmax is not None:
             vmax = self.vmax
+            if self.vmin is None:
+                vmin = min(vmin, vmax)
         self._target.module_manager.scalar_lut_manager.data_range = \
                         (vmin, vmax)
 


### PR DESCRIPTION
In my scripts I kept seeing things like:
```
ERROR: In /work/standalone-x64-build/VTK-source/Common/Core/vtkLookupTable.cxx, line 143                                                                                            
vtkLookupTable (0x5a21890): Bad table range: [6.42653e-11, 2.01495e-11]
```
Turns out it's because internally the code somewhere does essentially:
```
self.vmin = vmin
self.vmax = vmax
```
The problem is that the first set causes a trait notification, and can lead to the condition in `_vmin_changed` that `self.vmin is not None` but `self.vmax is None`; and if the max of the data is less than `self.vmin` you end up in `lut_manager` trying to set things incorrectly.

This puts some sort of fix in both places just to be safe.