### PR TITLE
Replace uses of traits.api.Long with traits.api.Int

### DIFF
--- a/tvtk/pyface/picker.py
+++ b/tvtk/pyface/picker.py
@@ -21,7 +21,7 @@ probe for the data at that point.
 # Copyright (c) 2004-2016, Enthought, Inc.
 # License: BSD Style.
 
-from traits.api import HasTraits, Trait, Long, Array, Any, Bool, Float, \
+from traits.api import HasTraits, Trait, Int, Array, Any, Bool, Float, \
                                  Instance, Range, Str
 from traitsui.api import View, Group, Item, Handler
 from tvtk.api import tvtk
@@ -57,9 +57,9 @@ class PickedData(HasTraits):
     valid = Trait(false_bool_trait,
                   desc='specifies the validity of the pick event')
     # Id of picked point (-1 implies none was picked)
-    point_id = Long(-1, desc='the picked point ID')
+    point_id = Int(-1, desc='the picked point ID')
     # Id of picked cell (-1 implies none was picked)
-    cell_id = Long(-1, desc='the picked cell ID')
+    cell_id = Int(-1, desc='the picked cell ID')
     # World pick -- this has no ID.
     world_pick = Trait(false_bool_trait,
                        desc='specifies if the pick is a world pick.')
@@ -99,7 +99,7 @@ class DefaultPickHandler(PickHandler):
     """The default handler for the picked data."""
 
     # Traits.
-    ID = Trait(None, None, Long, desc='the picked ID')
+    ID = Trait(None, None, Int, desc='the picked ID')
 
     coordinate = Trait(None, None, Array('d', (3,)),
                        desc='the coordinate of the picked point')

--- a/tvtk/wrapper_gen.py
+++ b/tvtk/wrapper_gen.py
@@ -59,8 +59,6 @@ def get_trait_def(value, **kwargs):
     ('traits.Array', '', 'auto_set=False, enter_set=True, shape=(2,), dtype=float, value=[100.0, 200.0], cols=2')
     >>> get_trait_def(100, enter_set=True, auto_set=False)
     ('traits.Int', '100', 'auto_set=False, enter_set=True')
-    >>> get_trait_def(long(100), enter_set=True, auto_set=False)  # Python 2
-    ('traits.Long', '100', 'auto_set=False, enter_set=True')
     >>> get_trait_def(u'something', enter_set=True, auto_set=False)
     ('traits.Unicode', "u'something'", 'auto_set=False, enter_set=True')
     >>> get_trait_def(True, enter_set=True, auto_set=False)
@@ -77,7 +75,7 @@ def get_trait_def(value, **kwargs):
 
     # In Python 2 there is long type
     if PY_VER < 3:
-        number_map[long] = 'traits.Long'
+        number_map[long] = 'traits.Int'
 
     if type_ in number_map:
         return number_map[type_], str(value), kwargs_code
@@ -1760,16 +1758,8 @@ class WrapperGenerator:
 
         default, _ = self.parser.get_get_set_methods()[vtk_attr_name]
 
-        # The documentation of vtkImageReader2.GetHeaderSize says
-        # it returns `int`, but really the API meant `long`
-        # matters for Python 2
-        if PY_VER < 3:
-            default = long(default)
-            t_def = ('traits.Long({default}, '
-                     'enter_set=True, auto_set=False)').format(default=default)
-        else:
-            t_def = ('traits.Int({default}, '
-                     'enter_set=True, auto_set=False)').format(default=default)
+        t_def = ('traits.Int({default}, '
+                    'enter_set=True, auto_set=False)').format(default=default)
 
         # trait name
         name = self._reform_name(vtk_attr_name)


### PR DESCRIPTION
This PR replaces uses of `Long` with `Int`. `Int`should be an acceptable substitute anywhere that `Long` is used. (On Python 2, the `Int` trait type accepts `long` instances since enthought/traits#104.)