### PR TITLE
Fix support for wxPython 3.0

### DIFF
--- a/docs/source/mayavi/auto/wx_embedding.py
+++ b/docs/source/mayavi/auto/wx_embedding.py
@@ -60,7 +60,7 @@ class MainWindow(wx.Frame):
                         kind='subpanel').control
         self.Show(True)
 
-app = wx.PySimpleApp()
+app = wx.App(False)
 frame = MainWindow(None, wx.ID_ANY)
 app.MainLoop()
 

--- a/docs/source/mayavi/auto/wx_mayavi_embed_in_notebook.py
+++ b/docs/source/mayavi/auto/wx_mayavi_embed_in_notebook.py
@@ -80,6 +80,6 @@ class MainWindow(wx.Frame):
         self.Show(True)
 
 if __name__ == '__main__':
-    app = wx.PySimpleApp()
+    app = wx.App(False)
     frame = MainWindow(None, wx.ID_ANY)
     app.MainLoop()

--- a/docs/source/mayavi/building_applications.rst
+++ b/docs/source/mayavi/building_applications.rst
@@ -258,7 +258,7 @@ Using the `Visualization` class defined above::
                                     kind='subpanel').control
             self.Show()
 
-    app = wx.PySimpleApp()
+    app = wx.App(False)
     frame = MainWindow(None, wx.ID_ANY)
     app.MainLoop()
 

--- a/examples/mayavi/interactive/wx_embedding.py
+++ b/examples/mayavi/interactive/wx_embedding.py
@@ -60,7 +60,7 @@ class MainWindow(wx.Frame):
                         kind='subpanel').control
         self.Show(True)
 
-app = wx.PySimpleApp()
+app = wx.App(False)
 frame = MainWindow(None, wx.ID_ANY)
 app.MainLoop()
 

--- a/examples/mayavi/interactive/wx_mayavi_embed_in_notebook.py
+++ b/examples/mayavi/interactive/wx_mayavi_embed_in_notebook.py
@@ -80,6 +80,6 @@ class MainWindow(wx.Frame):
         self.Show(True)
 
 if __name__ == '__main__':
-    app = wx.PySimpleApp()
+    app = wx.App(False)
     frame = MainWindow(None, wx.ID_ANY)
     app.MainLoop()

--- a/tvtk/util/wx_gradient_editor.py
+++ b/tvtk/util/wx_gradient_editor.py
@@ -393,7 +393,7 @@ class wxGradientEditorWidget(wx.Panel, GradientEditorWidget):
         (lookuptable) ``*.grad`` (gradient table for use with this program),
         and ``*.jpg`` (image of the gradient)
         """
-        dlg = wx.FileDialog(self, "Save LUT to...", style=wx.SAVE)
+        dlg = wx.FileDialog(self, "Save LUT to...", style=wx.FD_SAVE)
         wildcard = "Gradient Files (.grad)|*.grad|"   \
                    "All files (*.*)|*.*"
         dlg.SetWildcard(wildcard)
@@ -406,7 +406,7 @@ class wxGradientEditorWidget(wx.Panel, GradientEditorWidget):
         """
         Load a ``*.grad`` lookuptable file using wxpython dialog
         """
-        style = wx.OPEN | wx.HIDE_READONLY
+        style = wx.FD_OPEN
         dlg = wx.FileDialog(self, "Open a file", style=style)
         wildcard = "Gradient Files (.grad)|*.grad|"   \
                    "All files (*.*)|*.*"
@@ -511,7 +511,7 @@ def main():
         """If we had a vtk window running, update it here"""
         print("Update Render Window")
 
-    app = wx.PySimpleApp()
+    app = wx.App(False)
     editor = wxGradientEditor(table,
                               on_color_table_changed,
                               colors=['rgb', 'a', 'h', 's', 'v'],


### PR DESCRIPTION
Retains compatibility with 2.8 - there wx.InitAllImageHandlers() is a no-op,
wx.HIDE_READONLY is 0, and wx.PySimpleApp() issues a deprecation warning.

Patch originally by Olly Betts <olly@survex.com>