### PR TITLE
Fix issue #770

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
   - if [[ ${ETS_TOOLKIT} == 'qt4' && ${RUNTIME} == '3.6' ]]; then edm run -- pip install "pyqt5==5.10.1"; fi
   - edm run -- pip install -r ci/ci-requirements.txt
   - if [[ ${VTK} == '8' ]]; then edm run -- pip install vtk; fi
-  - if [[ ${VTK} != '8' ]]; then edm install -y vtk; fi
+  - if [[ ${VTK} != '8' ]]; then edm install -y vtk==7.0.0-3; fi
   - edm run -- python -c "import vtk; print(vtk.vtkVersion.GetVTKSourceVersion())"
   - edm run -- python setup.py develop
 

--- a/mayavi/tests/test_mlab_integration.py
+++ b/mayavi/tests/test_mlab_integration.py
@@ -24,12 +24,10 @@ from mayavi.tools.engine_manager import engine_manager
 from mayavi.core.registry import registry
 from mayavi.tests.common import get_example_data
 
-push_exception_handler(reraise_exceptions=True)  # XXX should probably be elsewhere
+# XXX should probably be elsewhere
+push_exception_handler(reraise_exceptions=True)
 
 
-################################################################################
-# class `TestMlabNullEngine`
-###############################################################################
 class TestMlabNullEngine(unittest.TestCase):
     """ Stub mlab to isolate as well as possible from creation of a new
         figure.
@@ -51,7 +49,7 @@ class TestMlabNullEngine(unittest.TestCase):
     def tearDown(self):
         # Check that the NullEngine is still the mlab engine
         current_engine = mlab.get_engine()
-        engine_overridden = not current_engine is self.e
+        engine_overridden = current_engine is not self.e
         engine_manager.current_engine = None
         self.e.stop()
         registry.unregister_engine(self.e)
@@ -61,12 +59,10 @@ class TestMlabNullEngine(unittest.TestCase):
             raise AssertionError("The NullEngine has been overridden")
 
 
-################################################################################
-# class `TestMlabNullEngineMisc`
-################################################################################
 class TestMlabNullEngineMisc(TestMlabNullEngine):
     """ Misc tests for mlab with the null engine
     """
+
     def test_contour_filter(self):
         a = np.zeros((3, 3, 3))
         a[1, 1, 1] = 1
@@ -77,9 +73,9 @@ class TestMlabNullEngineMisc(TestMlabNullEngine):
         x, y, z = filter.get_output_dataset().points.to_array().T
 
         # Check that the contour filter indeed did its work:
-        np.testing.assert_almost_equal(x, [ 2. ,  2. ,  1.5,  2.5,  2. ,  2. ])
-        np.testing.assert_almost_equal(y, [ 2. ,  1.5,  2. ,  2. ,  2.5,  2. ])
-        np.testing.assert_almost_equal(z, [ 1.5,  2. ,  2. ,  2. ,  2. ,  2.5])
+        np.testing.assert_almost_equal(x, [2., 2., 1.5, 2.5, 2., 2.])
+        np.testing.assert_almost_equal(y, [2., 1.5, 2., 2., 2.5, 2.])
+        np.testing.assert_almost_equal(z, [1.5, 2., 2., 2., 2., 2.5])
 
         # Check that the filter was not added to a live scene:
         if filter.scene is not None:
@@ -91,7 +87,9 @@ class TestMlabNullEngineMisc(TestMlabNullEngine):
         density = mlab.pipeline.user_defined(src, filter='GaussianSplatter')
 
         self.assertEqual(len(density.outputs), 1)
-        self.assertTrue(isinstance(density.get_output_dataset(), tvtk.ImageData))
+        self.assertTrue(
+            isinstance(density.get_output_dataset(), tvtk.ImageData)
+        )
 
     def test_mlab_source(self):
         # Test for functions taking 3D scalar data
@@ -101,7 +99,8 @@ class TestMlabNullEngineMisc(TestMlabNullEngine):
             (mlab.pipeline.scalar_field, mlab.pipeline.image_plane_widget),
             (mlab.contour3d, ),
             (mlab.volume_slice, ),
-            (mlab.points3d, ), )
+            (mlab.points3d, ),
+        )
         data = np.random.random((3, 3, 3))
         for pipeline in pipelines:
             obj = pipeline[0](data)
@@ -115,11 +114,13 @@ class TestMlabNullEngineMisc(TestMlabNullEngine):
             (mlab.surf, ),
             (mlab.quiver3d, ),
             (mlab.pipeline.vector_scatter, ),
-            (mlab.pipeline.vector_scatter,
-                            mlab.pipeline.extract_vector_components),
-            (mlab.pipeline.vector_scatter,
-                            mlab.pipeline.extract_vector_norm),
-            (mlab.pipeline.array2d_source, ), )
+            (
+                mlab.pipeline.vector_scatter,
+                mlab.pipeline.extract_vector_components
+            ),
+            (mlab.pipeline.vector_scatter, mlab.pipeline.extract_vector_norm),
+            (mlab.pipeline.array2d_source, ),
+        )
         for pipeline in pipelines:
             obj = pipeline[0](x, y, z)
             for factory in pipeline[1:]:
@@ -211,17 +212,15 @@ class TestMlabNullEngineMisc(TestMlabNullEngine):
         # test of the source, as to get a segfault, we need a module
         # opened on the source.
         n = 100
-        triangles = np.c_[np.arange(n-3),
-                            np.arange(n-3)+1,
-                            n-1-np.arange(n-3)]
+        triangles = np.c_[np.arange(n - 3),
+                          np.arange(n - 3) + 1, n - 1 - np.arange(n - 3)]
         x, y, z = np.random.random((3, n))
         src = mlab.triangular_mesh(x, y, z, triangles)
 
         # Now grow the mesh
         n = 1000
-        triangles = np.c_[np.arange(n-3),
-                            np.arange(n-3)+1,
-                            n-1-np.arange(n-3)]
+        triangles = np.c_[np.arange(n - 3),
+                          np.arange(n - 3) + 1, n - 1 - np.arange(n - 3)]
         x, y, z = np.random.random((3, n))
         src.mlab_source.reset(x=x, y=y, z=z, triangles=triangles)
 
@@ -234,11 +233,11 @@ class TestMlabNullEngineMisc(TestMlabNullEngine):
         s2 = mlab.surf(a, color=(0, 0, 0))
         mlab.colorbar()
         self.assertEqual(
-                    s2.module_manager.scalar_lut_manager.show_scalar_bar,
-                    False)
+            s2.module_manager.scalar_lut_manager.show_scalar_bar, False
+        )
         self.assertEqual(
-                    s1.module_manager.scalar_lut_manager.show_scalar_bar,
-                    True)
+            s1.module_manager.scalar_lut_manager.show_scalar_bar, True
+        )
 
     def test_source_can_save_output_to_file(self):
         # Given
@@ -269,15 +268,13 @@ class TestMlabNullEngineMisc(TestMlabNullEngine):
         sug = mlab.pipeline.slice_unstructured_grid(eg)
 
         # Then
-        assert_allclose(
-            sug.actor.actor.bounds, (1.0, 2.0, 0.0, 1.0, 0.0, 1.0)
-        )
+        assert_allclose(sug.actor.actor.bounds, (1.0, 2.0, 0.0, 1.0, 0.0, 1.0))
 
     def test_set_active_attribute(self):
         # Given
         x, y = np.mgrid[0:10:100j, 0:10:100j]
         z = x**2 + y**2
-        w = np.arctan(x/(y+0.1))
+        w = np.arctan(x / (y + 0.1))
 
         # Create the data source
         src = mlab.pipeline.array2d_source(z)
@@ -291,16 +288,14 @@ class TestMlabNullEngineMisc(TestMlabNullEngine):
 
         # select the array from a copy
         # When/Then
-        f = mlab.pipeline.set_active_attribute(dataset,
-                                               point_scalars='color')
-        self.assertFalse(np.allclose(
-            f.get_output_dataset().point_data.scalars.range, scalar_range
-        ))
+        f = mlab.pipeline.set_active_attribute(dataset, point_scalars='color')
+        self.assertFalse(
+            np.allclose(
+                f.get_output_dataset().point_data.scalars.range, scalar_range
+            )
+        )
 
 
-################################################################################
-# class `TestMlabPipeline`
-################################################################################
 class TestMlabPipeline(TestMlabNullEngine):
     """ Test the pipeline functions.
         For vtk versions greater than 5.10, widgets need
@@ -336,18 +331,14 @@ class TestMlabPipeline(TestMlabNullEngine):
         iso = mlab.contour3d(x, y, z, r)
         x_, y_, z_ = np.random.random((3, 10, 4, 2))
         r_ = mlab.pipeline.probe_data(iso, x_, y_, z_)
-        np.testing.assert_array_almost_equal(r_,
-                                             np.sqrt(x_**2 + y_**2 + z_**2),
-                                             decimal=1)
+        np.testing.assert_array_almost_equal(
+            r_, np.sqrt(x_**2 + y_**2 + z_**2), decimal=1
+        )
         flow = mlab.flow(x, y, z, x, y, z)
-        u_, v_, w_ = mlab.pipeline.probe_data(flow, x_, y_, z_,
-                                              type='vectors')
-        np.testing.assert_array_almost_equal(u_, x_,
-                                             decimal=2)
-        np.testing.assert_array_almost_equal(v_, y_,
-                                             decimal=2)
-        np.testing.assert_array_almost_equal(w_, z_,
-                                             decimal=3)
+        u_, v_, w_ = mlab.pipeline.probe_data(flow, x_, y_, z_, type='vectors')
+        np.testing.assert_array_almost_equal(u_, x_, decimal=2)
+        np.testing.assert_array_almost_equal(v_, y_, decimal=2)
+        np.testing.assert_array_almost_equal(w_, z_, decimal=3)
 
 
 ################################################################################
@@ -375,8 +366,7 @@ class TestMlabHelperFunctions(TestMlabNullEngine, UnittestTools):
         obj = mlab.imshow(s)
 
     def test_imshow_extent(self):
-        mlab.imshow(np.random.rand(10, 20),
-                    extent=[-1, 11, -1, 21, 0, 0])
+        mlab.imshow(np.random.rand(10, 20), extent=[-1, 11, -1, 21, 0, 0])
 
     def test_imshow_colormap(self):
         # Check if the pipeline is refreshed when we change colormap.
@@ -395,12 +385,10 @@ class TestMlabHelperFunctions(TestMlabNullEngine, UnittestTools):
         self.assertEqual(ipw.ipw.plane_orientation, 'y_axes')
 
 
-################################################################################
-# class `TestMlabModules`
-################################################################################
 class TestMlabModules(TestMlabNullEngine):
     """ Test the mlab modules.
     """
+
     def test_volume(self):
         """ Test the mlab volume factory.
         """
@@ -415,9 +403,9 @@ class TestMlabModules(TestMlabNullEngine):
             # use allclose() to match the tuples.
             np.allclose(vol._ctf.get_color(value), color)
         # Test the vmin and vmax features
-        for value in 0.5*np.random.random(10):
+        for value in 0.5 * np.random.random(10):
             self.assertEqual(vol._otf.get_value(value), 0)
-        for value in (0.9+0.1*np.random.random(10)):
+        for value in (0.9 + 0.1 * np.random.random(10)):
             self.assertEqual(vol._otf.get_value(value), 0.2)
         # Test the rescaling of the colormap when using vmin and vmax
         # Rmq: we have to be careful: the range of the ctf can change
@@ -427,19 +415,20 @@ class TestMlabModules(TestMlabNullEngine):
         range2 = vol2._ctf.range[1] - vol2._ctf.range[0]
         for value in np.random.random(10):
             np.testing.assert_array_almost_equal(
-                vol1._ctf.get_color(range1*value),
-                vol2._ctf.get_color(0.25 + 0.5*range2*value)
+                vol1._ctf.get_color(range1 * value),
+                vol2._ctf.get_color(0.25 + 0.5 * range2 * value)
             )
         # Test outside the special [0, 1] range
-        src = mlab.pipeline.scalar_field(2*scalars)
+        src = mlab.pipeline.scalar_field(2 * scalars)
         vol1 = mlab.pipeline.volume(src)
         range1 = vol1._ctf.range[1] - vol1._ctf.range[0]
         vol2 = mlab.pipeline.volume(src, vmin=0.5, vmax=1.5)
         range2 = vol2._ctf.range[1] - vol2._ctf.range[0]
         for value in np.random.random(10):
             np.testing.assert_array_almost_equal(
-                        vol1._ctf.get_color(2*range1*value),
-                        vol2._ctf.get_color(0.5+range2*value))
+                vol1._ctf.get_color(2 * range1 * value),
+                vol2._ctf.get_color(0.5 + range2 * value)
+            )
 
     def test_text(self):
         """ Test the text module.
@@ -459,9 +448,17 @@ class TestMlabModules(TestMlabNullEngine):
         """
         data = np.random.random((3, 3, 3))
         src = mlab.pipeline.scalar_field(data)
-        t = mlab.text3d(0, 0, 0, 'foo', opacity=0.5, scale=2,
-                    orient_to_camera=False, color=(0, 0, 0),
-                    orientation=(90, 0, 0))
+        t = mlab.text3d(
+            0,
+            0,
+            0,
+            'foo',
+            opacity=0.5,
+            scale=2,
+            orient_to_camera=False,
+            color=(0, 0, 0),
+            orientation=(90, 0, 0)
+        )
 
     def test_contour_grid_plane(self):
         """Test the contour_grid_plane.
@@ -475,33 +472,32 @@ class TestMlabModules(TestMlabNullEngine):
     def test_barchart(self):
         """Test the barchart function."""
 
-        s = np.abs(np.random.random((3,3)))
+        s = np.abs(np.random.random((3, 3)))
         b = mlab.barchart(s)
-        self.assertEqual(b.glyph.glyph.scale_mode,
-                         'scale_by_vector_components')
+        self.assertEqual(
+            b.glyph.glyph.scale_mode, 'scale_by_vector_components'
+        )
         s += 1
         b.mlab_source.update()
-        self.assertEqual(b.glyph.glyph.scale_mode,
-                         'scale_by_vector_components')
+        self.assertEqual(
+            b.glyph.glyph.scale_mode, 'scale_by_vector_components'
+        )
 
     def test_axes(self):
         s = mlab.test_plot3d()
         a = mlab.axes(s)
         assert_allclose(
-            a.axes.ranges, [-1.5, 1.5, -1.5, 1.5, -0.5, 0.5],
-            rtol=0, atol=0.1
+            a.axes.ranges, [-1.5, 1.5, -1.5, 1.5, -0.5, 0.5], rtol=0, atol=0.1
         )
 
-################################################################################
-# class `TestMlabAnimate`
-################################################################################
-class TestMlabAnimate(TestMlabNullEngine):
 
+class TestMlabAnimate(TestMlabNullEngine):
     def test_animate_sets_up_movie_maker(self):
         # Given
         @mlab.animate(ui=False)
         def anim():
-            for i in range(5): yield
+            for i in range(5):
+                yield
 
         self.e.new_scene()
         from mayavi.tests.test_file_timestep import make_mock_scene

--- a/mayavi/tests/test_mlab_integration.py
+++ b/mayavi/tests/test_mlab_integration.py
@@ -296,6 +296,54 @@ class TestMlabNullEngineMisc(TestMlabNullEngine):
         )
 
 
+class TestSourceReset(TestMlabNullEngine):
+    def test_glyph_reset_twice_with_fewer_points(self):
+        # Given
+        x, y, z = np.random.random((3, 100))
+        g = mlab.quiver3d(x, y, z, x, y, z)
+        src = g.mlab_source
+
+        # When/Then
+        x, y, z = np.random.random((3, 5))
+        src.reset(x=x, y=y, z=z, u=x, v=y, w=z)
+
+    def test_lines_reset_twice_with_fewer_points(self):
+        # Given
+        t = np.linspace(0, 10, 100)
+        x, y = np.cos(t), np.sin(t)
+        l = mlab.plot3d(x, y, t, t)
+
+        # When/Then
+        t = np.linspace(0, 10, 5)
+        x, y = np.cos(t), np.sin(t)
+        # If this works without a segfault, we are good.
+        l.mlab_source.reset(x=x, y=y, z=t, scalars=t)
+
+    def test_mesh_reset_twice_with_fewer_points(self):
+        # Given
+        x, y = np.mgrid[0:1:10j, 0:1:10j]
+        surf = mlab.mesh(x, y, x+y)
+
+        # When/Then
+        x, y = np.mgrid[0:1:2j, 0:1:2j]
+        # If this works without a segfault, we are good.
+        surf.mlab_source.reset(x=x, y=y, z=x+y, scalars=(x+y))
+
+    def test_trimesh_reset_twice_with_fewer_points(self):
+        # Given
+        x, y, z = np.random.random((3, 100))
+        cells = np.random.randint(0, 100, 300)
+        cells.resize((100, 3))
+        surf = mlab.triangular_mesh(x, y, z, cells)
+
+        # When/Then
+        x, y, z = np.random.random((3, 5))
+        cells = np.random.randint(0, 5, 15)
+        cells.resize((5, 3))
+        # If this works without a segfault, we are good.
+        surf.mlab_source.reset(x=x, y=y, z=z, triangles=cells)
+
+
 class TestMlabPipeline(TestMlabNullEngine):
     """ Test the pipeline functions.
         For vtk versions greater than 5.10, widgets need

--- a/mayavi/tests/test_mlab_source.py
+++ b/mayavi/tests/test_mlab_source.py
@@ -6,7 +6,7 @@ Test for MlabSource and its subclasses.
 # License: BSD Style.
 
 import unittest
-import numpy as N
+import numpy as np
 from mock import patch
 
 from tvtk.api import tvtk
@@ -19,11 +19,11 @@ from mayavi.sources.vtk_data_source import VTKDataSource
 ###############################################################################
 class TestMGlyphSource(unittest.TestCase):
     def setUp(self):
-        self.x = x = N.ones(10, float)
-        self.y = y = N.ones(10, float)*2.0
-        self.z = z = N.linspace(0, 10, 10)
-        self.v = v = N.ones((10, 3), float)*10.0
-        self.s = s = N.ones(10, float)
+        self.x = x = np.ones(10, float)
+        self.y = y = np.ones(10, float)*2.0
+        self.z = z = np.linspace(0, 10, 10)
+        self.v = v = np.ones((10, 3), float)*10.0
+        self.s = s = np.ones(10, float)
         src = sources.MGlyphSource()
         src.reset(x=x, y=y, z=z, u=v[:, 0], v=v[:, 1], w=v[:, 2], scalars=s)
         self.src = src
@@ -38,28 +38,28 @@ class TestMGlyphSource(unittest.TestCase):
         """Check if the sources traits are set correctly."""
         x, y, z, v, s, src = self.get_data()
         # Check if points are set correctly.
-        self.assertEqual(N.alltrue(src.points[:, 0].ravel() == x.ravel()),
+        self.assertEqual(np.alltrue(src.points[:, 0].ravel() == x.ravel()),
                          True)
-        self.assertEqual(N.alltrue(src.points[:, 1].ravel() == y.ravel()),
+        self.assertEqual(np.alltrue(src.points[:, 1].ravel() == y.ravel()),
                          True)
-        self.assertEqual(N.alltrue(src.points[:, 2].ravel() == z.ravel()),
+        self.assertEqual(np.alltrue(src.points[:, 2].ravel() == z.ravel()),
                          True)
         # Check the vectors and scalars.
-        self.assertEqual(N.alltrue(src.vectors == v), True)
-        self.assertEqual(N.alltrue(src.scalars == s), True)
+        self.assertEqual(np.alltrue(src.vectors == v), True)
+        self.assertEqual(np.alltrue(src.scalars == s), True)
 
     def check_dataset(self):
         """Check the TVTK dataset."""
         x, y, z, v, s, src = self.get_data()
         # Check if the dataset is setup right.
         pts = src.dataset.points.to_array()
-        self.assertEqual(N.alltrue(pts[:, 0].ravel() == x.ravel()), True)
-        self.assertEqual(N.alltrue(pts[:, 1].ravel() == y.ravel()), True)
-        self.assertEqual(N.alltrue(pts[:, 2].ravel() == z.ravel()), True)
+        self.assertEqual(np.alltrue(pts[:, 0].ravel() == x.ravel()), True)
+        self.assertEqual(np.alltrue(pts[:, 1].ravel() == y.ravel()), True)
+        self.assertEqual(np.alltrue(pts[:, 2].ravel() == z.ravel()), True)
         vec = src.dataset.point_data.vectors.to_array()
         sc = src.dataset.point_data.scalars.to_array()
-        self.assertEqual(N.alltrue(vec == v), True)
-        self.assertEqual(N.alltrue(sc == s.ravel()), True)
+        self.assertEqual(np.alltrue(vec == v), True)
+        self.assertEqual(np.alltrue(sc == s.ravel()), True)
 
     def test_reset_with_same_size_data(self):
         x, y, z, v, s, src = self.get_data()
@@ -83,11 +83,11 @@ class TestMGlyphSource(unittest.TestCase):
         # Call reset again with just a few things changed to see if it
         # works correctly.
 
-        self.x = x = N.ones(20, float)*30.0
-        self.y = y = N.ones(20, float)*30.0
-        self.z = z = N.ones(20, float)*30.0
-        self.s = s = N.ones(20, float)
-        self.v = v = N.ones((20, 3), float)*30.0
+        self.x = x = np.ones(20, float)*30.0
+        self.y = y = np.ones(20, float)*30.0
+        self.z = z = np.ones(20, float)*30.0
+        self.s = s = np.ones(20, float)
+        self.v = v = np.ones((20, 3), float)*30.0
 
         src.reset(x=x, y=y, z=z, u=v[:, 0], v=v[:, 1], w=v[:, 2],
                   scalars=s)
@@ -98,13 +98,13 @@ class TestMGlyphSource(unittest.TestCase):
         " Test the reset method when the inputs are 2-d arrays."
 
         x, y, z, v, s, src = self.get_data()
-        self.x = x = N.reshape(x, (5, 2))
-        self.y = y = N.reshape(y, (5, 2))
-        self.z = z = N.reshape(z, (5, 2))
-        u = N.reshape(v[:, 0], (5, 2))
-        vv = N.reshape(v[:, 1], (5, 2))
-        w = N.reshape(v[:, 2], (5, 2))
-        self.s = s = N.reshape(s, (5, 2))
+        self.x = x = np.reshape(x, (5, 2))
+        self.y = y = np.reshape(y, (5, 2))
+        self.z = z = np.reshape(z, (5, 2))
+        u = np.reshape(v[:, 0], (5, 2))
+        vv = np.reshape(v[:, 1], (5, 2))
+        w = np.reshape(v[:, 2], (5, 2))
+        self.s = s = np.reshape(s, (5, 2))
         src.reset(x=x, y=y, z=z, u=u, v=vv, w=w, scalars=s)
         self.check_traits()
         self.check_dataset()
@@ -132,13 +132,13 @@ class TestMGlyphSource(unittest.TestCase):
         """
         # Initialize with 2-d array data.
         x, y, z, v, s, src = self.get_data()
-        x = N.reshape(x, (5, 2))
-        y = N.reshape(y, (5, 2))
-        z = N.reshape(z, (5, 2))
-        u = N.reshape(v[:, 0], (5, 2))
-        vv = N.reshape(v[:, 1], (5, 2))
-        w = N.reshape(v[:, 2], (5, 2))
-        s = N.reshape(s, (5, 2))
+        x = np.reshape(x, (5, 2))
+        y = np.reshape(y, (5, 2))
+        z = np.reshape(z, (5, 2))
+        u = np.reshape(v[:, 0], (5, 2))
+        vv = np.reshape(v[:, 1], (5, 2))
+        w = np.reshape(v[:, 2], (5, 2))
+        s = np.reshape(s, (5, 2))
         src.reset(x=x, y=y, z=z, u=u, v=vv, w=w, scalars=s)
 
         # modify variables in src to check handlers
@@ -179,27 +179,24 @@ class TestMGlyphSource(unittest.TestCase):
     def test_reset_changes_pipeline(self):
         # Given
         from mayavi import mlab
-        x, y, z = N.random.random((3, 10))
+        x, y, z = np.random.random((3, 10))
         g = mlab.points3d(x, y, z, x*x + y*y + z*z)
         bounds = g.actor.actor.bounds
 
         # When
-        x, y, z = N.random.random((3, 20))
+        x, y, z = np.random.random((3, 20))
         g.mlab_source.reset(x=x, y=y, z=z, scalars=x*x + y*y + z*z)
 
         # Then
-        self.assertFalse(N.allclose(bounds, g.actor.actor.bounds))
+        self.assertFalse(np.allclose(bounds, g.actor.actor.bounds))
 
 
-################################################################################
-# `TestMGlyphSource`
-################################################################################
 class TestMVerticalSource(unittest.TestCase):
     def setUp(self):
-        self.x = x = N.ones(10, float)
-        self.y = y = N.ones(10, float)*2.0
-        self.z = z = N.linspace(0, 10, 10)
-        self.s = s = N.ones(10, float)
+        self.x = x = np.ones(10, float)
+        self.y = y = np.ones(10, float)*2.0
+        self.z = z = np.linspace(0, 10, 10)
+        self.s = s = np.ones(10, float)
         src = sources.MVerticalGlyphSource()
         src.reset(x=x, y=y, z=z, scalars=s)
         self.src = src
@@ -214,27 +211,27 @@ class TestMVerticalSource(unittest.TestCase):
         """Check if the sources traits are set correctly."""
         x, y, z, s, src = self.get_data()
         # Check if points are set correctly.
-        self.assertEqual(N.alltrue(src.points[:,0].ravel() == x), True)
-        self.assertEqual(N.alltrue(src.points[:,1].ravel() == y), True)
-        self.assertEqual(N.alltrue(src.points[:,2].ravel() == z), True)
+        self.assertEqual(np.alltrue(src.points[:, 0].ravel() == x), True)
+        self.assertEqual(np.alltrue(src.points[:, 1].ravel() == y), True)
+        self.assertEqual(np.alltrue(src.points[:, 2].ravel() == z), True)
         # Check the vectors and scalars.
-        self.assertEqual(N.alltrue(src.vectors[:, -1] == s), True)
-        self.assertEqual(N.alltrue(src.vectors[:, :-1] == 1), True)
-        self.assertEqual(N.alltrue(src.scalars == s), True)
+        self.assertEqual(np.alltrue(src.vectors[:, -1] == s), True)
+        self.assertEqual(np.alltrue(src.vectors[:, :-1] == 1), True)
+        self.assertEqual(np.alltrue(src.scalars == s), True)
 
     def check_dataset(self):
         """Check the TVTK dataset."""
         x, y, z, s, src = self.get_data()
         # Check if the dataset is setup right.
         pts = src.dataset.points.to_array()
-        self.assertEqual(N.alltrue(pts[:,0].ravel() == x), True)
-        self.assertEqual(N.alltrue(pts[:,1].ravel() == y), True)
-        self.assertEqual(N.alltrue(pts[:,2].ravel() == z), True)
+        self.assertEqual(np.alltrue(pts[:, 0].ravel() == x), True)
+        self.assertEqual(np.alltrue(pts[:, 1].ravel() == y), True)
+        self.assertEqual(np.alltrue(pts[:, 2].ravel() == z), True)
         vec = src.dataset.point_data.vectors.to_array()
         sc = src.dataset.point_data.scalars.to_array()
-        self.assertEqual(N.alltrue(vec[:, -1] == s), True)
-        self.assertEqual(N.alltrue(vec[:, :-1] == 1), True)
-        self.assertEqual(N.alltrue(sc == s), True)
+        self.assertEqual(np.alltrue(vec[:, -1] == s), True)
+        self.assertEqual(np.alltrue(vec[:, :-1] == 1), True)
+        self.assertEqual(np.alltrue(sc == s), True)
 
     def test_reset(self):
         "Test the reset method."
@@ -260,11 +257,11 @@ class TestMVerticalSource(unittest.TestCase):
         # Call reset again with just a few things changed to see if it
         # works correctly.
 
-        self.x = x = N.ones(20, float)*30.0
-        self.y = y = N.ones(20, float)*30.0
-        self.z = z = N.ones(20, float)*30.0
-        points = N.ones((20, 3), float)*30.0
-        self.s = s = N.ones(20, float)
+        self.x = x = np.ones(20, float)*30.0
+        self.y = y = np.ones(20, float)*30.0
+        self.z = z = np.ones(20, float)*30.0
+        points = np.ones((20, 3), float)*30.0
+        self.s = s = np.ones(20, float)
 
         src.reset(x=x, y=y, z=z, scalars=s, points=points)
         self.check_traits()
@@ -295,22 +292,19 @@ class TestMVerticalSource(unittest.TestCase):
         self.check_dataset()
 
 
-################################################################################
-# `TestMArraySource`
-################################################################################
 class TestMArraySource(unittest.TestCase):
     def setUp(self):
-        x, y, z = N.ogrid[-10:10:11j,
-                          -10:10:12j,
-                          -10:10:20j]
+        x, y, z = np.ogrid[-10:10:11j, -10:10:12j, -10:10:20j]
         self.x, self.y, self.z = x, y, z
         dims = (x.shape[0], y.shape[1], z.shape[2])
-        self.v = v = N.ones(dims + (3,), float)
-        v[...,2] = 2
-        v[...,2] = 3
-        self.s = s = N.ones(dims, float)
+        self.v = v = np.ones(dims + (3, ), float)
+        v[..., 2] = 2
+        v[..., 2] = 3
+        self.s = s = np.ones(dims, float)
         src = sources.MArraySource()
-        src.reset(x=x, y=y, z=z, u=v[...,0], v=v[...,1], w=v[...,2], scalars=s)
+        src.reset(
+            x=x, y=y, z=z, u=v[..., 0], v=v[..., 1], w=v[..., 2], scalars=s
+        )
         self.src = src
 
     def tearDown(self):
@@ -323,12 +317,12 @@ class TestMArraySource(unittest.TestCase):
         """Check if the sources traits are set correctly."""
         x, y, z, v, s, src = self.get_data()
         # Check if points are set correctly.
-        self.assertEqual(N.alltrue(src.x == x), True)
-        self.assertEqual(N.alltrue(src.y == y), True)
-        self.assertEqual(N.alltrue(src.z == z), True)
+        self.assertEqual(np.alltrue(src.x == x), True)
+        self.assertEqual(np.alltrue(src.y == y), True)
+        self.assertEqual(np.alltrue(src.z == z), True)
         # Check the vectors and scalars.
-        self.assertEqual(N.alltrue(src.vectors == v), True)
-        self.assertEqual(N.alltrue(src.scalars == s), True)
+        self.assertEqual(np.alltrue(src.vectors == v), True)
+        self.assertEqual(np.alltrue(src.scalars == s), True)
 
     def check_dataset(self):
         """Check the TVTK dataset."""
@@ -341,16 +335,16 @@ class TestMArraySource(unittest.TestCase):
         spacing = [dx, dy, dz]
         dimensions = (x.shape[0], y.shape[1], z.shape[2])
         ds = src.dataset
-        self.assertEqual(N.all(src.m_data.origin == origin), True)
-        self.assertEqual(N.allclose(src.m_data.spacing, spacing), True)
-        self.assertEqual(N.allclose(ds.dimensions, dimensions), True)
+        self.assertEqual(np.all(src.m_data.origin == origin), True)
+        self.assertEqual(np.allclose(src.m_data.spacing, spacing), True)
+        self.assertEqual(np.allclose(ds.dimensions, dimensions), True)
 
         vec = src.dataset.point_data.vectors.to_array()
         sc = src.dataset.point_data.scalars.to_array()
         v1 = v.transpose((2, 0, 1, 3))
-        self.assertEqual(N.alltrue(vec.ravel() == v1.ravel()), True)
+        self.assertEqual(np.alltrue(vec.ravel() == v1.ravel()), True)
         s1 = s.transpose()
-        self.assertEqual(N.alltrue(sc.ravel() == s1.ravel()), True)
+        self.assertEqual(np.alltrue(sc.ravel() == s1.ravel()), True)
 
     def test_reset(self):
         "Test the reset method."
@@ -363,7 +357,7 @@ class TestMArraySource(unittest.TestCase):
         x *= 5
         s *= 10
         v *= 0.1
-        src.reset(x=x, u=v[...,0], v=v[...,1], w=v[...,2], scalars=s)
+        src.reset(x=x, u=v[..., 0], v=v[..., 1], w=v[..., 2], scalars=s)
 
         self.check_traits()
         self.check_dataset()
@@ -376,18 +370,25 @@ class TestMArraySource(unittest.TestCase):
         # Call reset again with just a few things changed to see if it
         # works correctly.
 
-        x, y, z = N.ogrid[-10:10:11j,
-                          -10:10:12j,
-                          -10:10:20j]
+        x, y, z = np.ogrid[-10:10:11j, -10:10:12j, -10:10:20j]
         self.x, self.y, self.z = x, y, z
 
         dims = (x.shape[0], y.shape[1], z.shape[2])
-        self.v = v = N.ones(dims + (3,), float)
-        v[...,2] = 2
-        v[...,2] = 3
-        self.s = s = N.ones(dims, float)
+        self.v = v = np.ones(dims + (3, ), float)
+        v[..., 2] = 2
+        v[..., 2] = 3
+        self.s = s = np.ones(dims, float)
         src = sources.MArraySource()
-        src.reset(x=x, y=y, z=z, u=v[...,0], v=v[...,1], w=v[...,2], scalars=s,vectors=v)
+        src.reset(
+            x=x,
+            y=y,
+            z=z,
+            u=v[..., 0],
+            v=v[..., 1],
+            w=v[..., 2],
+            scalars=s,
+            vectors=v
+        )
         self.check_traits()
         self.check_dataset()
 
@@ -402,9 +403,9 @@ class TestMArraySource(unittest.TestCase):
         src.x = x
         src.y = y
         src.z = z
-        src.u = v[...,0]
-        src.v = v[...,1]
-        src.w = v[...,2]
+        src.u = v[..., 0]
+        src.v = v[..., 1]
+        src.w = v[..., 2]
         src.scalars = s
         self.check_traits()
         self.check_dataset()
@@ -420,16 +421,12 @@ class TestMArraySource(unittest.TestCase):
         self.check_dataset()
 
 
-
-################################################################################
-# `TestMLineSource`
-################################################################################
 class TestMLineSource(unittest.TestCase):
     def setUp(self):
-        self.x = x = N.ones(10, float)
-        self.y = y = N.ones(10, float)*2.0
-        self.z = z = N.linspace(0, 10, 10)
-        self.s = s = N.ones(10, float)
+        self.x = x = np.ones(10, float)
+        self.y = y = np.ones(10, float) * 2.0
+        self.z = z = np.linspace(0, 10, 10)
+        self.s = s = np.ones(10, float)
         src = sources.MLineSource()
         src.reset(x=x, y=y, z=z, scalars=s)
         self.src = src
@@ -444,22 +441,22 @@ class TestMLineSource(unittest.TestCase):
         """Check if the sources traits are set correctly."""
         x, y, z, s, src = self.get_data()
         # Check if points are set correctly.
-        self.assertEqual(N.alltrue(src.points[:,0].ravel() == x), True)
-        self.assertEqual(N.alltrue(src.points[:,1].ravel() == y), True)
-        self.assertEqual(N.alltrue(src.points[:,2].ravel() == z), True)
+        self.assertEqual(np.alltrue(src.points[:, 0].ravel() == x), True)
+        self.assertEqual(np.alltrue(src.points[:, 1].ravel() == y), True)
+        self.assertEqual(np.alltrue(src.points[:, 2].ravel() == z), True)
         # Check the scalars.
-        self.assertEqual(N.alltrue(src.scalars == s), True)
+        self.assertEqual(np.alltrue(src.scalars == s), True)
 
     def check_dataset(self):
         """Check the TVTK dataset."""
         x, y, z, s, src = self.get_data()
         # Check if the dataset is setup right.
         pts = src.dataset.points.to_array()
-        self.assertEqual(N.alltrue(pts[:,0].ravel() == x), True)
-        self.assertEqual(N.alltrue(pts[:,1].ravel() == y), True)
-        self.assertEqual(N.alltrue(pts[:,2].ravel() == z), True)
+        self.assertEqual(np.alltrue(pts[:, 0].ravel() == x), True)
+        self.assertEqual(np.alltrue(pts[:, 1].ravel() == y), True)
+        self.assertEqual(np.alltrue(pts[:, 2].ravel() == z), True)
         sc = src.dataset.point_data.scalars.to_array()
-        self.assertEqual(N.alltrue(sc == s), True)
+        self.assertEqual(np.alltrue(sc == s), True)
 
     def test_reset(self):
         "Test the reset method."
@@ -499,11 +496,11 @@ class TestMLineSource(unittest.TestCase):
         # Call reset again with just a few things changed to see if it
         # works correctly.
 
-        self.x = x = N.ones(20, float)*30.0
-        self.y = y = N.ones(20, float)*30.0
-        self.z = z = N.ones(20, float)*30.0
-        points = N.ones((20, 3), float)*30.0
-        self.s = s = N.ones(20, float)
+        self.x = x = np.ones(20, float)*30.0
+        self.y = y = np.ones(20, float)*30.0
+        self.z = z = np.ones(20, float)*30.0
+        points = np.ones((20, 3), float)*30.0
+        self.s = s = np.ones(20, float)
         src.reset(x=x, y=y, z=z, scalars=s, points=points)
         self.check_traits()
         self.check_dataset()
@@ -542,16 +539,16 @@ class TestMLineSource(unittest.TestCase):
     def test_reset_changes_pipeline(self):
         # Given
         from mayavi import mlab
-        x = N.linspace(0, 1, 10)
+        x = np.linspace(0, 1, 10)
         lines = mlab.plot3d(x, x, x, x)
         bounds = lines.actor.actor.bounds
 
         # When
-        x = N.linspace(0, 2, 20)
+        x = np.linspace(0, 2, 20)
         lines.mlab_source.reset(x=x, y=x, z=x, scalars=x)
 
         # Then
-        self.assertFalse(N.allclose(bounds, lines.actor.actor.bounds))
+        self.assertFalse(np.allclose(bounds, lines.actor.actor.bounds))
 
     def test_set_without_scalars_works(self):
         # Given
@@ -564,14 +561,14 @@ class TestMLineSource(unittest.TestCase):
         src.set(y=y+1)
 
         # Then
-        self.assertTrue(N.allclose(src.y, y + 1))
+        self.assertTrue(np.allclose(src.y, y + 1))
 
         # When
         src.reset(x=x, y=y+1, z=z+1)
 
         # Then
-        self.assertTrue(N.allclose(src.y, y + 1))
-        self.assertTrue(N.allclose(src.z, z + 1))
+        self.assertTrue(np.allclose(src.y, y + 1))
+        self.assertTrue(np.allclose(src.z, z + 1))
 
     def test_set_without_scalars_attribute_works(self):
         # Given
@@ -585,22 +582,18 @@ class TestMLineSource(unittest.TestCase):
         src.update()
 
         # Then
-        N.testing.assert_almost_equal(src.x, 1.0)
+        np.testing.assert_almost_equal(src.x, 1.0)
 
 
-################################################################################
-# `TestMArray2DSource`
-################################################################################
 class TestMArray2DSource(unittest.TestCase):
     def setUp(self):
-        x, y = N.mgrid[-10:10:11j,
-                          -10:10:12j]
+        x, y = np.mgrid[-10:10:11j, -10:10:12j]
 
-        self.x, self.y  = x, y
+        self.x, self.y = x, y
         dims = (x.shape[0], y.shape[1])
-        self.s = s = N.ones(dims, float)
+        self.s = s = np.ones(dims, float)
         src = sources.MArray2DSource()
-        src.reset(x=x, y=y,scalars=s)
+        src.reset(x=x, y=y, scalars=s)
         self.src = src
 
     def tearDown(self):
@@ -614,29 +607,29 @@ class TestMArray2DSource(unittest.TestCase):
         x, y, s, src = self.get_data()
 
         # Check if points are set correctly.
-        self.assertEqual(N.alltrue(src.x == x), True)
-        self.assertEqual(N.alltrue(src.y == y), True)
+        self.assertEqual(np.alltrue(src.x == x), True)
+        self.assertEqual(np.alltrue(src.y == y), True)
         # Check the scalars.
-        self.assertEqual(N.alltrue(src.scalars == s), True)
+        self.assertEqual(np.alltrue(src.scalars == s), True)
 
     def check_dataset(self):
         """Check the TVTK dataset."""
         x, y, s, src = self.get_data()
         # Check if the dataset is setup right.
-        x = N.atleast_2d(x.squeeze().T)[0, :].squeeze()
-        y = N.atleast_2d(y.squeeze())[0, :].squeeze()
+        x = np.atleast_2d(x.squeeze().T)[0, :].squeeze()
+        y = np.atleast_2d(y.squeeze())[0, :].squeeze()
         dx = x[1] - x[0]
         dy = y[1] - y[0]
 
-        origin = [x.min(), y.min(),0 ]
+        origin = [x.min(), y.min(), 0]
         spacing = [dx, dy, 1]
         ds = src.dataset
-        self.assertEqual(N.all(ds.origin == origin), True)
-        self.assertEqual(N.allclose(src.m_data.spacing, spacing), True)
+        self.assertEqual(np.all(ds.origin == origin), True)
+        self.assertEqual(np.allclose(src.m_data.spacing, spacing), True)
 
         sc = src.dataset.point_data.scalars.to_array()
         s1 = s.transpose()
-        self.assertEqual(N.alltrue(sc.ravel() == s1.ravel()), True)
+        self.assertEqual(np.alltrue(sc.ravel() == s1.ravel()), True)
 
     def test_reset(self):
         x, y, s, src = self.get_data()
@@ -648,7 +641,7 @@ class TestMArray2DSource(unittest.TestCase):
         # works correctly.
         x *= 5
         s *= 10
-        src.reset(x=x,y=y, scalars=s)
+        src.reset(x=x, y=y, scalars=s)
 
         self.check_traits()
         self.check_dataset()
@@ -668,10 +661,10 @@ class TestMArray2DSource(unittest.TestCase):
 
     def test_set(self):
         "Test if the set method works correctly."
-        x, y, s, src  = self.get_data()
+        x, y, s, src = self.get_data()
         x *= 2
         s *= 2
-        src.trait_set(x=x,scalars=s)
+        src.trait_set(x=x, scalars=s)
 
         self.check_traits()
         self.check_dataset()
@@ -683,15 +676,12 @@ class TestMArray2DSource(unittest.TestCase):
         self.check_dataset()
 
 
-###############################################################################
-# `TestMGridSource`
-###############################################################################
 class TestMGridSource(unittest.TestCase):
     def setUp(self):
-        self.x = x = N.ones([10,10], float)
-        self.y = y = N.ones([10,10], float)*2.0
-        self.z = z = N.ones([10,10], float)*3.0
-        self.s = s = N.ones([10,10], float)
+        self.x = x = np.ones([10, 10], float)
+        self.y = y = np.ones([10, 10], float) * 2.0
+        self.z = z = np.ones([10, 10], float) * 3.0
+        self.s = s = np.ones([10, 10], float)
         src = sources.MGridSource()
         src.reset(x=x, y=y, z=z, scalars=s)
         self.src = src
@@ -707,12 +697,18 @@ class TestMGridSource(unittest.TestCase):
         x, y, z, s, src = self.get_data()
 
         # Check if points are set correctly.
-        self.assertEqual(N.alltrue(src.points[:,0].ravel() == x.ravel()), True)
-        self.assertEqual(N.alltrue(src.points[:,1].ravel() == y.ravel()), True)
-        self.assertEqual(N.alltrue(src.points[:,2].ravel() == z.ravel()), True)
+        self.assertEqual(
+            np.alltrue(src.points[:, 0].ravel() == x.ravel()), True
+        )
+        self.assertEqual(
+            np.alltrue(src.points[:, 1].ravel() == y.ravel()), True
+        )
+        self.assertEqual(
+            np.alltrue(src.points[:, 2].ravel() == z.ravel()), True
+        )
         # Check the  scalars.
 
-        self.assertEqual(N.alltrue(src.scalars == s), True)
+        self.assertEqual(np.alltrue(src.scalars == s), True)
 
     def check_dataset(self):
         """Check the TVTK dataset."""
@@ -720,11 +716,11 @@ class TestMGridSource(unittest.TestCase):
         # Check if the dataset is setup right.
 
         pts = src.dataset.points.to_array()
-        self.assertEqual(N.alltrue(pts[:,0].ravel() == x.ravel()), True)
-        self.assertEqual(N.alltrue(pts[:,1].ravel() == y.ravel()), True)
-        self.assertEqual(N.alltrue(pts[:,2].ravel() == z.ravel()), True)
+        self.assertEqual(np.alltrue(pts[:, 0].ravel() == x.ravel()), True)
+        self.assertEqual(np.alltrue(pts[:, 1].ravel() == y.ravel()), True)
+        self.assertEqual(np.alltrue(pts[:, 2].ravel() == z.ravel()), True)
         sc = src.dataset.point_data.scalars.to_array()
-        self.assertEqual(N.alltrue(sc == s.ravel()), True)
+        self.assertEqual(np.alltrue(sc == s.ravel()), True)
 
     def test_reset(self):
         "Test the reset method."
@@ -771,39 +767,38 @@ class TestMGridSource(unittest.TestCase):
         # Given
         from mayavi import mlab
         s = slice(0, 1, 10j)
-        x, y = N.mgrid[s, s]
+        x, y = np.mgrid[s, s]
         obj = mlab.mesh(x, y, x*y, scalars=x)
         bounds = obj.actor.actor.bounds
 
         # When
         s = slice(0, 5, 20j)
-        x, y = N.mgrid[s, s]
+        x, y = np.mgrid[s, s]
         obj.mlab_source.reset(x=x, y=y, z=x*y, scalars=x)
 
         # Then
-        self.assertFalse(N.allclose(bounds, obj.actor.actor.bounds))
+        self.assertFalse(np.allclose(bounds, obj.actor.actor.bounds))
 
 
-################################################################################
-# `TestMArray2DSourceNoArgs`
-################################################################################
 class TestMArray2DSourceNoArgs(unittest.TestCase):
-    """Special Test Case for MArray2DSource when both x and y are specified as None"""
+    """Special Test Case for MArray2DSource when both x and y are specified as
+    None"""
+
     def setUp(self):
 
-        x=None
-        y=None
+        x = None
+        y = None
 
-        self.x, self.y  = x, y
+        self.x, self.y = x, y
 
         if x is not None and y is not None:
             dims = (x.shape[0], y.shape[1])
         else:
-            dims=(10,10)
+            dims = (10, 10)
 
-        self.s = s = N.ones(dims, float)
+        self.s = s = np.ones(dims, float)
         src = sources.MArray2DSource()
-        src.reset(x=x, y=y,scalars=s)
+        src.reset(x=x, y=y, scalars=s)
         self.src = src
 
     def tearDown(self):
@@ -818,17 +813,17 @@ class TestMArray2DSourceNoArgs(unittest.TestCase):
         # Check if points are set correctly.
 
         if x is not None and y is not None:
-            self.assertEqual(N.alltrue(src.x == x), True)
-            self.assertEqual(N.alltrue(src.y == y), True)
+            self.assertEqual(np.alltrue(src.x == x), True)
+            self.assertEqual(np.alltrue(src.y == y), True)
 
         else:
             nx, ny = s.shape
-            x1, y1 = N.mgrid[-nx/2.:nx/2, -ny/2.:ny/2]
-            self.assertEqual(N.alltrue(src.x == x1), True)
-            self.assertEqual(N.alltrue(src.y == y1), True)
+            x1, y1 = np.mgrid[-nx/2.:nx/2, -ny/2.:ny/2]
+            self.assertEqual(np.alltrue(src.x == x1), True)
+            self.assertEqual(np.alltrue(src.y == y1), True)
 
         # Check the scalars.
-        self.assertEqual(N.alltrue(src.scalars == s), True)
+        self.assertEqual(np.alltrue(src.scalars == s), True)
 
     def check_dataset(self):
         """Check the TVTK dataset."""
@@ -838,21 +833,21 @@ class TestMArray2DSourceNoArgs(unittest.TestCase):
         nx, ny = src.scalars.shape
 
         if x is None and y is None:
-            x, y = N.mgrid[-nx/2.:nx/2, -ny/2.:ny/2]
+            x, y = np.mgrid[-nx/2.:nx/2, -ny/2.:ny/2]
 
-        x = N.atleast_2d(x.squeeze().T)[0, :].squeeze()
-        y = N.atleast_2d(y.squeeze())[0, :].squeeze()
+        x = np.atleast_2d(x.squeeze().T)[0, :].squeeze()
+        y = np.atleast_2d(y.squeeze())[0, :].squeeze()
         dx = x[1] - x[0]
         dy = y[1] - y[0]
-        origin = [x.min(), y.min(),0 ]
+        origin = [x.min(), y.min(), 0]
         spacing = [dx, dy, 1]
         ds = src.dataset
-        self.assertEqual(N.all(ds.origin == origin), True)
-        self.assertEqual(N.allclose(ds.spacing, spacing), True)
+        self.assertEqual(np.all(ds.origin == origin), True)
+        self.assertEqual(np.allclose(ds.spacing, spacing), True)
 
         sc = src.dataset.point_data.scalars.to_array()
         s1 = s.transpose()
-        self.assertEqual(N.alltrue(sc.ravel() == s1.ravel()), True)
+        self.assertEqual(np.alltrue(sc.ravel() == s1.ravel()), True)
 
     def test_reset(self):
         "Test the reset method."
@@ -865,7 +860,7 @@ class TestMArray2DSourceNoArgs(unittest.TestCase):
         # works correctly.
 
         s *= 10
-        src.reset(x=x,y=y, scalars=s)
+        src.reset(x=x, y=y, scalars=s)
 
         self.check_traits()
         self.check_dataset()
@@ -879,26 +874,22 @@ class TestMArray2DSourceNoArgs(unittest.TestCase):
         self.check_traits()
         self.check_dataset()
 
-
     def test_set(self):
         "Test if the set method works correctly."
         x, y, s, src = self.get_data()
         s *= 2
-        src.trait_set(x=x,y=y,scalars=s)
+        src.trait_set(x=x, y=y, scalars=s)
 
         self.check_traits()
         self.check_dataset()
 
 
-################################################################################
-# `TestMTriangularMeshSource`
-################################################################################
 class TestMTriangularMeshSource(unittest.TestCase):
     def setUp(self):
-        x, y, z = N.array([0, 0, 0]), N.array([0, 0, 1]), N.array([0, 1, 1])
-        s = N.array([0.1, 0.2, 0.3])
+        x, y, z = np.array([0, 0, 0]), np.array([0, 0, 1]), np.array([0, 1, 1])
+        s = np.array([0.1, 0.2, 0.3])
         self.x, self.y, self.z, self.s = x, y, z, s
-        self.triangles = triangles = N.array([[0, 1, 2]])
+        self.triangles = triangles = np.array([[0, 1, 2]])
 
         src = sources.MTriangularMeshSource()
         src.reset(x=x, y=y, z=z, triangles=triangles, scalars=s)
@@ -915,11 +906,11 @@ class TestMTriangularMeshSource(unittest.TestCase):
         x, y, z, triangles, s, src = self.get_data()
 
         # Check if points are set correctly.
-        self.assertEqual(N.alltrue(src.x == x), True)
-        self.assertEqual(N.alltrue(src.y == y), True)
-        self.assertEqual(N.alltrue(src.z == z), True)
+        self.assertEqual(np.alltrue(src.x == x), True)
+        self.assertEqual(np.alltrue(src.y == y), True)
+        self.assertEqual(np.alltrue(src.z == z), True)
         # Check the scalars.
-        self.assertEqual(N.alltrue(src.scalars == s), True)
+        self.assertEqual(np.alltrue(src.scalars == s), True)
 
     def test_reset(self):
         "Test the reset method."
@@ -931,7 +922,7 @@ class TestMTriangularMeshSource(unittest.TestCase):
         # works correctly.
         x *= 5
         s *= 10
-        src.reset(x=x,y=y,z=z, triangles=triangles, scalars=s)
+        src.reset(x=x, y=y, z=z, triangles=triangles, scalars=s)
 
         self.check_traits()
 
@@ -942,12 +933,10 @@ class TestMTriangularMeshSource(unittest.TestCase):
         """
         n = 100
         _, _, _, _, _, src = self.get_data()
-        triangles = N.c_[N.arange(n-3),
-                            N.arange(n-3)+1,
-                            n-1-N.arange(n-3)]
-        x, y, z = N.random.random((3, n))
+        triangles = np.c_[np.arange(n - 3),
+                          np.arange(n - 3) + 1, n - 1 - np.arange(n - 3)]
+        x, y, z = np.random.random((3, n))
         src.reset(x=x, y=y, z=z, triangles=triangles)
-
 
     def test_handlers(self):
         "Test if the various static handlers work correctly."
@@ -962,13 +951,12 @@ class TestMTriangularMeshSource(unittest.TestCase):
 
         self.check_traits()
 
-
     def test_set(self):
         "Test if the set method works correctly."
         x, y, z, triangles, s, src = self.get_data()
         x *= 2
         s *= 2
-        src.trait_set(x=x,scalars=s)
+        src.trait_set(x=x, scalars=s)
 
         self.check_traits()
 
@@ -989,15 +977,15 @@ class TestMTriangularMeshSource(unittest.TestCase):
 
         # When
         n = 10
-        x, y, z = N.random.random((3, n))
-        triangles = N.c_[N.arange(n-3),
-                         N.arange(n-3)+1,
-                         n-1-N.arange(n-3)]
+        x, y, z = np.random.random((3, n))
+        triangles = np.c_[np.arange(n-3),
+                          np.arange(n-3)+1,
+                          n-1-np.arange(n-3)]
 
         obj.mlab_source.reset(x=x, y=y, z=z, triangles=triangles, scalars=z)
 
         # Then
-        self.assertFalse(N.allclose(bounds, obj.actor.actor.bounds))
+        self.assertFalse(np.allclose(bounds, obj.actor.actor.bounds))
 
 
 if __name__ == '__main__':

--- a/mayavi/tools/sources.py
+++ b/mayavi/tools/sources.py
@@ -217,6 +217,8 @@ class MGlyphSource(MlabSource):
         else:
             # Modify existing one.
             pd = self.dataset
+        # First set the polys to None to avoid accessing invalid points.
+        pd.polys = None
         pd.trait_set(points=points)
         pd.trait_set(polys=polys)
 
@@ -719,6 +721,7 @@ class MGridSource(MlabSource):
             new_dataset = True
         else:
             pd = self.dataset
+        pd.trait_set(polys=None)
         pd.trait_set(points=points)
         pd.trait_set(polys=triangles)
 
@@ -822,12 +825,15 @@ class MTriangularMeshSource(MlabSource):
             pd = self.dataset
         # Set the points first, and the triangles after: so that the
         # polygone can refer to the right points, in the polydata.
+
+        # Set the polys to None so that when the points are set, the
+        # cells do not point to garbage.
+        pd.polys = None
         pd.trait_set(points=points)
         pd.trait_set(polys=triangles)
 
-        if (not 'scalars' in traits
-                    and scalars is not None
-                    and scalars.shape != x.shape):
+        if ('scalars' not in traits and scalars is not None
+           and scalars.shape != x.shape):
             # The scalars where set probably automatically to z, by the
             # factory. We need to reset them, as the size has changed.
             scalars = z

--- a/tvtk/array_handler.py
+++ b/tvtk/array_handler.py
@@ -89,7 +89,6 @@ def set_id_type_array_py(id_array, out_array):
     out_array.shape = out_shp
 
 
-
 if not HAS_ARRAY_EXT:
     set_id_type_array = set_id_type_array_py
 
@@ -133,8 +132,9 @@ class ArrayCache(object):
         # `lambda` function is necessary because the callback will not
         # receive the object (it will receive `None`) and thus there
         # is no way to know which array reference one has to remove.
-        vtk_arr.AddObserver('DeleteEvent', lambda o, e, key=key: \
-                            self._remove_array(key))
+        vtk_arr.AddObserver(
+            'DeleteEvent', lambda o, e, key=key: self._remove_array(key)
+        )
 
         # Cache the array
         cache[key] = np_arr
@@ -180,29 +180,27 @@ else:
 del _dummy
 
 
-
-######################################################################
-# Array conversion functions.
-######################################################################
 def get_vtk_array_type(numeric_array_type):
     """Returns a VTK typecode given a numpy array."""
     # This is a Mapping from numpy array types to VTK array types.
-    _arr_vtk = {numpy.dtype(numpy.character):vtkConstants.VTK_UNSIGNED_CHAR,
-                numpy.dtype(numpy.uint8):vtkConstants.VTK_UNSIGNED_CHAR,
-                numpy.dtype(numpy.uint16):vtkConstants.VTK_UNSIGNED_SHORT,
-                numpy.dtype(numpy.int8):vtkConstants.VTK_CHAR,
-                numpy.dtype(numpy.int16):vtkConstants.VTK_SHORT,
-                numpy.dtype(numpy.int32):vtkConstants.VTK_INT,
-                numpy.dtype(numpy.uint32):vtkConstants.VTK_UNSIGNED_INT,
-                numpy.dtype(numpy.float32):vtkConstants.VTK_FLOAT,
-                numpy.dtype(numpy.float64):vtkConstants.VTK_DOUBLE,
-                numpy.dtype(numpy.complex64):vtkConstants.VTK_FLOAT,
-                numpy.dtype(numpy.complex128):vtkConstants.VTK_DOUBLE,
-                }
-    _extra = {numpy.dtype(ID_TYPE_CODE):vtkConstants.VTK_ID_TYPE,
-              numpy.dtype(ULONG_TYPE_CODE):vtkConstants.VTK_UNSIGNED_LONG,
-              numpy.dtype(LONG_TYPE_CODE):vtkConstants.VTK_LONG,
-             }
+    _arr_vtk = {
+        numpy.dtype(numpy.character): vtkConstants.VTK_UNSIGNED_CHAR,
+        numpy.dtype(numpy.uint8): vtkConstants.VTK_UNSIGNED_CHAR,
+        numpy.dtype(numpy.uint16): vtkConstants.VTK_UNSIGNED_SHORT,
+        numpy.dtype(numpy.int8): vtkConstants.VTK_CHAR,
+        numpy.dtype(numpy.int16): vtkConstants.VTK_SHORT,
+        numpy.dtype(numpy.int32): vtkConstants.VTK_INT,
+        numpy.dtype(numpy.uint32): vtkConstants.VTK_UNSIGNED_INT,
+        numpy.dtype(numpy.float32): vtkConstants.VTK_FLOAT,
+        numpy.dtype(numpy.float64): vtkConstants.VTK_DOUBLE,
+        numpy.dtype(numpy.complex64): vtkConstants.VTK_FLOAT,
+        numpy.dtype(numpy.complex128): vtkConstants.VTK_DOUBLE,
+    }
+    _extra = {
+        numpy.dtype(ID_TYPE_CODE): vtkConstants.VTK_ID_TYPE,
+        numpy.dtype(ULONG_TYPE_CODE): vtkConstants.VTK_UNSIGNED_LONG,
+        numpy.dtype(LONG_TYPE_CODE): vtkConstants.VTK_LONG,
+    }
     for t in _extra:
         if t not in _arr_vtk:
             _arr_vtk[t] = _extra[t]
@@ -213,22 +211,27 @@ def get_vtk_array_type(numeric_array_type):
         for key in _arr_vtk:
             if numpy.issubdtype(numeric_array_type, key):
                 return _arr_vtk[key]
-    raise TypeError("Couldn't translate array's type to VTK")
+    raise TypeError(
+        "Couldn't translate array's type to VTK %s" % numeric_array_type
+    )
+
 
 def get_vtk_to_numeric_typemap():
     """Returns the VTK array type to numpy array type mapping."""
-    _vtk_arr = {vtkConstants.VTK_BIT:numpy.bool,
-                vtkConstants.VTK_CHAR:numpy.int8,
-                vtkConstants.VTK_UNSIGNED_CHAR:numpy.uint8,
-                vtkConstants.VTK_SHORT:numpy.int16,
-                vtkConstants.VTK_UNSIGNED_SHORT:numpy.uint16,
-                vtkConstants.VTK_INT:numpy.int32,
-                vtkConstants.VTK_UNSIGNED_INT:numpy.uint32,
-                vtkConstants.VTK_LONG:LONG_TYPE_CODE,
-                vtkConstants.VTK_UNSIGNED_LONG:ULONG_TYPE_CODE,
-                vtkConstants.VTK_ID_TYPE:ID_TYPE_CODE,
-                vtkConstants.VTK_FLOAT:numpy.float32,
-                vtkConstants.VTK_DOUBLE:numpy.float64}
+    _vtk_arr = {
+        vtkConstants.VTK_BIT: numpy.bool,
+        vtkConstants.VTK_CHAR: numpy.int8,
+        vtkConstants.VTK_UNSIGNED_CHAR: numpy.uint8,
+        vtkConstants.VTK_SHORT: numpy.int16,
+        vtkConstants.VTK_UNSIGNED_SHORT: numpy.uint16,
+        vtkConstants.VTK_INT: numpy.int32,
+        vtkConstants.VTK_UNSIGNED_INT: numpy.uint32,
+        vtkConstants.VTK_LONG: LONG_TYPE_CODE,
+        vtkConstants.VTK_UNSIGNED_LONG: ULONG_TYPE_CODE,
+        vtkConstants.VTK_ID_TYPE: ID_TYPE_CODE,
+        vtkConstants.VTK_FLOAT: numpy.float32,
+        vtkConstants.VTK_DOUBLE: numpy.float64
+    }
     return _vtk_arr
 
 
@@ -239,18 +242,20 @@ def get_numeric_array_type(vtk_array_type):
 
 def get_sizeof_vtk_array(vtk_array_type):
     """Returns the size of a VTK array type."""
-    _size_dict = {vtkConstants.VTK_BIT : 1,
-                  vtkConstants.VTK_CHAR : 1,
-                  vtkConstants.VTK_UNSIGNED_CHAR : 1,
-                  vtkConstants.VTK_SHORT : 2,
-                  vtkConstants.VTK_UNSIGNED_SHORT : 2,
-                  vtkConstants.VTK_INT : 4,
-                  vtkConstants.VTK_UNSIGNED_INT : 4,
-                  vtkConstants.VTK_LONG : VTK_LONG_TYPE_SIZE,
-                  vtkConstants.VTK_UNSIGNED_LONG : VTK_LONG_TYPE_SIZE,
-                  vtkConstants.VTK_ID_TYPE : VTK_ID_TYPE_SIZE,
-                  vtkConstants.VTK_FLOAT : 4,
-                  vtkConstants.VTK_DOUBLE : 8 }
+    _size_dict = {
+        vtkConstants.VTK_BIT: 1,
+        vtkConstants.VTK_CHAR: 1,
+        vtkConstants.VTK_UNSIGNED_CHAR: 1,
+        vtkConstants.VTK_SHORT: 2,
+        vtkConstants.VTK_UNSIGNED_SHORT: 2,
+        vtkConstants.VTK_INT: 4,
+        vtkConstants.VTK_UNSIGNED_INT: 4,
+        vtkConstants.VTK_LONG: VTK_LONG_TYPE_SIZE,
+        vtkConstants.VTK_UNSIGNED_LONG: VTK_LONG_TYPE_SIZE,
+        vtkConstants.VTK_ID_TYPE: VTK_ID_TYPE_SIZE,
+        vtkConstants.VTK_FLOAT: 4,
+        vtkConstants.VTK_DOUBLE: 8
+    }
     return _size_dict[vtk_array_type]
 
 
@@ -306,11 +311,11 @@ def array2vtk(num_array, vtk_array=None):
 
     shape = z.shape
     assert len(shape) < 3, \
-           "Only arrays of dimensionality 2 or lower are allowed!"
+        "Only arrays of dimensionality 2 or lower are allowed!"
     assert not numpy.issubdtype(z.dtype, numpy.complexfloating), \
-           "Complex numpy arrays cannot be converted to vtk arrays."\
-           "Use real() or imag() to get a component of the array before"\
-           " passing it to vtk."
+        "Complex numpy arrays cannot be converted to vtk arrays."\
+        "Use real() or imag() to get a component of the array before"\
+        " passing it to vtk."
 
     # First create an array of the right type by using the typecode.
     # Bit arrays need special casing.
@@ -385,10 +390,10 @@ def vtk2array(vtk_array):
     """
     typ = vtk_array.GetDataType()
     assert typ in get_vtk_to_numeric_typemap().keys(), \
-           "Unsupported array type %s"%typ
+        "Unsupported array type %s" % typ
 
-    shape = vtk_array.GetNumberOfTuples(), \
-            vtk_array.GetNumberOfComponents()
+    shape = (vtk_array.GetNumberOfTuples(),
+             vtk_array.GetNumberOfComponents())
     if shape[0] == 0:
         dtype = get_numeric_array_type(typ)
         return numpy.array([], dtype)
@@ -526,7 +531,7 @@ def array2vtkCellArray(num_array, vtk_array=None):
     else:
         cells = vtk.vtkCellArray()
     assert cells.GetClassName() == 'vtkCellArray', \
-           'Second argument must be a `vtkCellArray` instance.'
+        'Second argument must be a `vtkCellArray` instance.'
 
     if len(num_array) == 0:
         return cells
@@ -561,7 +566,7 @@ def array2vtkCellArray(num_array, vtk_array=None):
     if issubclass(type(num_array), (list, tuple)):
         assert len(num_array[0]) > 0, "Input array must be 2D."
         tp = type(num_array[0])
-        if issubclass(tp, list): # Pure Python list.
+        if issubclass(tp, list):  # Pure Python list.
             _slow_array2cells(num_array, cells)
             return cells
         elif issubclass(tp, numpy.ndarray):  # List of arrays.
@@ -621,7 +626,7 @@ def array2vtkPoints(num_array, vtk_points=None):
 
     """
     if vtk_points:
-        points  = vtk_points
+        points = vtk_points
     else:
         points = vtk.vtkPoints()
 
@@ -696,7 +701,7 @@ def convert_array(arr, vtk_typ=None):
         elif vtk_typ.find('Array') > -1:
             try:
                 vtk_arr = getattr(vtk, vtk_typ)()
-            except TypeError: # vtk_typ == 'vtkDataArray'
+            except TypeError:  # vtk_typ == 'vtkDataArray'
                 return array2vtk(arr)
             else:
                 return array2vtk(arr, vtk_arr)
@@ -750,7 +755,7 @@ def get_correct_sig(args, sigs):
         if count == 0:
             # No sig has the right number of args.
             msg = "Insufficient number of arguments to method."\
-                  "Valid arguments are:\n%s"%sigs
+                  "Valid arguments are:\n%s" % sigs
             raise TypeError(msg)
         elif count == 1:
             # If only one of the sigs has the right number of args,
@@ -759,7 +764,7 @@ def get_correct_sig(args, sigs):
         else:
             # More than one sig has the same number of args.
             # Check if args need conversion at all.
-            array_idx = [i for i, a in enumerate(args) \
+            array_idx = [i for i, a in enumerate(args)
                          if is_array_or_vtkarray(a)]
             n_arr = len(array_idx)
             if n_arr == 0:

--- a/tvtk/array_handler.py
+++ b/tvtk/array_handler.py
@@ -10,7 +10,7 @@ seems no unique one-to-one VTK data array type to map it to.
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2004-2015,  Enthought, Inc.
+# Copyright (c) 2004-2019,  Enthought, Inc.
 # License: BSD Style.
 
 import sys
@@ -191,6 +191,7 @@ def get_vtk_array_type(numeric_array_type):
         numpy.dtype(numpy.int16): vtkConstants.VTK_SHORT,
         numpy.dtype(numpy.int32): vtkConstants.VTK_INT,
         numpy.dtype(numpy.uint32): vtkConstants.VTK_UNSIGNED_INT,
+        numpy.dtype(numpy.uint64): vtkConstants.VTK_UNSIGNED_LONG,
         numpy.dtype(numpy.float32): vtkConstants.VTK_FLOAT,
         numpy.dtype(numpy.float64): vtkConstants.VTK_DOUBLE,
         numpy.dtype(numpy.complex64): vtkConstants.VTK_FLOAT,
@@ -297,7 +298,6 @@ def array2vtk(num_array, vtk_array=None):
        4. The types of the `vtk_array` and the `num_array` are not
           equivalent to each other.  For example if one is an integer
           array and the other a float.
-
 
     - vtk_array : `vtkDataArray` (default: `None`)
 

--- a/tvtk/tests/test_array_handler.py
+++ b/tvtk/tests/test_array_handler.py
@@ -166,6 +166,7 @@ class TestArrayHandler(unittest.TestCase):
                        if x().dtype.name not in ('float16', 'float128')]
         for dtype in (numpy.sctypes['int'] + numpy.sctypes['uint'] +
                       float_types):
+            print(dtype)
             array_handler.array2vtk(numpy.zeros((1,), dtype=dtype))
 
     def test_arr2cell_array(self):


### PR DESCRIPTION
The issue arises in a few of the mlab sources where when we reset to a
polydata with a smaller number of points, we first set the points and
the original polys are still pointing to the old points which no longer
exist.  We now first set the polys to None before changing anything.