### PR TITLE
Replace uses of the deprecated trait types 'false' and 'true'

### DIFF
--- a/mayavi/modules/axes.py
+++ b/mayavi/modules/axes.py
@@ -5,7 +5,7 @@
 # License: BSD Style.
 
 # Enthought library imports.
-from traits.api import Instance, Property, true
+from traits.api import Bool, Instance, Property
 from traitsui.api import View, Group, HGroup, \
         Item, BooleanEditor
 from tvtk.api import tvtk
@@ -25,7 +25,7 @@ class CubeAxesActor2D(tvtk.CubeAxesActor2D):
     """
 
     # Automaticaly fit the bounds of the axes to the data
-    use_data_bounds = true
+    use_data_bounds = Bool(True)
 
     input_info = PipelineInfo(datasets=['any'],
                               attribute_types=['any'],

--- a/mayavi/tools/data_wizards/data_source_factory.py
+++ b/mayavi/tools/data_wizards/data_source_factory.py
@@ -1,8 +1,7 @@
 
 from numpy import c_, zeros, arange
 
-from traits.api import HasStrictTraits, \
-    true, false, Instance
+from traits.api import Bool, HasStrictTraits, Instance
 
 from mayavi.sources.vtk_data_source import VTKDataSource
 from mayavi.sources.array_source import ArraySource
@@ -21,16 +20,16 @@ class DataSourceFactory(HasStrictTraits):
     """
 
     # Whether the position is implicitely inferred from the array indices
-    position_implicit = false
+    position_implicit = Bool(False)
 
     # Whether the data is on an orthogonal grid
-    orthogonal_grid = false
+    orthogonal_grid = Bool(False)
 
     # If the data is unstructured
-    unstructured = false
+    unstructured = Bool(False)
 
     # If the factory should attempt to connect the data points
-    connected = true
+    connected = Bool(True)
 
     # The position of the data points
     position_x = ArrayOrNone
@@ -42,13 +41,13 @@ class DataSourceFactory(HasStrictTraits):
     connectivity_triangles = ArrayOrNone
 
     # Whether or not the data points should be connected.
-    lines = false
+    lines = Bool(False)
 
     # The scalar data array
     scalar_data = ArrayOrNone
 
     # Whether there is vector data
-    has_vector_data = false
+    has_vector_data = Bool(False)
 
     # The vector components
     vector_u = ArrayOrNone

--- a/mayavi/tools/data_wizards/data_source_wizard.py
+++ b/mayavi/tools/data_wizards/data_source_wizard.py
@@ -2,7 +2,7 @@
 from numpy import ones, resize, linspace, atleast_3d
 
 from traits.api import Property, Str, Button, Trait, \
-    Any, Instance, HasStrictTraits, false, Dict, HasTraits, \
+    Any, Instance, HasStrictTraits, Dict, HasTraits, \
     CArray, Bool
 from traitsui.api import EnumEditor, View, Item, HGroup, \
     VGroup, spring, Group, TextEditor, HTMLEditor, InstanceEditor, \
@@ -101,7 +101,7 @@ class DataSourceWizard(HasTraits):
     grid_shape = CArray(shape=(3,), dtype='i')
 
     # Whether or not the data points should be connected.
-    lines = false
+    lines = Bool(False)
 
     # The scalar data selection
     scalar_data = Str('', help="Select the array that gives the value of the "
@@ -118,10 +118,11 @@ class DataSourceWizard(HasTraits):
 
     connectivity_triangles = Str
 
-    has_vector_data = false(help="""Do you want to plot vector components?""")
+    has_vector_data = Bool(False, help="Do you want to plot "
+                                    "vector components?")
 
     # A boolean to ask the user if he wants to load scalar data
-    has_scalar_data = false
+    has_scalar_data = Bool(False)
 
     vector_u = Str
 

--- a/mayavi/tools/decorations.py
+++ b/mayavi/tools/decorations.py
@@ -13,7 +13,7 @@ import numpy as np
 
 # Enthought library imports.
 from traits.api import String, CFloat, Instance, HasTraits, \
-            Trait, CArray, true, Any, Range, Either
+            Trait, CArray, Bool, Any, Range, Either
 from . import tools
 from .figure import draw, gcf
 
@@ -352,13 +352,13 @@ class Axes(AxesLikeModuleFactory):
                             Ranges of the labels displayed on the axes.
                             Default is the object's extents.""", )
 
-    x_axis_visibility = true(adapts='axes.x_axis_visibility',
+    x_axis_visibility = Bool(True, adapts='axes.x_axis_visibility',
                 help="Whether or not the x axis is visible (boolean)")
 
-    y_axis_visibility = true(adapts='axes.y_axis_visibility',
+    y_axis_visibility = Bool(True, adapts='axes.y_axis_visibility',
                 help="Whether or not the y axis is visible (boolean)")
 
-    z_axis_visibility = true(adapts='axes.z_axis_visibility',
+    z_axis_visibility = Bool(True, adapts='axes.z_axis_visibility',
                 help="Whether or not the z axis is visible (boolean)")
 
     _target = Instance(modules.Axes, ())
@@ -505,7 +505,7 @@ class Text3D(ModuleFactory):
                         camera. If not, these angles are referenced to
                         the z axis.""")
 
-    orient_to_camera = true(adapts='orient_to_camera',
+    orient_to_camera = Bool(True, adapts='orient_to_camera',
                         desc="""if the text is kept oriented to the
                         camera, or is pointing in a specific direction,
                         regardless of the camera position.""")

--- a/mayavi/tools/helper_functions.py
+++ b/mayavi/tools/helper_functions.py
@@ -26,8 +26,8 @@ from .animator import animate
 from mayavi.core.scene import Scene
 from .auto_doc import traits_doc, dedent
 from . import tools
-from traits.api import Array, Callable, CFloat, HasTraits, \
-    List, Trait, Any, Instance, TraitError, true
+from traits.api import Array, Bool, Callable, CFloat, HasTraits, \
+    List, Trait, Any, Instance, TraitError
 import numpy as np
 
 
@@ -1085,7 +1085,7 @@ class BarChart(Pipeline):
     lateral_scale = CFloat(0.9, desc='The lateral scale of the glyph, '
                 'in units of the distance between nearest points')
 
-    auto_scale = true(desc='whether to compute automatically the '
+    auto_scale = Bool(True, desc='whether to compute automatically the '
                            'lateral scaling of the glyphs. This might be '
                            'computationally expensive.')
 

--- a/mayavi/tools/modules.py
+++ b/mayavi/tools/modules.py
@@ -14,7 +14,7 @@ helper functions.
 import numpy
 
 from traits.api import Trait, CArray, Instance, CFloat, \
-    Any, false, true, TraitTuple, Range, Bool, Property, CInt, Enum, Either
+    Any, TraitTuple, Range, Bool, Property, CInt, Enum, Either
 from traits.trait_errors import TraitError
 from tvtk.api import tvtk
 from tvtk.common import camel2enthought
@@ -86,7 +86,7 @@ class DataModuleFactory(ModuleFactory):
     """ Base class for all the module factories operating on data (ie not
         text and outline) """
 
-    reset_zoom = true(help="""Reset the zoom to accomodate the data newly
+    reset_zoom = Bool(True, help="""Reset the zoom to accomodate the data newly
                         added to the scene. Defaults to True.""")
 
     extent = CArray(shape=(6,),
@@ -98,8 +98,8 @@ class DataModuleFactory(ModuleFactory):
     def _extent_changed(self):
         tools.set_extent(self._target, self.extent)
 
-    transparent = false(help="""make the opacity of the actor depend on the
-                               scalar.""")
+    transparent = Bool(False, help="""make the opacity of the actor depend on
+                                    the scalar.""")
 
     def _transparent_changed(self):
         if self.transparent:

--- a/tvtk/pyface/picker.py
+++ b/tvtk/pyface/picker.py
@@ -21,8 +21,8 @@ probe for the data at that point.
 # Copyright (c) 2004-2016, Enthought, Inc.
 # License: BSD Style.
 
-from traits.api import HasTraits, Trait, Long, Array, Any, Float, \
-                                 Instance, Range, true, Str
+from traits.api import HasTraits, Trait, Long, Array, Any, Bool, Float, \
+                                 Instance, Range, Str
 from traitsui.api import View, Group, Item, Handler
 from tvtk.api import tvtk
 from tvtk.tvtk_base import TraitRevPrefixMap, false_bool_trait
@@ -218,10 +218,10 @@ class Picker(HasTraits):
     tolerance = Range(0.0, 0.25, 0.025)
 
     # show the GUI on pick ?
-    show_gui = true(desc = "whether to show the picker GUI on pick")
+    show_gui = Bool(True, desc = "whether to show the picker GUI on pick")
 
     # Raise the GUI on pick ?
-    auto_raise = true(desc = "whether to raise the picker GUI on pick")
+    auto_raise = Bool(True, desc = "whether to raise the picker GUI on pick")
 
     default_view = View(Group(Group(Item(name='pick_type'),
                                     Item(name='tolerance'), show_border=True),

--- a/tvtk/pyface/ui/qt4/decorated_scene.py
+++ b/tvtk/pyface/ui/qt4/decorated_scene.py
@@ -17,7 +17,7 @@ from pyface.qt import QtGui
 from pyface.api import ImageResource
 from pyface.action.api import ToolBarManager, Group, Action
 from tvtk.api import tvtk
-from traits.api import Instance, false, Either, List
+from traits.api import Bool, Instance, Either, List
 
 # Local imports.
 from .scene import Scene, popup_save
@@ -47,7 +47,7 @@ class DecoratedScene(Scene):
         axes = None
 
     # Determine if the orientation axis is shown or not.
-    show_axes = false
+    show_axes = Bool(False)
 
     # The list of actions represented in the toolbar
     actions = List(Either(Action, Group))

--- a/tvtk/pyface/ui/wx/decorated_scene.py
+++ b/tvtk/pyface/ui/wx/decorated_scene.py
@@ -27,7 +27,7 @@ import wx
 from pyface.api import ImageResource
 from pyface.action.api import ToolBarManager, Group, Action
 from tvtk.api import tvtk
-from traits.api import Instance, false, List, Either
+from traits.api import Bool, Instance, List, Either
 
 # Local imports.
 from .scene import Scene, popup_save
@@ -57,7 +57,7 @@ class DecoratedScene(Scene):
         axes = None
 
     # Determine if the orientation axis is shown or not.
-    show_axes = false
+    show_axes = Bool(False)
 
     # The list of actions represented in the toolbar
     actions = List(Either(Action, Group))


### PR DESCRIPTION
The Trait types `false` and `true` in Traits are due to be deprecated. This PR replaces them with `Bool(False)` and `Bool(True)` respectively.

Fixes #865