### PR TITLE
Remove use of six

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ Sphinx
 traits>=4.6.0
 traitsui>=6.0.0
 vtk
-six

--- a/tvtk/tests/test_messenger.py
+++ b/tvtk/tests/test_messenger.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2004-2020,  Enthought, Inc.
 # License: BSD Style.
 
-from six.moves import reload_module
+from importlib import reload
 import unittest
 
 from tvtk import messenger
@@ -77,7 +77,7 @@ class TestMessenger(unittest.TestCase):
         b = B()
         m = messenger.Messenger()
         orig_len = len(m._signals)
-        reload_module(messenger)
+        reload(messenger)
         m = messenger.Messenger()
         self.assertEqual(len(m._signals), orig_len)
         b.send(1, test=1)

--- a/tvtk/tests/test_tvtk_base.py
+++ b/tvtk/tests/test_tvtk_base.py
@@ -6,13 +6,12 @@ test_tvtk.py.
 # Author: Prabhu Ramachandran
 # Copyright (c) 2004-2020, Enthought, Inc.
 # License: BSD Style.
-
+from importlib import reload
 import unittest
 import pickle
 import weakref
 import vtk
 import gc
-from six.moves import reload_module
 
 from traits import api as traits
 from tvtk import tvtk_base
@@ -321,7 +320,7 @@ class TestTVTKBase(unittest.TestCase):
         # Check reload-safety.
         p = Prop()
         l1 = len(tvtk_base._object_cache)
-        reload_module(tvtk_base)
+        reload(tvtk_base)
         self.assertEqual(l1, len(tvtk_base._object_cache))
 
     # Reloading causes havoc with nosetests based tests so we skip in


### PR DESCRIPTION
part of #987 

This PR simply removes the couple uses of `six` in the codebase.

Note that `importlib.reload` is available for python 3.4+.  Thus this change assumes we are going to go ahead and drop support for python < 3.6 as we have done across the rest of ETS as python 3.5 is EOL.