### PR TITLE
FIX: Fix nose leftovers

### DIFF
--- a/mayavi/tests/test_csv_sniff.py
+++ b/mayavi/tests/test_csv_sniff.py
@@ -10,8 +10,8 @@ import os.path
 import sys
 import unittest
 import tempfile
+from unittest import SkipTest
 
-import nose
 from numpy import array, ndarray
 
 from mayavi.tools.data_wizards.csv_sniff import \
@@ -136,7 +136,7 @@ class Test_csv_py_files(Util):
             is the same as the array in csv_files/<name>.py
         """
         if skip_if_win and sys.platform.startswith('win'):
-            raise nose.SkipTest
+            raise SkipTest
 
         # Note: The files needed for the test are currently accessed directly.
         #       This assumes that the files are present, and not in a zipped

--- a/mayavi/tests/test_extract_grid_filter.py
+++ b/mayavi/tests/test_extract_grid_filter.py
@@ -108,8 +108,7 @@ class TestExtractGridFilter(unittest.TestCase):
     def test_extract_grid_filter_sample(self):
         import sys
         if sys.platform != "darwin":
-            from nose import SkipTest
-            raise SkipTest("actor.bounds returns incorrect values")
+            raise unittest.SkipTest("actor.bounds returns incorrect values")
         "Test if the sample rate works."
         eg = self.eg
         gpx = self.gpx
@@ -145,8 +144,7 @@ class TestExtractGridFilter(unittest.TestCase):
     def test_voi(self):
         import sys
         if sys.platform != "darwin":
-            from nose import SkipTest
-            raise SkipTest("actor.bounds returns incorrect values")
+            raise unittest.SkipTest("actor.bounds returns incorrect values")
         "Test if setting the VOI works correctly."
         eg = self.eg
         gpx = self.gpx

--- a/mayavi/tests/test_mlab_integration.py
+++ b/mayavi/tests/test_mlab_integration.py
@@ -381,7 +381,7 @@ class TestMlabHelperFunctions(TestMlabNullEngine, UnittestTools):
     def test_imshow_colormap(self):
         # Check if the pipeline is refreshed when we change colormap.
         # See issue #262
-        a = np.random.random_integers(0, 10, (100, 100))
+        a = np.random.randint(0, 10 + 1, (100, 100))
 
         actor = mlab.imshow(a, colormap="cool")
 

--- a/mayavi/tests/test_preferences_mirror.py
+++ b/mayavi/tests/test_preferences_mirror.py
@@ -11,7 +11,7 @@ from apptools.preferences.api import Preferences, PreferencesHelper
 from mayavi.tools.preferences_mirror import PreferencesMirror
 
 
-class TestPreference(PreferencesHelper):
+class _TestPreference(PreferencesHelper):
     """A simple test preference helper."""
     preferences_path = "test"
 
@@ -28,7 +28,7 @@ class ClassNameTest(unittest.TestCase):
         pref_file = resource_filename('mayavi.tests',
                                       'test_preference.ini')
         self.preferences.load(pref_file)
-        self.pref = TestPreference()
+        self.pref = _TestPreference()
         self.mirror = PreferencesMirror()
         self.mirror.preferences = self.pref
 
@@ -45,7 +45,7 @@ class ClassNameTest(unittest.TestCase):
         pref = self.pref
         mirror = self.mirror
         # Save original state.
-        saved = pref.get()
+        saved = pref.trait_get()
         pref.trait_set(bg = 'white', width=20, show=True)
         self.assertEqual(pref.bg, mirror.bg)
         self.assertEqual(pref.width, mirror.width)
@@ -57,7 +57,7 @@ class ClassNameTest(unittest.TestCase):
         """mirror must not sync changes back to the original preferences."""
         pref = self.pref
         mirror = self.mirror
-        saved = pref.get()
+        saved = pref.trait_get()
         mirror.trait_set(bg = 'white', width=20, show=True)
         self.assertNotEqual(pref.bg, mirror.bg)
         self.assertNotEqual(pref.width, mirror.width)
@@ -70,7 +70,7 @@ class ClassNameTest(unittest.TestCase):
         """Are Mirror's preferences saved correctly"""
         pref = self.pref
         mirror = self.mirror
-        saved = pref.get()
+        saved = pref.trait_get()
         mirror.trait_set(bg = 'white', width=20, show=True)
         mirror.save()
         self.assertEqual(pref.bg, mirror.bg)

--- a/mayavi/tests/test_recorder.py
+++ b/mayavi/tests/test_recorder.py
@@ -46,11 +46,13 @@ class Child(HasTraits):
     def not_recordable(self):
         pass
 
+
 class Parent(HasTraits):
     children = List(Child, record=True)
     recorder = Instance(Recorder, record=False)
 
-class Test(HasTraits):
+
+class _Test(HasTraits):
     # This should be set.
     recorder = Instance(HasTraits)
 
@@ -290,7 +292,7 @@ class TestRecorder(unittest.TestCase):
 
     def test_recorder_and_ignored(self):
         "Test if recorder trait is set and private traits are ignored."
-        t = Test()
+        t = _Test()
         self.assertEqual(t.recorder, None)
         self.assertEqual(t._ignore, False)
         self.assertEqual(t.ignore_, False)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[tool:pytest]
+filterwarnings =
+    # Currently unsatisfiable
+    ignore:Workbench will be moved from pyface:PendingDeprecationWarning


### PR DESCRIPTION
This allows `pytest mayavi` to work with fewer warnings, and no need for `nose` to be installed.

Also fixes a NumPy deprecation for `random_integers`, and a few for `get` vs `trait_get`.