### PR TITLE
import from pyface.image not traitsui.image

### DIFF
--- a/mayavi/tools/data_wizards/data_source_wizard.py
+++ b/mayavi/tools/data_wizards/data_source_wizard.py
@@ -9,9 +9,9 @@ from traitsui.api import EnumEditor, View, Item, HGroup, \
     TabularEditor, TitleEditor, Label, ArrayEditor, ImageEditor
 
 from traitsui.tabular_adapter import TabularAdapter
-from traitsui.image.image import ImageLibrary
 
 from pyface.api import ImageResource
+from pyface.image.image import ImageLibrary
 
 from .data_source_factory import DataSourceFactory
 from .preview_window import PreviewWindow


### PR DESCRIPTION
closes #971 

This PR simply changes an import from `traitsui.image.image` to be from `pyface.image.image` as I am about to open a PR to remove the `traitsui.image` submodule in traitsui.