### PR TITLE
Remove all __future__ imports

### DIFF
--- a/docs/source/mayavi/auto/compute_in_thread.py
+++ b/docs/source/mayavi/auto/compute_in_thread.py
@@ -8,8 +8,6 @@ data and visualize it as image data using a few modules.
 # Copyright (c) 2007-2020, Enthought, Inc.
 # License: BSD Style.
 
-from __future__ import print_function
-
 # Standard library imports
 import numpy
 from threading import Thread

--- a/docs/source/mayavi/auto/mlab_3D_to_2D.py
+++ b/docs/source/mayavi/auto/mlab_3D_to_2D.py
@@ -111,8 +111,6 @@ Now that the prelimenaries are out of the way, lets get started.
 # Copyright (c) 2009, S. Chris Colbert
 # License: BSD Style
 
-from __future__ import print_function
-
 # this import is here because we need to ensure that matplotlib uses the
 # wx backend and having regular code outside the main block is PyTaboo.
 # It needs to be imported first, so that matplotlib can impose the

--- a/examples/mayavi/advanced_visualization/mlab_3D_to_2D.py
+++ b/examples/mayavi/advanced_visualization/mlab_3D_to_2D.py
@@ -111,8 +111,6 @@ Now that the prelimenaries are out of the way, lets get started.
 # Copyright (c) 2009, S. Chris Colbert
 # License: BSD Style
 
-from __future__ import print_function
-
 # this import is here because we need to ensure that matplotlib uses the
 # wx backend and having regular code outside the main block is PyTaboo.
 # It needs to be imported first, so that matplotlib can impose the

--- a/examples/mayavi/interactive/compute_in_thread.py
+++ b/examples/mayavi/interactive/compute_in_thread.py
@@ -8,8 +8,6 @@ data and visualize it as image data using a few modules.
 # Copyright (c) 2007-2020, Enthought, Inc.
 # License: BSD Style.
 
-from __future__ import print_function
-
 # Standard library imports
 import numpy as np
 from threading import Thread

--- a/examples/tvtk/animated_texture.py
+++ b/examples/tvtk/animated_texture.py
@@ -10,8 +10,6 @@ TVTK sees a view of this array without doing any data transfers.
 # Copyright (c) 2006-2020, Enthought, Inc.
 # License: BSD Style.
 
-from __future__ import print_function
-
 from numpy import arange, zeros, uint8, exp, sqrt, pi
 
 from tvtk.api import tvtk

--- a/integrationtests/mayavi/common.py
+++ b/integrationtests/mayavi/common.py
@@ -4,8 +4,6 @@
 # Copyright (c) 2005-2020, Enthought, Inc.
 # License: BSD Style.
 
-from __future__ import print_function
-
 # Standard library imports
 import gc
 import os

--- a/mayavi/core/customize.py
+++ b/mayavi/core/customize.py
@@ -21,8 +21,6 @@ custom plugins.
 # Copyright (c) 2008-2020, Prabhu Ramachandran, Enthought, Inc.
 # License: BSD Style.
 
-from __future__ import print_function
-
 # Standard library imports.
 import sys
 import traceback

--- a/mayavi/core/traits_menu.py
+++ b/mayavi/core/traits_menu.py
@@ -5,8 +5,6 @@
 # Copyright (c) 2008-2020, Prabhu Ramachandran Enthought, Inc.
 # License: BSD Style.
 
-from __future__ import print_function
-
 # Standard library imports.
 from os.path import splitext, isfile
 

--- a/mayavi/scripts/mayavi2.py
+++ b/mayavi/scripts/mayavi2.py
@@ -12,8 +12,6 @@ Mayavi2: http://docs.enthought.com/mayavi/mayavi/overview.html
 # Copyright (c) 2005-2020, Enthought, Inc.
 # License: BSD Style.
 
-from __future__ import print_function
-
 # Standard library imports.
 import sys
 import getopt

--- a/mayavi/tests/runtests.py
+++ b/mayavi/tests/runtests.py
@@ -10,8 +10,6 @@ thing.
 # Copyright (c) 2009-2020,  Enthought Inc.
 # License: BSD Style.
 
-from __future__ import print_function
-
 import sys
 from os.path import dirname, join, isfile, isdir
 from glob import glob

--- a/mayavi/tools/notebook.py
+++ b/mayavi/tools/notebook.py
@@ -1,7 +1,5 @@
 """Functionality to display Mayavi scenes inside Jupyter notebooks.
 """
-from __future__ import print_function
-
 import base64
 from itertools import count
 

--- a/mayavi/tools/remote/remote_scene.py
+++ b/mayavi/tools/remote/remote_scene.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import base64
 from collections import namedtuple
 import time

--- a/mlab_reference.py
+++ b/mlab_reference.py
@@ -6,8 +6,6 @@ Script to generate the function reference for mlab.
 # Copyright (c) 2007-2020, Enthought, Inc.
 # License: BSD Style.
 
-from __future__ import print_function
-
 import os
 import sys
 

--- a/tvtk/code_gen.py
+++ b/tvtk/code_gen.py
@@ -5,8 +5,6 @@
 # Copyright (c) 2004-2020, Enthought, Inc.
 # License: BSD Style.
 
-from __future__ import print_function
-
 import vtk_module as vtk
 import os
 import os.path

--- a/tvtk/pyface/tvtk_scene.py
+++ b/tvtk/pyface/tvtk_scene.py
@@ -10,9 +10,6 @@ functionality. See the class docs for more details.
 # Copyright (c) 2007-2020, Enthought, Inc.
 # License: BSD Style.
 
-
-from __future__ import print_function
-
 import os
 import os.path
 

--- a/tvtk/setup.py
+++ b/tvtk/setup.py
@@ -2,7 +2,6 @@
 # Setup script for TVTK, numpy.distutils based.
 #
 #
-from __future__ import print_function
 
 import os
 import sys

--- a/tvtk/tests/test_vtk_parser.py
+++ b/tvtk/tests/test_vtk_parser.py
@@ -13,8 +13,6 @@ error messages but they are usually harmless.
 
 """
 
-from __future__ import print_function
-
 import unittest
 from tvtk import vtk_parser
 

--- a/tvtk/tools/visual.py
+++ b/tvtk/tools/visual.py
@@ -45,8 +45,6 @@ with the vanilla python interpretor.  ::
 # License: BSD Style.
 # Year : 2007-2016
 
-from __future__ import print_function
-
 # Standard library imports.
 import sys
 import numpy

--- a/tvtk/tvtk_access.py
+++ b/tvtk/tvtk_access.py
@@ -7,8 +7,6 @@ this see the devel.txt in the TVTK documentation directory.
 # Copyright (c) 2007-2020,  Enthought, Inc.
 # License: BSD Style.
 
-from __future__ import print_function
-
 from os.path import exists, join, dirname, isdir
 
 # The tvtk wrapper code is all typically inside one zip file.  We try to

--- a/tvtk/tvtk_base.py
+++ b/tvtk/tvtk_base.py
@@ -5,8 +5,6 @@
 # Copyright (c) 2004-2020,  Enthought, Inc.
 # License: BSD Style.
 
-from __future__ import print_function
-
 import sys
 import weakref
 import os

--- a/tvtk/vtk_parser.py
+++ b/tvtk/vtk_parser.py
@@ -6,8 +6,6 @@ type information, and organizes them.
 # Copyright (c) 2004-2020, Enthought, Inc.
 # License: BSD Style.
 
-from __future__ import print_function
-
 import collections.abc
 import re
 import types

--- a/tvtk/wrapper_gen.py
+++ b/tvtk/wrapper_gen.py
@@ -6,8 +6,6 @@ VTK classes.
 # Copyright (c) 2004-2020, Enthought, Inc.
 # License: BSD Style.
 
-from __future__ import print_function
-
 import re
 import sys
 import vtk


### PR DESCRIPTION
part of #987 

This PR simply removes all `__future__` imports which are no longer needed in the code base