### PR TITLE
FIX: Escape chars

### DIFF
--- a/mayavi/tools/animator.py
+++ b/mayavi/tools/animator.py
@@ -72,7 +72,7 @@ class Animator(HasTraits):
     ######################################################################
     # Initialize object
     def __init__(self, millisec, callable, *args, **kwargs):
-        """Constructor.
+        r"""Constructor.
 
         **Parameters**
 

--- a/tvtk/pipeline/browser.py
+++ b/tvtk/pipeline/browser.py
@@ -342,7 +342,7 @@ class FullTreeGenerator(SimpleTreeGenerator):
         del methods[0]
 
         # using only the first set of indented values.
-        patn = re.compile("  \S")
+        patn = re.compile(r"  \S")
         for method in methods[:]:
             if patn.match(method):
                 if method.find(":") == -1:
@@ -369,10 +369,10 @@ class FullTreeGenerator(SimpleTreeGenerator):
             methods[i] = strng.split(":")
             method_names.append(methods[i][0])
 
-        if re.match("vtk\w*Renderer", vtk_obj.GetClassName()):
+        if re.match(r"vtk\w*Renderer", vtk_obj.GetClassName()):
             methods.append(["ActiveCamera", ""])
 
-        if re.match("vtk\w*Assembly", vtk_obj.GetClassName()):
+        if re.match(r"vtk\w*Assembly", vtk_obj.GetClassName()):
             methods.append(["Parts", ""])
             methods.append(["Volumes", ""])
             methods.append(["Actors", ""])

--- a/tvtk/util/gradient_editor.py
+++ b/tvtk/util/gradient_editor.py
@@ -234,7 +234,7 @@ class GradientTable:
         return r, g, b, a
 
     def get_pos_color(self,f):
-        """return a Color object representing the color which is lies at
+        r"""return a Color object representing the color which is lies at
         position f \in [0..1] in the current gradient"""
         result = Color()
         e = self.get_color_hsva(f)
@@ -242,7 +242,7 @@ class GradientTable:
         return result
 
     def get_pos_rgba_color_lerped(self,f):
-        """return a (r,g,b,a) color representing the color which is lies at
+        r"""return a (r,g,b,a) color representing the color which is lies at
         position f \in [0..1] in the current gradient. if f is outside the
         [0..1] interval, the result will be clamped to this
         interval."""


### PR DESCRIPTION
Fixes errors like:
```
SyntaxError: invalid escape sequence \i
```
by using `r` strings.