### PR TITLE
Update edm and install/config scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
 
 env:
   global:
-    - INSTALL_EDM_VERSION=1.9.1
+    - INSTALL_EDM_VERSION=2.0.0
       PYTHONUNBUFFERED="1"
 
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ init:
 install:
   # Install edm, needed so we can quickly install numpy.
   - ps: Start-FileDownload "https://package-data.enthought.com/edm/win_x86_64/2.0/edm_cli_2.0.0_x86_64.msi"
-  - start /wait msiexec /a /I edm_cli_2.0.0_x86_64.msi /qn /log install.log EDMAPPDIR=c:\Enthought\edm
+  - start /wait msiexec /i edm_cli_2.0.0_x86_64.msi /qn /log install.log EDMAPPDIR=C:\Enthought\edm
   - edm info
   - edm install --version 3.6 -y numpy nose mock Sphinx coverage psutil
   - "%CMD_IN_ENV% edm run -- pip install -r ci\\ci-requirements.txt"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ init:
 install:
   # Install edm, needed so we can quickly install numpy.
   - ps: Start-FileDownload "https://package-data.enthought.com/edm/win_x86_64/2.0/edm_cli_2.0.0_x86_64.msi"
-  - start /wait msiexec /a /I edm_cli_2.0.0_x86_64.msi /qn /log install.log TARGETDIR=c:\Enthought\edm
+  - start /wait msiexec /a /I edm_cli_2.0.0_x86_64.msi /qn /log install.log EDMAPPDIR=c:\Enthought\edm
   - edm info
   - edm install --version 3.6 -y numpy nose mock Sphinx coverage psutil
   - "%CMD_IN_ENV% edm run -- pip install -r ci\\ci-requirements.txt"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,8 +21,8 @@ init:
 
 install:
   # Install edm, needed so we can quickly install numpy.
-  - ps: Start-FileDownload "https://package-data.enthought.com/edm/win_x86_64/1.9/edm_1.9.1_x86_64.msi"
-  - start /wait msiexec /a edm_1.9.1_x86_64.msi /qn /log install.log TARGETDIR=c:\
+  - ps: Start-FileDownload "https://package-data.enthought.com/edm/win_x86_64/2.0/edm_cli_2.0.0_x86_64.msi"
+  - start /wait msiexec /a /I edm_cli_2.0.0_x86_64.msi /qn /log install.log TARGETDIR=c:\Enthought\edm
   - edm info
   - edm install --version 3.6 -y numpy nose mock Sphinx coverage psutil
   - "%CMD_IN_ENV% edm run -- pip install -r ci\\ci-requirements.txt"

--- a/ci/install-edm-linux.sh
+++ b/ci/install-edm-linux.sh
@@ -4,11 +4,11 @@ set -e
 
 install_edm() {
     local EDM_MAJOR_MINOR="$(echo "$INSTALL_EDM_VERSION" | sed -E -e 's/([[:digit:]]+\.[[:digit:]]+)\..*/\1/')"
-    local EDM_PACKAGE="edm_${INSTALL_EDM_VERSION}_linux_x86_64.sh"
+    local EDM_PACKAGE="edm_cli_${INSTALL_EDM_VERSION}_linux_x86_64.sh"
     local EDM_INSTALLER_PATH="${HOME}/.cache/download/${EDM_PACKAGE}"
 
     if [ ! -e "$EDM_INSTALLER_PATH" ]; then
-        curl -o "$EDM_INSTALLER_PATH" -L "https://package-data.enthought.com/edm/rh5_x86_64/${EDM_MAJOR_MINOR}/${EDM_PACKAGE}"
+        curl -o "$EDM_INSTALLER_PATH" -L "https://package-data.enthought.com/edm/rh6_x86_64/${EDM_MAJOR_MINOR}/${EDM_PACKAGE}"
     fi
 
     bash "$EDM_INSTALLER_PATH" -b -p "${HOME}/edm"

--- a/ci/install-edm-osx.sh
+++ b/ci/install-edm-osx.sh
@@ -4,7 +4,7 @@ set -e
 
 install_edm() {
     local EDM_MAJOR_MINOR="$(echo "$INSTALL_EDM_VERSION" | sed -E -e 's/([[:digit:]]+\.[[:digit:]]+)\..*/\1/')"
-    local EDM_PACKAGE="edm_${INSTALL_EDM_VERSION}.pkg"
+    local EDM_PACKAGE="edm_cli_${INSTALL_EDM_VERSION}.pkg"
     local EDM_INSTALLER_PATH="${HOME}/.cache/download/${EDM_PACKAGE}"
 
     if [ ! -e "$EDM_INSTALLER_PATH" ]; then


### PR DESCRIPTION
This PR updates the CI to use the latest version of edm (version 2.0.0) - this will preempt some of the issues we were seeing on other ETS projects related to invalid metadata in eggs.

See similar PRs in other ETS packages here - https://github.com/enthought/traits/pull/560