### PR TITLE
New Jupyter notebook ipy backend

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -142,8 +142,12 @@ following (after ensuring that you have jupyter installed of course)::
   $ jupyter nbextension install --py mayavi --user
   $ jupyter nbextension enable --py mayavi --user
 
+You will also need to have ipywidgets_ and ipyevents_ installed. These can be
+installed via pip_ or your favorite package manager.
 
 .. _pip: https://pip.pypa.io/en/stable/
+.. _ipywidgets: https://ipywidgets.readthedocs.io
+.. _ipyevents: https://github.com/mwcraig/ipyevents
 
 Bleeding edge
 --------------

--- a/docs/source/mayavi/installation.rst
+++ b/docs/source/mayavi/installation.rst
@@ -77,6 +77,12 @@ following (after ensuring that you have jupyter_ installed of course)::
   $ jupyter nbextension install --py mayavi --user
   $ jupyter nbextension enable --py mayavi --user
 
+You will also need to have ipywidgets_ and ipyevents_ installed. These can be
+installed via pip or your favorite package manager.
+
+.. _ipywidgets: https://ipywidgets.readthedocs.io
+.. _ipyevents: https://github.com/mwcraig/ipyevents
+
 
 .. _installing_git:
 

--- a/docs/source/mayavi/tips.rst
+++ b/docs/source/mayavi/tips.rst
@@ -9,11 +9,29 @@ Mayavi2.
 Using Mayavi in Jupyter notebooks
 ---------------------------------
 
-Mayavi can display either images or X3D_ elements on the notebook.
-The images are static and one cannot interact with them.  The X3D
-output produces a fully interactive 3D scene.  For information on how
-to interact with the scene, see here:
-http://www.x3dom.org/documentation/interaction/
+There are three different ways in which one can embed Mayavi
+visualizations in a Jupyter notebook.  The best way is to use the
+``'ipy'`` backend (which is the default).  This backend was first
+introduced in Mayavi 4.7.0.  This backend requires that the
+ipywidgets_ and ipyevents_ packages be installed.  It behaves almost
+exactly like a normal Mayavi UI window and supports any Mayavi/VTK
+visualization and is fully interactive.  This backend relies on VTK's
+off screen support and depending on how your VTK is configured may
+require a windowing system.
+
+.. _ipywidgets: https://ipywidgets.readthedocs.io
+.. _ipyevents: https://github.com/mwcraig/ipyevents
+
+There are two other backends, the simplest one is the ``'png'``
+backend which produces images that can be embedded in the notebook.
+These are static and not interactive.
+
+In between these two extremes is the ``'x3d'`` backend which displays
+X3D_ elements on the notebook.  The X3D output produces a fully
+interactive 3D scene, however, this will not support VTK's interactive
+widgets.  It does not support transparency and other advanced
+visualizations either.  For information on how to interact with the
+X3D scene, see here: http://www.x3dom.org/documentation/interaction/
 
 Mayavi ships with some javascript files that can be installed as::
 
@@ -43,14 +61,18 @@ objects so they can be rendered on the Jupyter notebook.
 .. note::
 
    One can call ``init_notebook`` multiple times if one wishes to
-   change the backend between ``png`` and ``x3d`` for some reason.
+   change the backend between ``ipy``, ``png``, and ``x3d`` for some
+   reason.
 
 There are several optional arguments to ``init_notebook``.
 
-- The first is the backend which defaults to ``'x3d'`` and can also
-  be set to ``'png'``.
-- One can set the pixel width and height of the figure to create
-  (as integers) (for example ``mlab.init_notebook('x3d',800,800)``).
+- The first is the backend which defaults to ``'ipy'``, and can also
+  be set to ``'x3d'`` or ``'png'``.
+- One can set the pixel width and height of the figure to create (as
+  integers) (for example ``mlab.init_notebook('x3d', 800, 800)``).
+  This only applies to the ``x3d`` backend.  For the ``ipy`` backend
+  this can be set when creating a new ``figure`` with the ``size``
+  keyword argument.
 - The last keyword argument ``local`` defaults to ``True``.
   When ``local=True`` it uses javascript files that are distributed
   along with Mayavi otherwise will require an internet connection

--- a/examples/mayavi/mayavi_jupyter.ipynb
+++ b/examples/mayavi/mayavi_jupyter.ipynb
@@ -4,26 +4,129 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Mayavi on Jupyter\n",
+    "## Mayavi on Jupyter\n",
     "\n",
-    "Works with either `'x3d'` or `'png'` modes.  The PNG mode embeds images in the notebook and relies on off-screen-rendering working correctly.\n",
+    "Works with either `'ipy'`, `'x3d'` or `'png'` modes.  The PNG mode embeds images in the notebook and relies on off-screen-rendering working correctly.  The `'ipy'` mode also relies on off-screen support but is the default and most powerful of the options.  It also does not require WebGL support in your browser.\n",
+    "\n",
+    "For the default `'ipy'` backend, one also requires to have `ipywidgets` and `ipyevents` installed.  You may do this as:\n",
+    "\n",
+    "```\n",
+    "  $ pip install ipywidgets ipyevents\n",
+    "  $ jupyter nbextension enable --py widgetsnbextension\n",
+    "  $ jupyter nbextension enable --py ipyevents\n",
+    "\n",
+    "```\n",
+    "Or use a suitable package manager.\n",
     "\n",
     "For [X3D](http://www.x3dom.org) output to be rendered one either needs to [install the nbextensions](http://jupyter-notebook.readthedocs.io/en/latest/examples/Notebook/Distributing%20Jupyter%20Extensions%20as%20Python%20Packages.html#Installation-of-Jupyter-Extensions) for mayavi as\n",
     "\n",
     "```\n",
     "   $ jupyter nbextension install --py mayavi --user\n",
     "```\n",
-    "or requires an internet connection.  \n",
+    "or requires an internet connection and your browser to support WebGL.\n",
     "\n",
-    "In this notebook we demonstrate the X3D output while requiring an internet connection."
+    "In this notebook we demonstrate the different backends. For the X3D output this notebook requires an internet connection."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Notebook initialized with ipy backend.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Always start with this.\n",
+    "from mayavi import mlab\n",
+    "mlab.init_notebook()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5b58828ea7f6435ba751ee36ae7aa269",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Image(value=b'\\x89PNG\\r\\n\\x1a\\n\\x00\\x00\\x00\\rIHDR\\x00\\x00\\x01\\x90\\x00\\x00\\x01^\\x08\\x02\\x00\\x00\\x00$?\\xde_\\x00\\…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "s = mlab.test_contour3d()\n",
+    "scp = mlab.pipeline.scalar_cut_plane(s)\n",
+    "s.module_manager.scalar_lut_manager.show_scalar_bar = True\n",
+    "s"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that if all goes well, you should be able to interact with the above just as you would with a typical Mayavi UI widget.  You should be able to interact with the camera, with the cut plane widget and with the scalar bar.\n",
+    "\n",
+    "Note that you will need to create a new figure if you want a different visualization.  In the following we show the same figure as above, note that interacting with one will automatically update the other as they are the same figure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5b58828ea7f6435ba751ee36ae7aa269",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Image(value=b'\\x89PNG\\r\\n\\x1a\\n\\x00\\x00\\x00\\rIHDR\\x00\\x00\\x01\\x90\\x00\\x00\\x01^\\x08\\x02\\x00\\x00\\x00$?\\xde_\\x00\\…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "mlab.gcf()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that unlike the other backends, if you call `mlab.clf()`, it will clear all the widgets for that particular figure -- since they are all the same."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### X3D backend\n",
+    "\n",
+    "When initializing the notebook, use the x3d backend.  This backend embeds an X3D element into the notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -34,8 +137,6 @@
     }
    ],
    "source": [
-    "# Always start with this.\n",
-    "from mayavi import mlab\n",
     "mlab.init_notebook(backend='x3d', local=False) \n",
     "# local=True is the default but requires the nbextension to be installed.  \n",
     "# local=False pulls the content from the internet."
@@ -43,9 +144,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 5,
    "metadata": {
-    "collapsed": false
+    "scrolled": true
    },
    "outputs": [
     {
@@ -5011,13 +5112,13 @@
        "</X3D>\n",
        "\n",
        "    <script type=\"text/javascript\">\n",
-       "    require([\"/nbextensions/mayavi/x3d/x3dom.js\"], function(x3dom) {\n",
+       "    require([\"https://www.x3dom.org/download/1.7.2/x3dom\"], function(x3dom) {\n",
        "        var x3dom_css = document.getElementById(\"x3dom-css\");\n",
        "        if (x3dom_css === null) {\n",
        "            var l = document.createElement(\"link\");\n",
        "            l.setAttribute(\"rel\", \"stylesheet\");\n",
        "            l.setAttribute(\"type\", \"text/css\");\n",
-       "            l.setAttribute(\"href\", \"/nbextensions/mayavi/x3d/x3dom.css\");\n",
+       "            l.setAttribute(\"href\", require.toUrl(\"https://www.x3dom.org/download/1.7.2/x3dom.css\"));\n",
        "            l.setAttribute(\"id\", \"x3dom-css\");\n",
        "            $(\"head\").append(l);\n",
        "        }\n",
@@ -5032,15 +5133,16 @@
        "    "
       ],
       "text/plain": [
-       "<mayavi.modules.glyph.Glyph at 0x124b196b0>"
+       "<IPython.core.display.HTML object>"
       ]
      },
-     "execution_count": 2,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
+    "mlab.figure()\n",
+    "# Note the use of the figure here to create a new visualization.\n",
     "s = mlab.test_points3d()\n",
     "s"
    ]
@@ -5059,10 +5161,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 6,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -23635,13 +23735,13 @@
        "</X3D>\n",
        "\n",
        "    <script type=\"text/javascript\">\n",
-       "    require([\"/nbextensions/mayavi/x3d/x3dom.js\"], function(x3dom) {\n",
+       "    require([\"https://www.x3dom.org/download/1.7.2/x3dom\"], function(x3dom) {\n",
        "        var x3dom_css = document.getElementById(\"x3dom-css\");\n",
        "        if (x3dom_css === null) {\n",
        "            var l = document.createElement(\"link\");\n",
        "            l.setAttribute(\"rel\", \"stylesheet\");\n",
        "            l.setAttribute(\"type\", \"text/css\");\n",
-       "            l.setAttribute(\"href\", \"/nbextensions/mayavi/x3d/x3dom.css\");\n",
+       "            l.setAttribute(\"href\", require.toUrl(\"https://www.x3dom.org/download/1.7.2/x3dom.css\"));\n",
        "            l.setAttribute(\"id\", \"x3dom-css\");\n",
        "            $(\"head\").append(l);\n",
        "        }\n",
@@ -23656,12 +23756,11 @@
        "    "
       ],
       "text/plain": [
-       "<mayavi.modules.surface.Surface at 0x12660d110>"
+       "<IPython.core.display.HTML object>"
       ]
      },
-     "execution_count": 3,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -23683,9 +23782,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "mlab.clf()\n",
@@ -23697,9 +23794,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "mlab.init_notebook('png') # This may not work well if off screen rendering is not working."
@@ -23708,9 +23803,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "mlab.clf()\n",
@@ -23720,9 +23813,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "mlab.init_notebook('x3d')\n",
@@ -23742,23 +23833,23 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/mayavi/tools/notebook.py
+++ b/mayavi/tools/notebook.py
@@ -4,30 +4,31 @@ from __future__ import print_function
 
 import base64
 from itertools import count
+
 from tvtk.api import tvtk
 from tvtk.common import configure_input
 
 
-_backend = 'x3d'
+_backend = 'ipy'
 _width = None
 _height = None
 _local = True
+_widget_manager = None
+_counter = count()
 
-counter = count()
 
-
-def init(backend='x3d', width=None, height=None, local=True):
+def init(backend='ipy', width=None, height=None, local=True):
     """Initialize a suitable backend for Jupyter notebooks.
 
     **Parameters**
 
-    backend :str: one of ('png', 'x3d')
+    backend :str: one of ('png', 'x3d', 'ipy')
     width :int: suggested default width of the element
     height :int: suggested default height of the element
     local :bool: Use local copy of x3dom.js instead of online version.
     """
-    global _backend, _width, _height, _local
-    backends = ('png', 'x3d')
+    global _backend, _width, _height, _local, _widget_manager
+    backends = ('png', 'x3d', 'ipy')
     error_msg = "Backend must be one of %r, got %s" % (backends, backend)
     assert backend in backends, error_msg
     from mayavi import mlab
@@ -35,32 +36,46 @@ def init(backend='x3d', width=None, height=None, local=True):
     _backend = backend
     _width, _height = width, height
     _local = local
+    if backend == 'ipy':
+        _setup_widget_manager()
     _monkey_patch_for_ipython()
     print("Notebook initialized with %s backend." % backend)
+
+
+def _setup_widget_manager():
+    global _widget_manager
+    if _widget_manager is None:
+        from mayavi.tools.remote.ipy_remote import WidgetManager
+        _widget_manager = WidgetManager()
 
 
 def _monkey_patch_for_ipython():
     from mayavi.core.base import Base
     from tvtk.pyface.tvtk_scene import TVTKScene
-    Base._repr_html_ = _repr_html_
-    TVTKScene._repr_html_ = _repr_html_
+    Base._ipython_display_ = _ipython_display_
+    TVTKScene._ipython_display_ = _ipython_display_
 
 
-def _repr_html_(self):
+def _ipython_display_(self):
     """Method for displaying elements on the Jupyter notebook.
     """
+    from IPython.display import HTML
+    from IPython.display import display as idisplay
+
     if hasattr(self, 'render_window'):
         scene = self
     elif hasattr(self, 'scene'):
         scene = self.scene
     if _backend == 'png':
-        return scene_to_png(scene)
+        return idisplay(HTML(scene_to_png(scene)))
     elif _backend == 'x3d':
-        return scene_to_x3d(scene)
+        return idisplay(HTML(scene_to_x3d(scene)))
+    elif _backend == 'ipy':
+        return idisplay(scene_to_ipy(scene))
 
 
 def _fix_x3d_header(x3d):
-    id = 'scene_%d' % next(counter)
+    id = 'scene_%d' % next(_counter)
     rep = '<X3D profile="Immersive" version="3.0" id="%s" ' % id
     if _width is not None:
         rep += 'width="%dpx" ' % _width
@@ -129,16 +144,21 @@ def scene_to_png(scene):
     return html % data
 
 
+def scene_to_ipy(scene):
+    return _widget_manager.scene_to_ipy(scene)
+
+
 def display(obj, backend=None):
     """Display given object on Jupyter notebook using given backend.
 
     This is largely for testing.
     """
     global _backend
-    from IPython.display import HTML, display as ipy_display
     backend = _backend if backend is None else backend
+    if backend == 'ipy':
+        _setup_widget_manager()
     orig_backend = _backend
     _backend = backend
-    html = _repr_html_(obj)
+    result = _ipython_display_(obj)
     _backend = orig_backend
-    return ipy_display(HTML(html))
+    return result

--- a/mayavi/tools/remote/bridge.py
+++ b/mayavi/tools/remote/bridge.py
@@ -1,0 +1,60 @@
+from collections import defaultdict
+
+
+class Bridge(object):
+    def add_widget(self, scene_id, widget):
+        '''Add widget corresponding to a given scene id.
+        '''
+        pass
+
+    def remove_widget(self, scene_id, widget):
+        '''Remove a widget corresponding to a given scene_id.
+        '''
+        pass
+
+    def get_scenes(self):
+        '''Returns a list of the available scenes.
+        '''
+        pass
+
+    def handle_event(self, event_data):
+        '''Handle an event sent by the server.
+        '''
+        pass
+
+    def run(self):
+        '''Run any code for the bridge to do its job.
+        '''
+        pass
+
+
+class LocalBridge(Bridge):
+    def __init__(self, scene_manager):
+        self.scene_manager = scene_manager
+        # In the local case, we are the client of
+        # the scene manager and manage those events.
+        self.scene_manager.add_client(self)
+        self.widgets = defaultdict(list)
+
+    def add_widget(self, scene_id, widget):
+        '''Add widget corresponding to a given scene id.
+        '''
+        self.widgets[scene_id].append(widget)
+
+    def remove_widget(self, scene_id, widget):
+        '''Remove a widget corresponding to a given scene_id.
+        '''
+        w = self.widgets[scene_id]
+        w.remove(widget)
+        if len(w) == 0:
+            del self.widgets[scene_id]
+
+    def get_scenes(self):
+        '''Returns a list of the available scenes.
+        '''
+        return self.scene_manager.scenes
+
+    def handle_event(self, event_data):
+        s_id, obj_name, event, data = event_data
+        for w in self.widgets[s_id]:
+            w.handle_vtk_event(obj_name, event, data)

--- a/mayavi/tools/remote/ipy_remote.py
+++ b/mayavi/tools/remote/ipy_remote.py
@@ -1,0 +1,119 @@
+import base64
+from IPython.display import display
+from ipywidgets import Image
+from ipyevents import Event
+
+from mayavi.tools.remote.remote_widget import RemoteWidget
+
+decode_func = getattr(base64, 'decodebytes', getattr(base64, 'decodestring'))
+
+
+def base64_to_bytes(str_or_bytes):
+    data = str_or_bytes.encode('ascii')
+    return decode_func(data)
+
+
+class IPyRemoteWidget(RemoteWidget):
+    def __init__(self, scene_proxy, bridge, *args, **kw):
+        super(IPyRemoteWidget, self).__init__(scene_proxy, bridge, *args, **kw)
+        self.image = Image(format='PNG')
+        self.event = Event(
+            source=self.image,
+            watched_events=[
+                'dragstart', 'mouseenter', 'mouseleave',
+                'mousedown', 'mouseup', 'mousemove', 'wheel',
+                'keyup', 'keydown'
+            ],
+            prevent_default_action=True
+        )
+        self.event.on_dom_event(self.handle_ipyevent)
+        self._update_image()
+
+    def _ipython_display_(self):
+        display(self.image)
+
+    # ###### Public protocol ##############
+
+    def show(self):
+        pass
+
+    def show_image(self, data, format='PNG'):
+        self.image.format = format
+        self.image.value = data
+
+    # ##### VTK Event handling ##########
+    def on_render(self, data):
+        self.show_image(base64_to_bytes(data['data']),
+                        format=data.get('format', 'PNG'))
+
+    def on_cursor_changed(self, data):
+        # self.setCursor(cursor)
+        pass
+
+    def handle_ipyevent(self, event):
+        type = event['type']
+        shift = event.get('shiftKey', False)
+        ctrl = event.get('ctrlKey', False)
+        btn_map = {0: 'left', 1: 'right', 2: 'middle'}
+        if type == 'mouseenter':
+            self.on_enter(ctrl, shift)
+        elif type == 'mouseleave':
+            self.on_leave(ctrl, shift)
+        elif type == 'mouseleave':
+            self.on_leave(ctrl, shift)
+        elif type == 'mousedown':
+            repeat = 0
+            button = btn_map.get(event.get('button'), 'none')
+            x, y = event.get('relativeX'), event.get('relativeY')
+            self.on_mouse_press(ctrl, shift, x, y, button, repeat)
+        elif type == 'mouseup':
+            x, y = event.get('relativeX'), event.get('relativeY')
+            self.on_mouse_release(ctrl, shift, x, y)
+        elif type == 'mousemove':
+            button = btn_map.get(event.get('button'), 'none')
+            x, y = event.get('relativeX'), event.get('relativeY')
+            self.on_mouse_move(ctrl, shift, button, x, y)
+        elif type == 'wheel':
+            dx = event.get('deltaX')
+            dy = event.get('deltaY')
+            dz = event.get('deltaZ')
+            delta = dx + dy + dz
+            self.on_wheel(delta)
+        elif type == 'keydown':
+            key = event.get('key')
+            # Need to map the special keys correctly.
+            key_sym = key
+            self.on_key_press(ctrl, shift, key, key_sym)
+        elif type == 'keyup':
+            key = event.get('key')
+            # Need to map the special keys correctly.
+            key_sym = key
+            self.on_key_release(ctrl, shift, key)
+
+
+class WidgetManager(object):
+    def __init__(self):
+        from .remote_scene import SceneManager
+        from .bridge import LocalBridge
+        self.sm = SceneManager()
+        # FIXME: we need a way to set the SceneManager.call_later.
+        # not sure what sort of event loop we can rely on with IPython.
+        self.bridge = LocalBridge(self.sm)
+        self.bridge.run()
+        self.widgets = {}
+
+    def scene_to_ipy(self, scene):
+        from mayavi.tools.figure import gcf
+        from mayavi.tools.remote.ipy_remote import IPyRemoteWidget
+        figure = gcf()
+        sm = self.sm
+        sid = sm.figure_to_id.get(figure)
+        if sid is None:
+            sid = sm.register_figure(figure)
+        if sid in self.widgets:
+            return self.widgets[sid]
+        else:
+            scene = sm.scenes[sid]
+            w = IPyRemoteWidget(scene, self.bridge)
+            self.widgets[sid] = w
+            return w

--- a/mayavi/tools/remote/ipy_remote.py
+++ b/mayavi/tools/remote/ipy_remote.py
@@ -3,7 +3,10 @@ from IPython.display import display
 from ipywidgets import Image
 from ipyevents import Event
 
-from mayavi.tools.remote.remote_widget import RemoteWidget
+from .bridge import LocalBridge
+from .remote_scene import SceneManager
+from .remote_widget import RemoteWidget
+from ..figure import gcf
 
 decode_func = getattr(base64, 'decodebytes', getattr(base64, 'decodestring'))
 
@@ -93,8 +96,6 @@ class IPyRemoteWidget(RemoteWidget):
 
 class WidgetManager(object):
     def __init__(self):
-        from .remote_scene import SceneManager
-        from .bridge import LocalBridge
         self.sm = SceneManager()
         # FIXME: we need a way to set the SceneManager.call_later.
         # not sure what sort of event loop we can rely on with IPython.
@@ -103,8 +104,6 @@ class WidgetManager(object):
         self.widgets = {}
 
     def scene_to_ipy(self, scene):
-        from mayavi.tools.figure import gcf
-        from mayavi.tools.remote.ipy_remote import IPyRemoteWidget
         figure = gcf()
         sm = self.sm
         sid = sm.figure_to_id.get(figure)

--- a/mayavi/tools/remote/remote_scene.py
+++ b/mayavi/tools/remote/remote_scene.py
@@ -1,0 +1,316 @@
+from __future__ import print_function
+import base64
+from collections import namedtuple
+import time
+
+from traits.api import (Any, Bool, Dict, Enum, Event, HasTraits,
+                        Instance, Int, List, Callable)
+import vtk
+
+from tvtk.api import tvtk
+from mayavi.tools.figure import figure, gcf
+from mayavi.tools.engine_manager import options
+from tvtk.tvtk_base import global_disable_update
+
+options.offscreen = True
+
+encode_func = getattr(base64, 'encodebytes', getattr(base64, 'encodestring'))
+
+EventInfo = namedtuple('EventInfo', ['id', 'name', 'event', 'data'])
+
+
+if hasattr(vtk, 'vtkOSOpenGLRenderWindow'):
+    # Needed for VTK's vtkglew to be able to load the OSMesa.so. See:
+    # https://www.vtk.org/pipermail/vtk-developers/2017-November/035592.html
+    import ctypes
+    osm = ctypes.CDLL("libOSMesa.so", ctypes.RTLD_GLOBAL)
+
+
+class ImageEncoder(HasTraits):
+    scene = Any
+    w2if = Instance(tvtk.WindowToImageFilter)
+    writer = Instance(tvtk.ImageWriter)
+    image_type = Enum('png', 'jpeg')
+    quality = Int(60)
+    compress = Bool(False)
+
+    _png_writer = Instance(tvtk.ImageWriter)
+    _jpg_writer = Instance(tvtk.ImageWriter)
+
+    # ---- Public protocol -------
+    def get_raw_image(self):
+        '''Returns the raw bytes of the image.
+        '''
+        self.w2if.modified()
+        w = self.writer
+        w.update()
+        w.write()
+        return w.result.to_array().tostring()
+
+    # ---- Private protocol -------
+    def _w2if_default(self):
+        w2if = tvtk.WindowToImageFilter()
+        if self.scene is not None:
+            w2if.input = self.scene.render_window
+        return w2if
+
+    def _writer_default(self):
+        return self._get_writer(self.image_type)
+
+    def _get_writer(self, image_type):
+        if image_type == 'png':
+            writer = self._png_writer
+        else:
+            writer = self._jpg_writer
+        writer.set_input_connection(self.w2if.output_port)
+        return writer
+
+    def __png_writer_default(self):
+        return tvtk.PNGWriter(write_to_memory=True)
+
+    def __jpg_writer_default(self):
+        return tvtk.JPEGWriter(quality=self.quality, write_to_memory=True)
+
+    def _quality_changed(self, value):
+        self._jpg_writer.quality = value
+
+    def _image_type_changed(self, value):
+        if self.writer is not None:
+            self.writer.set_input_connection(None)
+        self.writer = self._get_writer(value)
+
+    def _scene_changed(self, value):
+        self.w2if.input = value.render_window
+
+    def _compress_changed(self, value):
+        if value:
+            self.image_type = 'jpeg'
+        else:
+            self.image_type = 'png'
+
+
+class RemoteScene(HasTraits):
+
+    #: Any events for clients to listen to. Only a subset of events are emitted
+    # currently, the event is an `EventInfo` instance.
+    event = Event
+
+    #: Set a callback function with signature `f(secs, callable, *args, **kw)`.
+    # The function should call the passed `callable` function with the given
+    # args and kwargs after the specified time in seconds.
+    call_later = Callable
+
+    #: The image encoder which converts the scene to a suitable image.
+    image_encoder = Instance(ImageEncoder)
+
+    def __init__(self, figure=None, **traits):
+        super(RemoteScene, self).__init__(**traits)
+        if figure is None:
+            figure = gcf()
+        self.figure = figure
+        self.scene = figure.scene
+        self.trw = self.scene.render_window
+        self.trwi = self.scene.interactor
+        self.rwi = tvtk.to_vtk(self.trwi)
+        self.rw = tvtk.to_vtk(self.trw)
+        self.ren = tvtk.to_vtk(self.scene.renderer)
+        self.id = id(self)
+        self._last_image = ''
+        self._last_render = 0
+        self._time_to_render = 0
+        self._time_for_image = 0
+        self._render_size = 200*200
+        self._pending_render = False
+        self._doing_render = False
+        self._timer_enabled = True
+        self._setup_scene()
+
+    # ## Public protocol ####
+    def get_raw_image(self):
+        # This flag is set to prevent render events from being generated
+        # while generating the image (which does happen!).
+        self._doing_render = True
+        data = self.image_encoder.get_raw_image()
+        self._doing_render = False
+        return data
+
+    def get_image(self):
+        data = self.get_raw_image()
+        return encode_func(data).decode('ascii')
+
+    def call_rwi(self, method, *args):
+        if method == 'SetSize':
+            # This is an issue with the way TVTK is setup and how VTK resizes
+            # an offscreen window. It basically releases all graphics resources
+            # and this job is passed on to the various mappers. When the mapper
+            # does this it emits a ModifiedEvent which is picked by TVTK to
+            # fire a render. This call to render when the window is resizing
+            # locks up VTK or entirely messes up the rendering. I've reported
+            # this upstream but it turns out that disabling the auto updates in
+            # TVTK maybe of general use so we have a convenient context manager
+            # to do this called `global_disable_update` that shuts off the
+            # automatic updates for ALL TVTK objects for a brief while. This
+            # fixes the issue.
+            with global_disable_update():
+                self.trw.size = args
+                self.trw.render()
+
+        if 'PressEvent' in method:
+            self.image_encoder.compress = True
+        if 'ReleaseEvent' in method:
+            self.image_encoder.compress = False
+
+        getattr(self.rwi, method)(*args)
+
+    # ## Private protocol ####
+
+    def _send_pending_render(self):
+        if self._pending_render:
+            self._send_render_event()
+
+    def _emit_event(self, obj, evt):
+        self.event = EventInfo(self.id, obj.GetClassName(), evt, None)
+
+    def _required_time_to_render(self):
+        return (self._time_for_image + self._time_to_render +
+                self._render_size/1e6)
+
+    def _ok_to_send_render_event(self):
+        required_time = self._required_time_to_render()
+        return (time.time() - self._last_render) > required_time
+
+    def _on_create_timer(self, obj, evt):
+        self._timer_enabled = True
+        self.call_later(0.05, self._on_timer_event)
+
+    def _on_destroy_timer(self, obj, evt):
+        self._timer_enabled = False
+
+    def _on_timer_event(self):
+        if self._timer_enabled:
+            self.rwi.TimerEvent()
+
+    @vtk.calldata_type(vtk.VTK_INT)
+    def _on_cursor_changed_event(self, obj, evt, calldata):
+        self.event = EventInfo(self.id, obj.GetClassName(), evt, calldata)
+
+    def _on_render_event(self, obj, event):
+        if self._doing_render:
+            return
+
+        if self._ok_to_send_render_event():
+            self._send_render_event()
+        else:
+            if not self._pending_render and self.call_later:
+                req_time = self._required_time_to_render()
+                # print("Required time:", req_time)
+                self.call_later(min(req_time, 0.25), self._send_pending_render)
+            self._pending_render = True
+
+    def _send_render_event(self):
+        self._pending_render = False
+        event = 'RenderEvent'
+        start = time.time()
+        img = self.get_image()
+        self._render_size = len(img)
+        # print(self._render_size)
+        self._last_render = time.time()
+        self._time_for_image = self._last_render - start
+        self._time_to_render = self.ren.GetLastRenderTimeInSeconds()
+        # print("Time to render:", self._time_to_render)
+        if img != self._last_image:
+            self._last_image = img
+            format = self.image_encoder.image_type.upper()
+            data = dict(data=img, type='image', format=format,
+                        time=self._time_for_image,
+                        render_time=self._time_to_render)
+            self.event = EventInfo(
+                self.id, self.rw.GetClassName(), event, data
+            )
+
+    def _setup_scene(self):
+        self.trwi.interactor_style.set_current_style_to_trackball_camera()
+        self.rwi.AddObserver('CreateTimerEvent', self._on_create_timer)
+        self.rwi.AddObserver('DestroyTimerEvent', self._on_destroy_timer)
+        rw = self.rw
+        rw.AddObserver('RenderEvent', self._on_render_event)
+        rw.AddObserver('CursorChangedEvent', self._on_cursor_changed_event)
+
+    def _image_encoder_default(self):
+        return ImageEncoder(scene=self.scene, quality=60)
+
+
+class SceneManager(HasTraits):
+
+    scenes = Dict
+
+    figure_to_id = Dict
+
+    clients = List
+
+    #: Set a callback function with signature `f(secs, callable, *args, **kw)`.
+    # The function should call the passed `callable` function with the given
+    # args and kwargs after the specified time in seconds.
+    call_later = Callable
+
+    def add_client(self, client):
+        '''All the client needs to do is to provide a method called
+        `handle_event` which is given the event data from the scenes
+        and route that to the appropriate recipient.
+
+        The event data is basically an `EventInfo` instance.
+        '''
+        self.clients.append(client)
+
+    def remove_client(self, client):
+        self.clients.remove(client)
+
+    def register_figure(self, figure):
+        '''Given an existing figure, set it up for remote visualization.
+        '''
+        remote = RemoteScene(figure=figure)
+        r_id = id(remote)
+        self.figure_to_id[figure] = r_id
+        self.scenes[r_id] = remote
+        self._setup_events(remote)
+        if self.call_later:
+            remote.call_later = self.call_later
+        return r_id
+
+    def figure(self, *args, **kw):
+        '''Create a figure and manage it as a remote figure. Any args
+        and kwargs are passed on to the `mlab.figure` function.
+
+        '''
+        f = figure(*args, **kw)
+        return self.register_figure(f)
+
+    def message(self, obj_id, method_name, *args, **kw):
+        '''Call a method with given args but do not return any responses.
+
+        This is meant to be used for passing messages to the scenes.
+        '''
+        self.call(obj_id, method_name, *args, **kw)
+
+    def call(self, obj_id, method_name, *args, **kw):
+        '''Call a method and also return the response of the method.
+
+        Used for synchronous calls to the scenes.
+        '''
+        scene = self.scenes[obj_id]
+        method = getattr(scene, method_name)
+        return method(*args, **kw)
+
+    # ## Private protocol ####
+
+    def _setup_events(self, obj):
+        obj.on_trait_change(self._forward_event, 'event')
+
+    def _forward_event(self, event):
+        # Override this to change the default if needed.
+        for client in self.clients:
+            client.handle_event(event)
+
+    def _call_later_changed(self, f):
+        for scene in self.scenes.values():
+            scene.call_later = f

--- a/mayavi/tools/remote/remote_scene.py
+++ b/mayavi/tools/remote/remote_scene.py
@@ -8,8 +8,8 @@ from traits.api import (Any, Bool, Dict, Enum, Event, HasTraits,
 import vtk
 
 from tvtk.api import tvtk
-from mayavi.tools.figure import figure, gcf
-from mayavi.tools.engine_manager import options
+from ..figure import figure, gcf
+from ..engine_manager import options
 from tvtk.tvtk_base import global_disable_update
 
 options.offscreen = True

--- a/mayavi/tools/remote/remote_widget.py
+++ b/mayavi/tools/remote/remote_widget.py
@@ -148,14 +148,3 @@ class RemoteWidget(object):
         elif self._wheelDelta <= -60:
             self.send('MouseWheelBackwardEvent')
             self._wheelDelta = 0
-
-
-def make_viewers(bridge, widget_cls):
-    bridge.run()
-    widgets = []
-    for id, scene in bridge.get_scenes().items():
-        w = widget_cls(scene, bridge)
-        w.show()
-        widgets.append(w)
-
-    return widgets

--- a/mayavi/tools/remote/remote_widget.py
+++ b/mayavi/tools/remote/remote_widget.py
@@ -1,0 +1,161 @@
+import imghdr
+
+
+class RemoteWidget(object):
+    """An abstract remote widget which talks to the bridge but has no toolkit
+    specific code.
+
+    This is similar to the QVTKRenderWindowInteractor but instead of actually
+    setting things on a local render window interactor, passes them off to a
+    remote server to do the job and simply renders a PNG sent by the remote
+    server.
+    """
+    def __init__(self, scene_proxy, bridge, **kw):
+        super(RemoteWidget, self).__init__(**kw)
+        self.scene_proxy = scene_proxy
+        self.bridge = bridge
+        bridge.add_widget(scene_proxy.id, self)
+
+        self._ActiveButton = 'none'
+
+        # private attributes
+        self._saveX = 0
+        self._saveY = 0
+        self._saveModifiers = False, False
+        self._saveButtons = 'none'
+        self._wheelDelta = 0
+        self._is_resizing = False
+        self._move_count = 0
+
+        # Note that since this is just a raw image sent by the server we do
+        # not need to worry about the pixel ratio for this case unlike
+        # the QRenderWindowInteractor.
+
+    # ###### Public protocol ##############
+
+    def handle_vtk_event(self, obj_name, vtk_event, data):
+        if vtk_event == 'RenderEvent':
+            if not self._is_resizing:
+                self.on_render(data)
+        elif vtk_event == 'CursorChangedEvent':
+            self.on_cursor_changed(data)
+
+    def send(self, method, *args):
+        self.scene_proxy.call_rwi(*((method, ) + args))
+
+    def show_image(self, data, format='PNG'):
+        pass
+
+    # #### Private protocol ############
+
+    def _update_image(self):
+        data = self.scene_proxy.get_raw_image()
+        format = imghdr.what('', h=data)
+        self.show_image(data, format=format.upper())
+
+    # ##### VTK Event handling ##########
+    def on_render(self, data):
+        pass
+
+    def on_cursor_changed(self, data):
+        pass
+
+    # ##### Toolkit event handling ##########
+
+    def on_resize(self, w, h):
+        if not self._is_resizing:
+            self.send('SetSize', w, h)
+            self.send('ConfigureEvent')
+            self._update_image()
+
+    def on_close(self):
+        self.bridge.remove_widget(self.scene_proxy.id, self)
+
+    def on_enter(self, ctrl, shift):
+        self.send('SetEventInformationFlipY', self._saveX, self._saveY,
+                  ctrl, shift, chr(0), 0, None)
+        self.send('EnterEvent')
+
+    def on_leave(self, ctrl, shift):
+        self.send('SetEventInformationFlipY', self._saveX, self._saveY,
+                  ctrl, shift, chr(0), 0, None)
+        self.send('LeaveEvent')
+
+    def on_mouse_press(self, ctrl, shift, x, y, button, repeat=0):
+        '''
+        ctrl, shift are bools indicating if the modifiers are pressed.
+        x, y are screen relative coordinates.
+        button is one of 'left', 'right', 'middle' or 'none'
+        repeate is for repeat clicks (double click)
+        '''
+        self.send('SetEventInformationFlipY', x, y,
+                  ctrl, shift, chr(0), repeat, None)
+
+        self._ActiveButton = 'left'
+
+        if button == 'left':
+            self.send('LeftButtonPressEvent')
+        elif button == 'right':
+            self.send('RightButtonPressEvent')
+        elif button == 'middle':
+            self.send('MiddleButtonPressEvent')
+
+    def on_mouse_release(self, ctrl, shift, x, y):
+        self.send('SetEventInformationFlipY', x, y,
+                  ctrl, shift, chr(0), 0, None)
+        button = self._ActiveButton
+        if button == 'left':
+            self.send('LeftButtonReleaseEvent')
+        elif button == 'right':
+            self.send('RightButtonReleaseEvent')
+        elif button == 'middle':
+            self.send('MiddleButtonReleaseEvent')
+
+    def on_mouse_move(self, ctrl, shift, button, x, y):
+        self._move_count += 1
+
+        if self._move_count % 3 == 0:
+            self._saveModifiers = ctrl, shift
+            self._saveButtons = button
+            self._saveX = x
+            self._saveY = y
+
+            self.send('SetEventInformationFlipY', x, y,
+                      ctrl, shift, chr(0), 0, None)
+            self.send('MouseMoveEvent')
+            self._move_count = 0
+
+    def on_key_press(self, ctrl, shift, key, key_sym):
+        """ React to key pressed event.
+
+        """
+        self.send('SetEventInformationFlipY', self._saveX, self._saveY,
+                  ctrl, shift, key, 0, key_sym)
+        self.send('KeyPressEvent')
+        self.send('CharEvent')
+
+    def on_key_release(self, ctrl, shift, key):
+        self.send('SetEventInformationFlipY', self._saveX, self._saveY,
+                  ctrl, shift, key, 0, None)
+        self.send('KeyReleaseEvent')
+
+    def on_wheel(self, delta):
+        self._wheelDelta += delta
+
+        if self._wheelDelta >= 60:
+            self.send('MouseWheelForwardEvent')
+            self._wheelDelta = 0
+        elif self._wheelDelta <= -60:
+            self.send('MouseWheelBackwardEvent')
+            self._wheelDelta = 0
+
+
+def make_viewers(bridge, widget_cls):
+    bridge.run()
+    widgets = []
+    for id, scene in bridge.get_scenes().items():
+        w = widget_cls(scene, bridge)
+        w.show()
+        widgets.append(w)
+
+    return widgets


### PR DESCRIPTION
This backend is called 'ipy' and is now the default.  It requires
that VTK's offscreen support work correctly.  This backend requires
ipywidgets and ipyevents.  It allows complete interactivity and behaves
almost exactly like a normal UI backend but inside a notebook.  Note
that this will still require an xserver or windowing toolkit unless VTK
is compiled to be able to work without those.

Many thanks to Enthought for supporting this.