### PR TITLE
Replace deprecated rich_compare kwarg when creating traits

### DIFF
--- a/mayavi/sources/array_source.py
+++ b/mayavi/sources/array_source.py
@@ -11,7 +11,7 @@ from vtk.util import vtkConstants
 
 # Enthought library imports
 from traits.api import (Instance, Trait, Str, Bool, Button, DelegatesTo, List,
-                        Int)
+                        Int, OBJECT_IDENTITY_COMPARE)
 from traitsui.api import View, Group, Item
 from tvtk.api import tvtk
 from tvtk.array_handler import array2vtk, get_vtk_array_type
@@ -71,13 +71,22 @@ class ArraySource(Source):
     """
 
     # The scalar array data we manage.
-    scalar_data = Trait(None, _check_scalar_array, rich_compare=False)
+    scalar_data = Trait(
+        None,
+        _check_scalar_array,
+        comparison_mode=OBJECT_IDENTITY_COMPARE
+    )
 
     # The name of our scalar array.
     scalar_name = Str('scalar')
 
     # The vector array data we manage.
-    vector_data = Trait(None, _check_vector_array, rich_compare=False)
+    vector_data = Trait(
+        None,
+        _check_vector_array,
+        comparison_mode=OBJECT_IDENTITY_COMPARE
+    )
+
 
     # The name of our vector array.
     vector_name = Str('vector')


### PR DESCRIPTION
`rich_compare` has been deprecated since version 3.0.3 of traits and it's been replaced with the `comparison_mode` kwarg.

See PR https://github.com/enthought/traits/pull/598/ for more information.