### PR TITLE
Add formats to savefig docstring

### DIFF
--- a/mayavi/tools/figure.py
+++ b/mayavi/tools/figure.py
@@ -198,7 +198,8 @@ def savefig(filename, size=None, figure=None, magnification='auto',
     """ Save the current scene.
         The output format are deduced by the extension to filename.
         Possibilities are png, jpg, bmp, tiff, ps, eps, pdf, rib (renderman),
-        oogl (geomview), iv (OpenInventor), vrml, obj (wavefront)
+        oogl (geomview), iv (OpenInventor), wrl, vrml, obj (wavefront),
+        x3d, pov (povray).
 
         **Parameters**
 


### PR DESCRIPTION
I discovered by accident that more formats are available, so they might as well also be listed in the docstring.