### PR TITLE
GitHub Action to ensure we can pip install mayavi

### DIFF
--- a/.github/workflows/pip_install_mayavi.yml
+++ b/.github/workflows/pip_install_mayavi.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]    # [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7]  # [2.7, 3.5, 3.6, 3.7, 3.8, pypy3]
+        python-version: [3.8]  # [2.7, 3.5, 3.6, 3.7, 3.8, pypy3]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -17,5 +17,5 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install --upgrade pip setuptools wheel
-      - run: pip install numpy 'vtk<9.0.0'  # enthought/mayavi#939
+      - run: pip install numpy vtk
       - run: pip install mayavi

--- a/.github/workflows/pip_install_mayavi.yml
+++ b/.github/workflows/pip_install_mayavi.yml
@@ -1,0 +1,19 @@
+name: pip_install_mayavi
+on:
+  pull_request:
+  push:
+  #  branches: [master]
+jobs:
+  pip_install_mayavi:
+    strategy:
+     matrix:
+       os: [ubuntu-latest]    # [ubuntu-latest, macos-latest, windows-latest]
+       python-version: [3.8]  # [2.7, 3.5, 3.6, 3.7, 3.8, pypy3]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install --upgrade pip setuptools wheel
+      - run: pip install mayavi

--- a/.github/workflows/pip_install_mayavi.yml
+++ b/.github/workflows/pip_install_mayavi.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
      matrix:
        os: [ubuntu-latest]    # [ubuntu-latest, macos-latest, windows-latest]
-       python-version: [3.8]  # [2.7, 3.5, 3.6, 3.7, 3.8, pypy3]
+       python-version: [3.6, 3.7, 3.8]  # [2.7, 3.5, 3.6, 3.7, 3.8, pypy3]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pip_install_mayavi.yml
+++ b/.github/workflows/pip_install_mayavi.yml
@@ -15,5 +15,6 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install --upgrade pip setuptools wheel
+      - run: pip install --upgrade pip
+      - run: pip install --upgrade numpy setuptools wheel
       - run: pip install mayavi

--- a/.github/workflows/pip_install_mayavi.yml
+++ b/.github/workflows/pip_install_mayavi.yml
@@ -15,6 +15,6 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install --upgrade pip
-      - run: pip install --upgrade numpy setuptools wheel
+      - run: pip install --upgrade pip setuptools wheel
+      - run: pip install numpy vtk
       - run: pip install mayavi

--- a/.github/workflows/pip_install_mayavi.yml
+++ b/.github/workflows/pip_install_mayavi.yml
@@ -16,5 +16,5 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install --upgrade pip setuptools wheel
-      - run: pip install numpy vtk<9.0.0  # enthought/mayavi#939
+      - run: pip install numpy 'vtk<9.0.0'  # enthought/mayavi#939
       - run: pip install mayavi

--- a/.github/workflows/pip_install_mayavi.yml
+++ b/.github/workflows/pip_install_mayavi.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]    # [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8]  # [2.7, 3.5, 3.6, 3.7, 3.8, pypy3]
+        python-version: [3.7]  # [2.7, 3.5, 3.6, 3.7, 3.8, pypy3]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pip_install_mayavi.yml
+++ b/.github/workflows/pip_install_mayavi.yml
@@ -6,9 +6,10 @@ on:
 jobs:
   pip_install_mayavi:
     strategy:
-     matrix:
-       os: [ubuntu-latest]    # [ubuntu-latest, macos-latest, windows-latest]
-       python-version: [3.6, 3.7, 3.8]  # [2.7, 3.5, 3.6, 3.7, 3.8, pypy3]
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]    # [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.6, 3.7, 3.8]  # [2.7, 3.5, 3.6, 3.7, 3.8, pypy3]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pip_install_mayavi.yml
+++ b/.github/workflows/pip_install_mayavi.yml
@@ -16,5 +16,5 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install --upgrade pip setuptools wheel
-      - run: pip install numpy vtk
+      - run: pip install numpy vtk<9.0.0  # enthought/mayavi#939
       - run: pip install mayavi


### PR DESCRIPTION
A basic test to ensure that we can `pip install mayavi` from [PyPI](https://pypi.org/project/mayavi).

Output: https://github.com/cclauss/mayavi/actions

`pip install numpy 'vtk<9.0.0'`  # Must happen first #939 and Python 3.8 is not supported.