### PR TITLE
Use edm 1.10.1 in travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 
 env:
   global:
-    - INSTALL_EDM_VERSION=1.9.1
+    - INSTALL_EDM_VERSION=1.10.1
       PYTHONUNBUFFERED="1"
 
 matrix:


### PR DESCRIPTION
the primary purpose of this PR is to trigger CI so that mayavi is tested against the latest released versions of it's dependencies.