### PR TITLE
Use mock through unittest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ cache:
 before_install:
   - mkdir -p "${HOME}/.cache/download"
   - if [[ ${TRAVIS_OS_NAME} == 'linux' ]]; then ./ci/install-edm-linux.sh; export PATH="${HOME}/edm/bin:${PATH}"; fi
-  - edm install --version ${RUNTIME} -y wheel numpy nose mock Sphinx coverage psutil
+  - edm install --version ${RUNTIME} -y wheel numpy nose Sphinx coverage psutil
 
 install:
   - if [[ ${ETS_TOOLKIT} == 'wx' ]]; then edm install -y wxpython; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ install:
   - ps: Start-FileDownload "https://package-data.enthought.com/edm/win_x86_64/2.0/edm_cli_2.0.0_x86_64.msi"
   - start /wait msiexec /i edm_cli_2.0.0_x86_64.msi /qn /log install.log EDMAPPDIR=C:\Enthought\edm
   - edm info
-  - edm install --version 3.6 -y numpy nose mock Sphinx coverage psutil
+  - edm install --version 3.6 -y numpy nose Sphinx coverage psutil
   - "%CMD_IN_ENV% edm run -- pip install -r ci\\ci-requirements.txt"
   - edm run -- pip install vtk pyqt5==5.9.2
   # get a sufficiently modern OpenGL for VTK9

--- a/ci/ci-requirements.txt
+++ b/ci/ci-requirements.txt
@@ -1,5 +1,4 @@
 pillow
-mock
 Sphinx
 coverage
 psutil

--- a/ci/ci-src-requirements.txt
+++ b/ci/ci-src-requirements.txt
@@ -1,5 +1,4 @@
 pillow
-mock
 Sphinx
 coverage
 psutil

--- a/mayavi/tests/test_engine_manager.py
+++ b/mayavi/tests/test_engine_manager.py
@@ -2,7 +2,7 @@
 Tests for mayavi.tools.engine_manager
 """
 import unittest
-from mock import patch
+from unittest.mock import patch
 
 from mayavi.core.null_engine import NullEngine
 from mayavi.plugins.envisage_engine import EnvisageEngine

--- a/mayavi/tests/test_file_timestep.py
+++ b/mayavi/tests/test_file_timestep.py
@@ -2,7 +2,6 @@ import os
 import unittest
 import tempfile
 import shutil
-import mock
 
 from mayavi.core.null_engine import NullEngine
 from mayavi.sources.vtk_xml_file_reader import VTKXMLFileReader
@@ -15,10 +14,10 @@ from tvtk.pyface.tvtk_scene import TVTKScene
 def make_mock_scene():
     """Mocks a scene suitable for testing the movie generation.
     """
-    s = mock.Mock(spec=TVTKScene)
+    s = unittest.mock.Mock(spec=TVTKScene)
     s.foreground = (1,0,0)
     s.off_screen_rendering = True
-    mm = mock.MagicMock(spec=MovieMaker)
+    mm = unittest.mock.MagicMock(spec=MovieMaker)
     s.movie_maker = mm
     return s
 

--- a/mayavi/tests/test_file_timestep.py
+++ b/mayavi/tests/test_file_timestep.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from unittest.mock import MagicMock, Mock
 import tempfile
 import shutil
 
@@ -14,10 +15,10 @@ from tvtk.pyface.tvtk_scene import TVTKScene
 def make_mock_scene():
     """Mocks a scene suitable for testing the movie generation.
     """
-    s = unittest.mock.Mock(spec=TVTKScene)
+    s = Mock(spec=TVTKScene)
     s.foreground = (1,0,0)
     s.off_screen_rendering = True
-    mm = unittest.mock.MagicMock(spec=MovieMaker)
+    mm = MagicMock(spec=MovieMaker)
     s.movie_maker = mm
     return s
 

--- a/mayavi/tests/test_image_plane_widget.py
+++ b/mayavi/tests/test_image_plane_widget.py
@@ -9,7 +9,7 @@ from io import BytesIO
 import copy
 import numpy
 import unittest
-from mock import patch
+from unittest.mock import patch
 
 
 # Enthought library imports

--- a/mayavi/tests/test_mlab_integration.py
+++ b/mayavi/tests/test_mlab_integration.py
@@ -7,6 +7,7 @@ This also tests some numerics with VTK.
 import os
 import tempfile
 import unittest
+from unittest.mock import patch
 
 import numpy as np
 from numpy.testing import assert_allclose
@@ -552,7 +553,7 @@ class TestMlabAnimate(TestMlabNullEngine):
 
         # When
         from mayavi.core.file_data_source import NoUITimer
-        with unittest.mock.patch('mayavi.tools.animator.Timer', NoUITimer):
+        with patch('mayavi.tools.animator.Timer', NoUITimer):
             a = anim()
             a.timer.Start()
 

--- a/mayavi/tests/test_mlab_integration.py
+++ b/mayavi/tests/test_mlab_integration.py
@@ -8,8 +8,6 @@ import os
 import tempfile
 import unittest
 
-import mock
-
 import numpy as np
 from numpy.testing import assert_allclose
 from traits.testing.unittest_tools import UnittestTools
@@ -554,7 +552,7 @@ class TestMlabAnimate(TestMlabNullEngine):
 
         # When
         from mayavi.core.file_data_source import NoUITimer
-        with mock.patch('mayavi.tools.animator.Timer', NoUITimer):
+        with unittest.mock.patch('mayavi.tools.animator.Timer', NoUITimer):
             a = anim()
             a.timer.Start()
 

--- a/mayavi/tests/test_mlab_source.py
+++ b/mayavi/tests/test_mlab_source.py
@@ -7,7 +7,7 @@ Test for MlabSource and its subclasses.
 
 import unittest
 import numpy as np
-from mock import patch
+from unittest.mock import patch
 
 from tvtk.api import tvtk
 from mayavi.tools import sources

--- a/mayavi/tests/test_pylab_luts.py
+++ b/mayavi/tests/test_pylab_luts.py
@@ -1,7 +1,7 @@
 import sys
 import unittest
 
-from mock import patch
+from unittest.mock import patch
 
 
 class TestPylabLuts(unittest.TestCase):

--- a/mayavi/tests/test_volume.py
+++ b/mayavi/tests/test_volume.py
@@ -1,7 +1,7 @@
 # Standard library imports.
 import numpy as np
 import unittest
-from mock import patch
+from unittest.mock import patch
 
 # Enthought library imports
 from mayavi.tests.common import get_example_data

--- a/tvtk/tests/test_movie_maker.py
+++ b/tvtk/tests/test_movie_maker.py
@@ -1,4 +1,3 @@
-import mock
 import os
 import shutil
 import tempfile
@@ -17,7 +16,7 @@ class TestMovieMaker(unittest.TestCase):
     def test_does_nothing_when_record_is_off(self):
         # Given
         mm = MovieMaker(record=False)
-        mm._save_scene = mock.MagicMock()
+        mm._save_scene = unittest.mock.MagicMock()
 
         # When
         mm.animation_start()
@@ -31,7 +30,7 @@ class TestMovieMaker(unittest.TestCase):
     def test_calls_save_scene_when_record_is_on(self):
         # Given
         mm = MovieMaker(record=True)
-        mm._save_scene = mock.MagicMock()
+        mm._save_scene = unittest.mock.MagicMock()
 
         # When
         mm.animation_start()
@@ -45,9 +44,9 @@ class TestMovieMaker(unittest.TestCase):
     def test_calls_save_scene_with_record_movie(self):
         # Given
         mm = MovieMaker(record=False)
-        mm._save_scene = mock.MagicMock()
-        mm.animation_start = mock.MagicMock()
-        mm.animation_stop = mock.MagicMock()
+        mm._save_scene = unittest.mock.MagicMock()
+        mm.animation_start = unittest.mock.MagicMock()
+        mm.animation_stop = unittest.mock.MagicMock()
 
         # When
         with mm.record_movie():
@@ -63,7 +62,7 @@ class TestMovieMaker(unittest.TestCase):
     def test_directory_updates_correctly(self):
         # Given
         mm = MovieMaker(record=True, directory=self.root)
-        mm._save_scene = mock.MagicMock()
+        mm._save_scene = unittest.mock.MagicMock()
 
         # When
         with mm.record_movie():

--- a/tvtk/tests/test_movie_maker.py
+++ b/tvtk/tests/test_movie_maker.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import tempfile
 import unittest
+from unittest.mock import MagicMock
 
 from tvtk.pyface.movie_maker import MovieMaker
 
@@ -16,7 +17,7 @@ class TestMovieMaker(unittest.TestCase):
     def test_does_nothing_when_record_is_off(self):
         # Given
         mm = MovieMaker(record=False)
-        mm._save_scene = unittest.mock.MagicMock()
+        mm._save_scene = MagicMock()
 
         # When
         mm.animation_start()
@@ -30,7 +31,7 @@ class TestMovieMaker(unittest.TestCase):
     def test_calls_save_scene_when_record_is_on(self):
         # Given
         mm = MovieMaker(record=True)
-        mm._save_scene = unittest.mock.MagicMock()
+        mm._save_scene = MagicMock()
 
         # When
         mm.animation_start()
@@ -44,9 +45,9 @@ class TestMovieMaker(unittest.TestCase):
     def test_calls_save_scene_with_record_movie(self):
         # Given
         mm = MovieMaker(record=False)
-        mm._save_scene = unittest.mock.MagicMock()
-        mm.animation_start = unittest.mock.MagicMock()
-        mm.animation_stop = unittest.mock.MagicMock()
+        mm._save_scene = MagicMock()
+        mm.animation_start = MagicMock()
+        mm.animation_stop = MagicMock()
 
         # When
         with mm.record_movie():
@@ -62,7 +63,7 @@ class TestMovieMaker(unittest.TestCase):
     def test_directory_updates_correctly(self):
         # Given
         mm = MovieMaker(record=True, directory=self.root)
-        mm._save_scene = unittest.mock.MagicMock()
+        mm._save_scene = MagicMock()
 
         # When
         with mm.record_movie():

--- a/tvtk/tests/test_pyface_utils.py
+++ b/tvtk/tests/test_pyface_utils.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import Mock, patch
 
 from pyface.api import FileDialog, NO, OK
 
@@ -6,13 +7,13 @@ from pyface.api import FileDialog, NO, OK
 class TestPopupSave(unittest.TestCase):
 
     def _make_mock_file_dialog(self, return_value):
-        m = unittest.mock.Mock(spec=FileDialog)
+        m = Mock(spec=FileDialog)
         m.open.return_value = return_value
         m.path = 'mock'
         return m
 
     def test_popup_save_with_user_ok(self):
-        with unittest.mock.patch('pyface.api.FileDialog') as fd:
+        with patch('pyface.api.FileDialog') as fd:
             fd.return_value = self._make_mock_file_dialog(OK)
             from tvtk.pyface.utils import popup_save
             x = popup_save()
@@ -20,7 +21,7 @@ class TestPopupSave(unittest.TestCase):
         self.assertEqual(x, 'mock')
 
     def test_popup_save_with_user_not_ok(self):
-        with unittest.mock.patch('pyface.api.FileDialog') as fd:
+        with patch('pyface.api.FileDialog') as fd:
             fd.return_value = self._make_mock_file_dialog(NO)
             from tvtk.pyface.utils import popup_save
             x = popup_save()

--- a/tvtk/tests/test_pyface_utils.py
+++ b/tvtk/tests/test_pyface_utils.py
@@ -1,4 +1,3 @@
-import mock
 import unittest
 
 from pyface.api import FileDialog, NO, OK
@@ -7,13 +6,13 @@ from pyface.api import FileDialog, NO, OK
 class TestPopupSave(unittest.TestCase):
 
     def _make_mock_file_dialog(self, return_value):
-        m = mock.Mock(spec=FileDialog)
+        m = unittest.mock.Mock(spec=FileDialog)
         m.open.return_value = return_value
         m.path = 'mock'
         return m
 
     def test_popup_save_with_user_ok(self):
-        with mock.patch('pyface.api.FileDialog') as fd:
+        with unittest.mock.patch('pyface.api.FileDialog') as fd:
             fd.return_value = self._make_mock_file_dialog(OK)
             from tvtk.pyface.utils import popup_save
             x = popup_save()
@@ -21,7 +20,7 @@ class TestPopupSave(unittest.TestCase):
         self.assertEqual(x, 'mock')
 
     def test_popup_save_with_user_not_ok(self):
-        with mock.patch('pyface.api.FileDialog') as fd:
+        with unittest.mock.patch('pyface.api.FileDialog') as fd:
             fd.return_value = self._make_mock_file_dialog(NO)
             from tvtk.pyface.utils import popup_save
             x = popup_save()


### PR DESCRIPTION
`mock` is now in the standard library since python 3.3.  This PR updates the codebase to use mock via unittest.

Python 2 is end of life and we plan to drop support at some point.

This PR may be jumping the gun a bit in which case we can hold off on merging or close and re open later.