### PR TITLE
Update deprecated import "collections.Callable"

### DIFF
--- a/tvtk/vtk_parser.py
+++ b/tvtk/vtk_parser.py
@@ -8,7 +8,7 @@ type information, and organizes them.
 
 from __future__ import print_function
 
-import collections
+import collections.abc
 import re
 import types
 
@@ -475,7 +475,7 @@ class VTKMethodParser:
         meths = self._find_get_methods(klass, meths)
         self.other_meths = [
             x for x in meths \
-            if isinstance(getattr(klass, x), collections.Callable)
+            if isinstance(getattr(klass, x), collections.abc.Callable)
         ]
 
     def _remove_method(self, meths, method):


### PR DESCRIPTION
Use of `collections.Callable` was deprecated in Python 3.3 and is finally removed in the upcoming Python 3.10. It needs to be imported from `collections.abc`.