### PR TITLE
MAINT: Support Python 3.9

### DIFF
--- a/mayavi/tools/remote/ipy_remote.py
+++ b/mayavi/tools/remote/ipy_remote.py
@@ -8,12 +8,10 @@ from .remote_scene import SceneManager
 from .remote_widget import RemoteWidget
 from ..figure import gcf
 
-decode_func = getattr(base64, 'decodebytes', getattr(base64, 'decodestring'))
-
 
 def base64_to_bytes(str_or_bytes):
     data = str_or_bytes.encode('ascii')
-    return decode_func(data)
+    return base64.decodebytes(data)
 
 
 class IPyRemoteWidget(RemoteWidget):

--- a/mayavi/tools/remote/remote_scene.py
+++ b/mayavi/tools/remote/remote_scene.py
@@ -14,8 +14,6 @@ from tvtk.tvtk_base import global_disable_update
 
 options.offscreen = True
 
-encode_func = getattr(base64, 'encodebytes', getattr(base64, 'encodestring'))
-
 EventInfo = namedtuple('EventInfo', ['id', 'name', 'event', 'data'])
 
 
@@ -136,7 +134,7 @@ class RemoteScene(HasTraits):
 
     def get_image(self):
         data = self.get_raw_image()
-        return encode_func(data).decode('ascii')
+        return base64.encodebytes(data).decode('ascii')
 
     def call_rwi(self, method, *args):
         if method == 'SetSize':


### PR DESCRIPTION
`base64.decodestring` does not exist in Python 3.9 so current `master` causes an error on import. `decodestring` has been deprecated since 3.1 so should be safe just to use `decodebytes` directly (and same with `encodebytes`).