### PR TITLE
DOC: fix syntax error in animation example

### DIFF
--- a/docs/source/mayavi/mlab_animating.rst
+++ b/docs/source/mayavi/mlab_animating.rst
@@ -49,7 +49,7 @@ nicely::
     s = mlab.surf(x, y, np.asarray(x*0.1, 'd'))
 
     @mlab.animate
-    def anim()
+    def anim():
         for i in range(10):
             s.mlab_source.scalars = np.asarray(x*0.1*(i+1), 'd')
             yield


### PR DESCRIPTION
Fix a syntax error in the mlab animation example, `def anim()` to `def anim():`.