### PR TITLE
FIX: Work around NumPy deprecation

### DIFF
--- a/tvtk/array_handler.py
+++ b/tvtk/array_handler.py
@@ -184,7 +184,7 @@ def get_vtk_array_type(numeric_array_type):
     """Returns a VTK typecode given a numpy array."""
     # This is a Mapping from numpy array types to VTK array types.
     _arr_vtk = {
-        numpy.dtype(numpy.character): vtkConstants.VTK_UNSIGNED_CHAR,
+        numpy.dtype('S'): vtkConstants.VTK_UNSIGNED_CHAR,  # numpy.character
         numpy.dtype(numpy.uint8): vtkConstants.VTK_UNSIGNED_CHAR,
         numpy.dtype(numpy.uint16): vtkConstants.VTK_UNSIGNED_SHORT,
         numpy.dtype(numpy.int8): vtkConstants.VTK_CHAR,


### PR DESCRIPTION
Fixes:
```
../mayavi/tvtk/array_handler.py:324: in array2vtk
    vtk_typecode = get_vtk_array_type(z.dtype)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

numeric_array_type = dtype('float64')

    def get_vtk_array_type(numeric_array_type):
        """Returns a VTK typecode given a numpy array."""
        # This is a Mapping from numpy array types to VTK array types.
        _arr_vtk = {
>           numpy.dtype(numpy.character): vtkConstants.VTK_UNSIGNED_CHAR,
            numpy.dtype(numpy.uint8): vtkConstants.VTK_UNSIGNED_CHAR,
            numpy.dtype(numpy.uint16): vtkConstants.VTK_UNSIGNED_SHORT,
            numpy.dtype(numpy.int8): vtkConstants.VTK_CHAR,
            numpy.dtype(numpy.int16): vtkConstants.VTK_SHORT,
            numpy.dtype(numpy.int32): vtkConstants.VTK_INT,
            numpy.dtype(numpy.uint32): vtkConstants.VTK_UNSIGNED_INT,
            numpy.dtype(numpy.uint64): vtkConstants.VTK_UNSIGNED_LONG,
            numpy.dtype(numpy.float32): vtkConstants.VTK_FLOAT,
            numpy.dtype(numpy.float64): vtkConstants.VTK_DOUBLE,
            numpy.dtype(numpy.complex64): vtkConstants.VTK_FLOAT,
            numpy.dtype(numpy.complex128): vtkConstants.VTK_DOUBLE,
        }
E       DeprecationWarning: Converting `np.character` to a dtype is deprecated. The current result is `np.dtype(np.str_)` which is not strictly correct. Note that `np.character` is generally deprecated and 'S1' should be used.
```