### PR TITLE
Bug Fix Release 4.7.3

### DIFF
--- a/docs/CHANGES.txt
+++ b/docs/CHANGES.txt
@@ -1,3 +1,22 @@
+Mayavi 4.7.3
+============
+
+This is a small bug fix release mainly concerned with compatability with Traits
+6.2.0 and soon to be release TraitsUI 7.2.0.
+
+Fixes
+-----
+
+10 Dec 2021 `#983 <https://github.com/enthought/mayavi/pull/983>`_ (larsoner)
+   - MAINT: Support Python 3.9
+
+06 May 2021 `#1030 <https://github.com/enthought/mayavi/pull/1030>`_ (aaronayres35)
+   - import from pyface.image not traitsui.image
+
+06 May 2021 `#1035 <https://github.com/enthought/mayavi/pull/1035>`_ (aaronayres35)
+   - Pass a value in appropriate range to avoid failure
+
+
 Mayavi 4.7.2
 ============
 

--- a/mayavi/__init__.py
+++ b/mayavi/__init__.py
@@ -5,7 +5,7 @@
     Part of the Mayavi project of the Enthought Tool Suite.
 """
 
-__version__ = '4.7.3.dev0'
+__version__ = '4.7.3'
 
 __requires__ = [
     'apptools',

--- a/mayavi/__init__.py
+++ b/mayavi/__init__.py
@@ -5,7 +5,7 @@
     Part of the Mayavi project of the Enthought Tool Suite.
 """
 
-__version__ = '4.7.3'
+__version__ = '4.7.4.dev0'
 
 __requires__ = [
     'apptools',


### PR DESCRIPTION
This PR follows the lead of #960 

I suspect there is a way to auto-update change log given the formatting?  I was lazy and did not figure out if this was the case and just did it manually for the few PRs going into this release.  I also have not updated the auto generated docs :/ see second commit on linked PR.
It looks like we also don't keep `maint/<release number>` branches in mayavi as we do in other ets projects (ref: latest traitsui bugfix issue: https://github.com/enthought/traitsui/issues/1419)

In any case, this is a very quick/minor bug fix release, and I tried to follow the previous PR made in mayavi.  

I will be sure to not squash merge, and then will tag the first commit of this PR as the release.  Perhaps we need a follow up gh-pages PR? No documentation has been changed, but so that published docs have updated changelog?

