### PR TITLE
Pass a value in appropriate range to avoid failure

### DIFF
--- a/mayavi/tests/test_optional_collection.py
+++ b/mayavi/tests/test_optional_collection.py
@@ -66,7 +66,7 @@ class TestOptionalCollection(unittest.TestCase):
         self.assertEqual(np.allclose(r, (6.09,6.09), atol=1.01e-03), True)
         # Adding a contour should create the appropriate output in
         # the collection.
-        c.contours.append(200)
+        c.contours.append(10)
         self.assertEqual(np.allclose(r, [6.09,6.09], atol=1.01e-03), True)
         # the collection's output should be that of the normals.
         self.assertEqual(coll.outputs[0] is n.outputs[0],True)


### PR DESCRIPTION
closes #1004 
Based off the tracebacks:
```
traits.trait_errors.TraitError: Each element of the 'contours' trait of a Contour instance must be 0.9999999999999999 <= a number <= 11.180339887498949, but a value of 200 <class 'int'> was specified.
```

In the test I swapped out 200 for 10 to be in the range