### PR TITLE
Use xenial linux instead of trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ dist: xenial
 services:
   - xvfb
 
+addons:
+  apt:
+    packages:
+      - libglu1-mesa
+
 env:
   global:
     - INSTALL_EDM_VERSION=1.9.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,8 @@ install:
   - if [[ ${ETS_TOOLKIT} == 'qt4' && ${RUNTIME} == '2.7' ]]; then edm install -y pyside; fi
   - if [[ ${ETS_TOOLKIT} == 'qt4' && ${RUNTIME} == '3.6' ]]; then edm run -- pip install "pyqt5==5.10.1"; fi
   - edm run -- pip install -r ci/ci-requirements.txt
-  - if [[ ${VTK} == '8' ]]; then edm run -- pip install vtk; fi
-  - if [[ ${VTK} != '8' ]]; then edm install -y vtk; fi
+  - if [[ ${VTK} == '8' ]]; then edm install -y vtk^=8 ; fi
+  - if [[ ${VTK} == '7' ]]; then edm install -y vtk^=7 ; fi
   - edm run -- python -c "import vtk; print(vtk.vtkVersion.GetVTKSourceVersion())"
   - edm run -- python setup.py develop
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
   - if [[ ${ETS_TOOLKIT} == 'qt4' && ${RUNTIME} == '2.7' ]]; then edm install -y pyside; fi
   - if [[ ${ETS_TOOLKIT} == 'qt4' && ${RUNTIME} == '3.6' ]]; then edm run -- pip install "pyqt5==5.10.1"; fi
   - edm run -- pip install -r ci/ci-requirements.txt
-  - if [[ ${VTK} == '8' ]]; then edm install -y vtk==8.0.0-2; fi
+  - if [[ ${VTK} == '8' ]]; then edm run -- pip install vtk; fi
   - if [[ ${VTK} != '8' ]]; then edm install -y vtk==7.0.0-3; fi
   - edm run -- python -c "import vtk; print(vtk.vtkVersion.GetVTKSourceVersion())"
   - edm run -- python setup.py develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: generic
-sudo: false
+
+dist: xenial
+services:
+  - xvfb
 
 env:
   global:
@@ -26,7 +29,6 @@ cache:
 before_install:
   - mkdir -p "${HOME}/.cache/download"
   - export DISPLAY=:99.0
-  - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then sh -e /etc/init.d/xvfb start; fi
   - if [[ ${TRAVIS_OS_NAME} == 'linux' ]]; then ./ci/install-edm-linux.sh; export PATH="${HOME}/edm/bin:${PATH}"; fi
   - if [[ ${TRAVIS_OS_NAME} == 'osx' ]]; then ./ci/install-edm-osx.sh; export PATH="${PATH}:/usr/local/bin"; fi
   - edm install --version ${RUNTIME} -y wheel numpy nose mock Sphinx coverage psutil


### PR DESCRIPTION
and use the travis xvfb service instead of manually starting xvfb on linux,
and remove sudo setting in the travis config, which isn't needed anymore

ref : https://docs.travis-ci.com/user/gui-and-headless-browsers/ for information about using xvfb and https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment for information about the xenial rollout on travis.