### PR TITLE
Remove code that handles unsupported vtk versions (< 7)

### DIFF
--- a/docs/source/mayavi/auto/structured_points3d.py
+++ b/docs/source/mayavi/auto/structured_points3d.py
@@ -17,7 +17,6 @@ Alternatively, it can be run as::
 
 from tvtk.api import tvtk
 from tvtk.array_handler import get_vtk_array_type
-from tvtk.common import is_old_pipeline
 from numpy import array, ogrid, sin, ravel
 from mayavi.scripts import mayavi2
 
@@ -43,12 +42,6 @@ spoints = tvtk.StructuredPoints(origin=origin, spacing=spacing,
 s = scalars.transpose().copy()
 spoints.point_data.scalars = ravel(s)
 spoints.point_data.scalars.name = 'scalars'
-
-# This is needed in slightly older versions of VTK (like the 5.0.2
-# release) to prevent a segfault.  VTK does not detect the correct
-# data type.
-if is_old_pipeline():
-    spoints.scalar_type = get_vtk_array_type(s.dtype)
 
 # Uncomment the next two lines to save the dataset to a VTK XML file.
 #w = tvtk.XMLImageDataWriter(input=spoints, file_name='spoints3d.vti')

--- a/examples/tvtk/animated_texture.py
+++ b/examples/tvtk/animated_texture.py
@@ -13,8 +13,7 @@ TVTK sees a view of this array without doing any data transfers.
 from numpy import arange, zeros, uint8, exp, sqrt, pi
 
 from tvtk.api import tvtk
-from tvtk.common import configure_input_data, configure_source_data, \
-                        is_old_pipeline
+from tvtk.common import configure_input_data, configure_source_data
 
 # Source for glyph.  Note that you need to pick a source that has
 # texture co-ords already set.  If not you'll have to generate them.
@@ -81,11 +80,7 @@ def image_from_array(ary):
         img.point_data.scalars = ary
 
     elif dims == 3:
-        # 2D array of pixels.
-        if is_old_pipeline():
-            img.whole_extent = (0, sz[0]-1, 0, sz[1]-1, 0, 0)
-        else:
-            img.extent = (0, sz[0]-1, 0, sz[1]-1, 0, 0)
+        img.extent = (0, sz[0]-1, 0, sz[1]-1, 0, 0)
         img.dimensions = sz[0], sz[1], 1
 
         # create a 2d view of the array

--- a/examples/tvtk/texture_glyph.py
+++ b/examples/tvtk/texture_glyph.py
@@ -10,7 +10,7 @@ the input of the Glyph using Python lists.
 # License: BSD Style.
 
 from tvtk.api import tvtk
-from tvtk.common import is_old_pipeline, configure_input_data, configure_source_data
+from tvtk.common import configure_input_data, configure_source_data
 
 # Source for glyph.  Note that you need to pick a source that has
 # texture co-ords already set.  If not you'll have to generate them.
@@ -54,10 +54,7 @@ a = tvtk.Actor(mapper=m)
 # will do (you must use a suitable reader though).
 img = tvtk.JPEGReader(file_name='images/masonry.jpg')
 t = tvtk.Texture(interpolate = 1)
-if is_old_pipeline():
-    t.input = img.output
-else:
-    t.input_connection = img.output_port
+t.input_connection = img.output_port
 a.texture = t
 
 # Renderwindow stuff and add actor.

--- a/integrationtests/mayavi/test_ipw_multiple_scalars.py
+++ b/integrationtests/mayavi/test_ipw_multiple_scalars.py
@@ -7,7 +7,7 @@
 from common import TestCase
 from numpy import zeros, random
 from tvtk.api import tvtk
-from tvtk.common import is_old_pipeline
+
 
 class TestIPWMultipleScalars(TestCase):
 
@@ -34,8 +34,6 @@ class TestIPWMultipleScalars(TestCase):
         arr3 = arr3.astype('f')
 
         p = tvtk.ImageData(dimensions=[3,3,3], spacing=[1,1,1])
-        if is_old_pipeline():
-            p.scalar_type = 'int'
 
         p.point_data.scalars = arr1
         p.point_data.scalars.name = 'first'
@@ -43,8 +41,6 @@ class TestIPWMultipleScalars(TestCase):
         p.point_data.get_array(j2).name='second'
         j3 = p.point_data.add_array(arr3)
         p.point_data.get_array(j3).name='third'
-        if is_old_pipeline():
-            p.update()
 
         # Make the pipeline.
         self.new_scene()
@@ -61,10 +57,6 @@ class TestIPWMultipleScalars(TestCase):
         assert r == expect
         o = src.outputs[0]
         o.update_traits()
-        if is_old_pipeline():
-            st = ipw.input.scalar_type
-            assert scalars.data_type == 10
-            assert st == 'float'
 
         src.point_scalars_name = 'second'
         scalars = ipw.input.point_data.scalars
@@ -72,10 +64,6 @@ class TestIPWMultipleScalars(TestCase):
         expect = min(arr2), max(arr2)
         assert r == expect
         o.update_traits()
-        if is_old_pipeline():
-            st = ipw.input.scalar_type
-            assert scalars.data_type == 11
-            assert st == 'double'
 
         src.point_scalars_name = 'third'
         scalars = ipw.input.point_data.scalars
@@ -83,10 +71,6 @@ class TestIPWMultipleScalars(TestCase):
         expect = min(arr3), max(arr3)
         assert r == expect
         o.update_traits()
-        if is_old_pipeline():
-            st = ipw.input.scalar_type
-            assert scalars.data_type == 10
-            assert st == 'float'
 
 
 if __name__ == '__main__':

--- a/mayavi/components/actor.py
+++ b/mayavi/components/actor.py
@@ -11,7 +11,6 @@ import vtk
 from traits.api import Instance, Bool, Enum
 from tvtk.api import tvtk
 from traits.api import DelegatesTo
-from tvtk.common import is_old_pipeline
 
 # Local imports.
 from mayavi.core.component import Component
@@ -116,15 +115,14 @@ class Actor(Component):
         sends a `data_changed` event.
         """
         # Invoke render to update any changes.
-        if not is_old_pipeline():
-            from mayavi.modules.outline import Outline
-            from mayavi.components.glyph import Glyph
-            #FIXME: A bad hack, but without these checks results in seg fault
-            input = self.inputs[0]
-            if isinstance(input, Outline) or isinstance(input, Glyph):
-                self.mapper.update(0)
-            else:
-                self.mapper.update()
+        from mayavi.modules.outline import Outline
+        from mayavi.components.glyph import Glyph
+        #FIXME: A bad hack, but without these checks results in seg fault
+        input = self.inputs[0]
+        if isinstance(input, Outline) or isinstance(input, Glyph):
+            self.mapper.update(0)
+        else:
+            self.mapper.update()
         self.render()
 
     ######################################################################

--- a/mayavi/components/implicit_plane.py
+++ b/mayavi/components/implicit_plane.py
@@ -13,8 +13,6 @@ from tvtk.api import tvtk
 from mayavi.core.component import Component
 from mayavi.core.utils import DataSetHelper
 
-VTK_VER = tvtk.Version().vtk_version
-
 
 ######################################################################
 # `ImplicitPlane` class.
@@ -54,29 +52,17 @@ class ImplicitPlane(Component):
     ########################################
     # View related traits.
 
-    if VTK_VER[:3] in ['4.2', '4.4']:
-        _widget_group = Group(Item(name='enabled'),
-                              Item(name='normal_to_x_axis'),
-                              Item(name='normal_to_y_axis'),
-                              Item(name='normal_to_z_axis'),
-                              Item(name='outline_translation'),
-                              Item(name='tubing'),
-                              Item(name='draw_plane'),
-                              Item(name='normal'),
-                              Item(name='origin')
-                              )
-    else:
-        _widget_group = Group(Item(name='enabled'),
-                              Item(name='normal_to_x_axis'),
-                              Item(name='normal_to_y_axis'),
-                              Item(name='normal_to_z_axis'),
-                              Item(name='outline_translation'),
-                              Item(name='scale_enabled'),
-                              Item(name='tubing'),
-                              Item(name='draw_plane'),
-                              Item(name='normal'),
-                              Item(name='origin')
-                              )
+    _widget_group = Group(Item(name='enabled'),
+                          Item(name='normal_to_x_axis'),
+                          Item(name='normal_to_y_axis'),
+                          Item(name='normal_to_z_axis'),
+                          Item(name='outline_translation'),
+                          Item(name='scale_enabled'),
+                          Item(name='tubing'),
+                          Item(name='draw_plane'),
+                          Item(name='normal'),
+                          Item(name='origin')
+                          )
 
     view = View(Group(Item(name='widget', style='custom',
                            editor=InstanceEditor(view=View(_widget_group))),

--- a/mayavi/components/ui/actor.py
+++ b/mayavi/components/ui/actor.py
@@ -17,8 +17,6 @@ from traitsui.api import (View, Group, Item, InstanceEditor,
 from tvtk.api import tvtk
 from tvtk.common import vtk_major_version
 
-VTK_VER = tvtk.Version().vtk_version
-
 # The properties view group.
 _prop_base_group = Group(Item(name='representation'),
                          Item(name='color'),
@@ -35,13 +33,10 @@ _prop_group = Group(Item(name='property', style='custom', show_label=False,
 
 
 # The mapper's view group.
-if VTK_VER[:3] in ['4.2', '4.4']:
-    _mapper_base_group = Group(Item(name='scalar_visibility'))
-else:
-    _mapper_base_group = Group(
-        Item(name='scalar_visibility'),
-        Item(name='interpolate_scalars_before_mapping'),
-    )
+_mapper_base_group = Group(
+    Item(name='scalar_visibility'),
+    Item(name='interpolate_scalars_before_mapping'),
+)
 
 _mapper_group = Group(
     Item(name='mapper', style='custom', show_label=False,

--- a/mayavi/core/base.py
+++ b/mayavi/core/base.py
@@ -25,7 +25,6 @@ from traitsui.api import View
 from apptools.scripting.api import Recorder
 
 # Local imports.
-from tvtk.common import is_old_pipeline
 from mayavi.preferences.api import preference_manager
 from mayavi.core.common import get_engine
 
@@ -199,13 +198,12 @@ class Base(TreeNodeObject):
             state = state_pickler.get_state(self)
             # FIXME: This is for streamline seed point widget position which
             # does not get serialized correctly
-            if not is_old_pipeline():
-                try:
-                    st = state.children[0].children[4]
-                    l_pos = st.seed.widget.position
-                    st.seed.widget.position = [pos.item() for pos in l_pos]
-                except (IndexError, AttributeError):
-                    pass
+            try:
+                st = state.children[0].children[4]
+                l_pos = st.seed.widget.position
+                st.seed.widget.position = [pos.item() for pos in l_pos]
+            except (IndexError, AttributeError):
+                pass
             saved_state = pickle.dumps(state)
         new._saved_state = saved_state
         # In the unlikely case that a new instance is running, load

--- a/mayavi/core/engine.py
+++ b/mayavi/core/engine.py
@@ -24,7 +24,6 @@ from apptools.persistence import state_pickler
 from apptools.scripting.api import Recorder, recordable
 
 # Local imports.
-from tvtk.common import is_old_pipeline
 from mayavi.core.base import Base
 from mayavi.core.scene import Scene
 from mayavi.core.common import error, process_ui_events
@@ -257,15 +256,12 @@ class Engine(HasStrictTraits):
         try:
             #FIXME: This is for streamline seed point widget position which
             #does not get serialized correctly
-            if is_old_pipeline():
-                state_pickler.dump(self, file_or_fname)
-            else:
-                state = state_pickler.get_state(self)
-                st = state.scenes[0].children[0].children[0].children[4]
-                l_pos = st.seed.widget.position
-                st.seed.widget.position = [pos.item() for pos in l_pos]
-                saved_state = state_pickler.dumps(state)
-                file_or_fname.write(saved_state)
+            state = state_pickler.get_state(self)
+            st = state.scenes[0].children[0].children[0].children[4]
+            l_pos = st.seed.widget.position
+            st.seed.widget.position = [pos.item() for pos in l_pos]
+            saved_state = state_pickler.dumps(state)
+            file_or_fname.write(saved_state)
         except (IndexError, AttributeError):
             state_pickler.dump(self, file_or_fname)
         finally:

--- a/mayavi/core/mouse_pick_dispatcher.py
+++ b/mayavi/core/mouse_pick_dispatcher.py
@@ -10,8 +10,6 @@ from traits.api import HasTraits, Dict, Instance, \
 from mayavi.core.scene import Scene
 from tvtk.api import tvtk
 
-VTK_VERSION =        tvtk.Version().vtk_major_version \
-                + .1*tvtk.Version().vtk_minor_version
 
 ################################################################################
 # class `MousePickDispatcher`
@@ -93,10 +91,7 @@ class MousePickDispatcher(HasTraits):
                                                 self.on_pick)
 
         # Register the callbacks on the scene interactor
-        if VTK_VERSION>5:
-            move_event = "RenderEvent"
-        else:
-            move_event = 'MouseMoveEvent'
+        move_event = "RenderEvent"
         if not self._mouse_mvt_callback_nb:
             self._mouse_mvt_callback_nb = \
                 self.scene.scene.interactor.add_observer(move_event,
@@ -106,10 +101,7 @@ class MousePickDispatcher(HasTraits):
                 self.scene.scene.interactor.add_observer(
                                     '%sButtonPressEvent' % button,
                                     self.on_button_press)
-        if VTK_VERSION>5:
-            release_event = "EndInteractionEvent"
-        else:
-            release_event = '%sButtonReleaseEvent' % button
+        release_event = "EndInteractionEvent"
         if not button in self._mouse_release_callback_nbs:
             self._mouse_release_callback_nbs[button] = \
                 self.scene.scene.interactor.add_observer(

--- a/mayavi/core/pipeline_base.py
+++ b/mayavi/core/pipeline_base.py
@@ -121,16 +121,7 @@ class PipelineBase(Base):
                 if hasattr(actor, 'mapper'):
                     m = actor.mapper
                     if m is not None:
-                        if tvtk_common.is_old_pipeline():
-                            m.update()
-                        else:
-                            m.update(0)
-            if tvtk_common.is_old_pipeline():
-                for widget in self.widgets:
-                    if hasattr(widget, 'input'):
-                        input = widget.input
-                        if input is not None:
-                            input.update()
+                        m.update(0)
         if hasattr(self, 'components'):
             for component in self.components:
                     component.render()

--- a/mayavi/filters/extract_grid.py
+++ b/mayavi/filters/extract_grid.py
@@ -18,7 +18,6 @@ from tvtk.vtk_module import VTK_MAJOR_VERSION
 from mayavi.core.common import error
 from mayavi.filters.filter_base import FilterBase
 from mayavi.core.pipeline_info import PipelineInfo
-from tvtk.common import is_old_pipeline
 
 ######################################################################
 # `ExtractGrid` class.
@@ -190,9 +189,7 @@ class ExtractGrid(FilterBase):
     # Non-public methods.
     ######################################################################
     def _update_limits(self):
-        if is_old_pipeline():
-            extents = self.filter.input.whole_extent
-        elif VTK_MAJOR_VERSION <= 7:
+        if VTK_MAJOR_VERSION <= 7:
             extents = self.filter.get_update_extent()
         else:
             extents = self.filter.input.extent

--- a/mayavi/filters/image_data_probe.py
+++ b/mayavi/filters/image_data_probe.py
@@ -143,14 +143,8 @@ class ImageDataProbe(Filter):
             fac = 3.0*npnt/tot_len
             dims = (l*fac).astype(int) + 1
             extent = (0, dims[0] - 1, 0, dims[1] - 1, 0, dims[2] - 1)
-            if tvtk_common.is_old_pipeline():
-                pd.trait_set(extent=extent,
-                             update_extent=extent,
-                             whole_extent=extent,
-                             dimensions=dims)
-            else:
-                pd.trait_set(extent=extent,
-                             dimensions=dims)
+            pd.trait_set(extent=extent,
+                         dimensions=dims)
 
             max_dim = dims.max()
             dims = (dims-1).clip(min=1, max=max_dim+1)
@@ -228,16 +222,9 @@ class ImageDataProbe(Filter):
         dims = self.dimensions
         spacing = self.spacing
         extent = (0, dims[0] - 1, 0, dims[1] - 1, 0, dims[2] - 1)
-        if tvtk_common.is_old_pipeline():
-            pd.trait_set(extent=extent,
-                         update_extent=extent,
-                         whole_extent=extent,
-                         dimensions=dims,
-                         spacing=spacing)
-        else:
-            pd.trait_set(extent=extent,
-                         dimensions=dims,
-                         spacing=spacing)
+        pd.trait_set(extent=extent,
+                     dimensions=dims,
+                     spacing=spacing)
         pd.modified()
         fil = self.filter
         w = fil.global_warning_display

--- a/mayavi/filters/set_active_attribute.py
+++ b/mayavi/filters/set_active_attribute.py
@@ -6,7 +6,6 @@
 from traits.api import Instance, List, Str, Bool
 from traitsui.api import View, Group, Item
 from tvtk.api import tvtk
-from tvtk.common import is_old_pipeline
 
 # Local imports.
 from mayavi.core.pipeline_info import PipelineInfo
@@ -144,9 +143,6 @@ class SetActiveAttribute(Filter):
             return
 
         input = self.inputs[0].get_output_object()
-        if self._first and is_old_pipeline():
-            # Force all attributes to be defined and computed
-            input.update()
         pnt_attr, cell_attr = get_all_attributes(
             self.inputs[0].get_output_dataset()
         )

--- a/mayavi/modules/outline.py
+++ b/mayavi/modules/outline.py
@@ -13,7 +13,6 @@ from traits.api import Instance, Enum, Property, Bool, \
     DelegatesTo
 from traitsui.api import View, Group, Item
 from tvtk.api import tvtk
-from tvtk.common import is_old_pipeline
 
 # Local imports
 from mayavi.core.module import Module
@@ -142,8 +141,7 @@ class Outline(Module):
         self.data_changed = True
 
     def render(self):
-        if not is_old_pipeline():
-            self.outline_filter.update()
+        self.outline_filter.update()
         super(Outline, self).render()
 
     ######################################################################
@@ -185,10 +183,7 @@ class Outline(Module):
 
     def _manual_bounds_changed(self):
         if self.manual_bounds:
-            if is_old_pipeline():
-                self.outline_filter.input = self.outline_source.output
-            else:
-                self.outline_filter.input_connection = self.outline_source.output_port
+            self.outline_filter.input_connection = self.outline_source.output_port
         else:
             # Set the input of the filter.
             mm = self.module_manager

--- a/mayavi/modules/text.py
+++ b/mayavi/modules/text.py
@@ -5,8 +5,6 @@
 # Copyright (c) 2005, Enthought, Inc.
 # License: BSD Style.
 
-from distutils.version import StrictVersion
-
 # Enthought library imports.
 from traits.api import Instance, Range, Str, Bool, Property, \
                                     Float
@@ -17,8 +15,6 @@ from apptools.persistence import state_pickler
 # Local imports
 from mayavi.core.module import Module
 from mayavi.core.pipeline_info import PipelineInfo
-
-VTK_VER = StrictVersion(tvtk.Version().vtk_version)
 
 
 ######################################################################
@@ -70,22 +66,13 @@ class Text(Module):
     ########################################
     # The view of this object.
 
-    if VTK_VER > '5.1':
-        _text_actor_group = Group(Item(name='visibility'),
-                                  Item(name='text_scale_mode'),
-                                  Item(name='alignment_point'),
-                                  Item(name='minimum_size'),
-                                  Item(name='maximum_line_height'),
-                                  show_border=True,
-                                  label='Text Actor')
-    else:
-        _text_actor_group = Group(Item(name='visibility'),
-                                  Item(name='scaled_text'),
-                                  Item(name='alignment_point'),
-                                  Item(name='minimum_size'),
-                                  Item(name='maximum_line_height'),
-                                  show_border=True,
-                                  label='Text Actor')
+    _text_actor_group = Group(Item(name='visibility'),
+                              Item(name='text_scale_mode'),
+                              Item(name='alignment_point'),
+                              Item(name='minimum_size'),
+                              Item(name='maximum_line_height'),
+                              show_border=True,
+                              label='Text Actor')
 
     _position_group_2d = Group(Item(name='_x_position_2d',
                                     label='X position'),

--- a/mayavi/sources/unstructured_grid_reader.py
+++ b/mayavi/sources/unstructured_grid_reader.py
@@ -13,7 +13,6 @@ from traitsui.api import View, Group, Item, Include
 from tvtk.api import tvtk
 
 # Local imports.
-from tvtk.common import is_old_pipeline
 from mayavi.core.file_data_source import FileDataSource
 from mayavi.core.pipeline_info import PipelineInfo
 from mayavi.core.common import error
@@ -127,15 +126,9 @@ class UnstructuredGridReader(FileDataSource):
 
     def __reader_dict_default(self):
         """Default value for reader dict."""
-        if is_old_pipeline():
-            rd = {'inp':tvtk.AVSucdReader(),
-                 'neu':tvtk.GAMBITReader(),
-                 'exii':tvtk.ExodusReader()
-                }
-        else:
-            rd = {'inp':tvtk.AVSucdReader(),
-                 'neu':tvtk.GAMBITReader(),
-                 'ex2':tvtk.ExodusIIReader()
-                }
+        rd = {'inp':tvtk.AVSucdReader(),
+              'neu':tvtk.GAMBITReader(),
+              'ex2':tvtk.ExodusIIReader()
+        }
 
         return rd

--- a/mayavi/sources/vtk_data_source.py
+++ b/mayavi/sources/vtk_data_source.py
@@ -22,7 +22,7 @@ from apptools.persistence.state_pickler \
 from tvtk.api import tvtk
 from tvtk import messenger
 from tvtk.array_handler import array2vtk
-from tvtk.common import is_old_pipeline, configure_input_data
+from tvtk.common import configure_input_data
 from mayavi.core.source import Source
 from mayavi.core.common import handle_children_state
 from mayavi.core.trait_defs import DEnum
@@ -341,9 +341,6 @@ class VTKDataSource(Source):
             # get garbage rendered or worse.
             s = getattr(dataset, attr_type + '_data').scalars
             r = s.range
-            if is_old_pipeline():
-                dataset.scalar_type = s.data_type
-                aa.output.scalar_type = s.data_type
         aa.update()
         # Fire an event, so the changes propagate.
         self.data_changed = True
@@ -378,9 +375,6 @@ class VTKDataSource(Source):
             # the data through to prevent some really strange errors
             # when using an ImagePlaneWidget.
             r = scalars.range
-            if is_old_pipeline():
-                self._assign_attribute.output.scalar_type = scalars.data_type
-                self.data.scalar_type = scalars.data_type
 
         def _setup_data_traits(obj, attributes, d_type):
             """Given the object, the dict of the attributes from the

--- a/mayavi/tests/test_builtin_image.py
+++ b/mayavi/tests/test_builtin_image.py
@@ -11,7 +11,7 @@ import unittest
 from numpy import array
 
 # Enthought library imports.
-from tvtk.common import is_old_pipeline, vtk_major_version
+from tvtk.common import vtk_major_version
 from mayavi.core.null_engine import NullEngine
 from mayavi.sources.builtin_image import BuiltinImage
 from mayavi.modules.surface import Surface
@@ -40,9 +40,7 @@ class TestBuiltinImageSource(unittest.TestCase):
         image_data.data_source.radius = array([80.,  80.,  80.])
         image_data.data_source.center = array([150.,  150.,    0.])
         image_data.data_source.whole_extent = array([10, 245, 10, 245, 0, 0])
-        if is_old_pipeline():
-            image_data.data_source.update_whole_extent()
-        elif vtk_major_version < 8:
+        if vtk_major_version < 8:
             image_data.data_source.set_update_extent_to_whole_extent()
 
         self.e = e
@@ -98,8 +96,7 @@ class TestBuiltinImageSource(unittest.TestCase):
 
         src.data_source.maximum = 2.0
         src.data_source.standard_deviation = 15
-        if not is_old_pipeline():
-            src.data_source.update()
+        src.data_source.update()
         self.check()
 
     def test_save_and_restore(self):

--- a/mayavi/tests/test_extract_grid_filter.py
+++ b/mayavi/tests/test_extract_grid_filter.py
@@ -16,7 +16,6 @@ from mayavi.modules.grid_plane import GridPlane
 from mayavi.modules.axes import Axes
 from mayavi.filters.extract_grid import ExtractGrid
 from tvtk.api import tvtk
-from tvtk.common import is_old_pipeline
 
 class TestExtractGridFilter(unittest.TestCase):
 
@@ -41,8 +40,6 @@ class TestExtractGridFilter(unittest.TestCase):
         image_data = tvtk.ImageData(origin=(xmin, ymin, zmin),
                                     spacing=(dx, dy, dz),
                                     extent=(0, nx-1, 0, ny-1, 0, nz-1))
-        if is_old_pipeline():
-            image_data.whole_extent = image_data.extent
         src.data = image_data
         return src
 
@@ -87,10 +84,6 @@ class TestExtractGridFilter(unittest.TestCase):
         d = VTKDataSource()
         d.data = self.make_scatter()
         e.add_source(d)
-        if is_old_pipeline():
-            a = Axes()
-            e.add_module(a)
-            a.axes.number_of_labels = nb_ticks
 
         self.eg = eg
         self.gpx = gpx

--- a/mayavi/tests/test_ipw_multiple_scalars.py
+++ b/mayavi/tests/test_ipw_multiple_scalars.py
@@ -2,7 +2,6 @@ import unittest
 
 from numpy import zeros, random
 from tvtk.api import tvtk
-from tvtk.common import is_old_pipeline
 from mayavi.sources.vtk_data_source import VTKDataSource
 from mayavi.core.null_engine import NullEngine
 from mayavi.modules.image_plane_widget import ImagePlaneWidget
@@ -17,11 +16,7 @@ class TestIPWMultipleScalars(unittest.TestCase):
         arr3 = arr1 + 2.0*(0.5 - random.random(27))
         arr3 = arr3.astype('f')
 
-        if is_old_pipeline():
-            p = tvtk.ImageData(dimensions=[3,3,3],spacing=[1,1,1],
-                               scalar_type='int')
-        else:
-            p = tvtk.ImageData(dimensions=[3,3,3],spacing=[1,1,1])
+        p = tvtk.ImageData(dimensions=[3,3,3],spacing=[1,1,1])
         p.point_data.scalars = arr1
         p.point_data.scalars.name = 'first'
         j2 = p.point_data.add_array(arr2)
@@ -62,10 +57,7 @@ class TestIPWMultipleScalars(unittest.TestCase):
         self.assertEqual(r, expect)
         o = self.src.outputs[0]
         o.update_traits()
-        if is_old_pipeline():
-            st = ipw.input.scalar_type
-        else:
-            st = ipw.input.scalar_type_as_string
+        st = ipw.input.scalar_type_as_string
         self.assertEqual(scalars.data_type, 10)
         self.assertEqual(st, 'float')
 
@@ -75,10 +67,7 @@ class TestIPWMultipleScalars(unittest.TestCase):
         expect = min(arr2), max(arr2)
         self.assertEqual(r, expect)
         o.update_traits()
-        if is_old_pipeline():
-            st = ipw.input.scalar_type
-        else:
-            st = ipw.input.scalar_type_as_string
+        st = ipw.input.scalar_type_as_string
         self.assertEqual(scalars.data_type, 11)
         self.assertEqual(st, 'double')
 
@@ -88,10 +77,7 @@ class TestIPWMultipleScalars(unittest.TestCase):
         expect = min(arr3), max(arr3)
         self.assertEqual(r, expect)
         o.update_traits()
-        if is_old_pipeline():
-            st = ipw.input.scalar_type
-        else:
-            st = ipw.input.scalar_type_as_string
+        st = ipw.input.scalar_type_as_string
         self.assertEqual(scalars.data_type, 10)
         self.assertEqual(st, 'float')
 

--- a/mayavi/tests/test_mlab_integration.py
+++ b/mayavi/tests/test_mlab_integration.py
@@ -255,9 +255,6 @@ class TestMlabNullEngineMisc(TestMlabNullEngine):
             os.remove(tmpfname)
 
     def test_slice_unstructured_grid(self):
-        v = tvtk.Version()
-        if v.vtk_major_version < 6 and v.vtk_minor_version < 10:
-            raise unittest.SkipTest('Broken on Travis with VTK-5.8?')
         # Given
         src = mlab.pipeline.open(get_example_data('uGridEx.vtk'))
         eg = mlab.pipeline.extract_unstructured_grid(src)
@@ -352,16 +349,9 @@ class TestMlabPipeline(TestMlabNullEngine):
     """
 
     def setUp(self):
-        ver = tvtk.Version()
-        self.less_than_or_equal_to_vtk_5_10 = True
-        if ver.vtk_major_version >= 5 and ver.vtk_minor_version > 10:
-            self.less_than_or_equal_to_vtk_5_10 = False
-        if self.less_than_or_equal_to_vtk_5_10:
-            super(TestMlabPipeline, self).setUp()
-        else:
-            e = Engine()
-            e.start()
-            mlab.set_engine(e)
+        e = Engine()
+        e.start()
+        mlab.set_engine(e)
 
     def tearDown(self):
         if self.less_than_or_equal_to_vtk_5_10:

--- a/mayavi/tests/test_poly_data_reader.py
+++ b/mayavi/tests/test_poly_data_reader.py
@@ -15,9 +15,6 @@ from mayavi.tests.data_reader_test_base import DataReaderTestBase
 # External library imports
 import vtk
 
-vtk_major_version = vtk.vtkVersion.GetVTKMajorVersion()
-vtk_minor_version = vtk.vtkVersion.GetVTKMinorVersion()
-
 
 class TestPDBReader(DataReaderTestBase):
 

--- a/mayavi/tests/test_unstructured_data_reader.py
+++ b/mayavi/tests/test_unstructured_data_reader.py
@@ -6,14 +6,12 @@
 import unittest
 
 # Enthought library imports
-from tvtk.common import is_old_pipeline
 from mayavi.sources.unstructured_grid_reader import UnstructuredGridReader
 from mayavi.tests.data_reader_test_base import DataReaderTestBase
 
 # Local imports.
 from mayavi.tests.common import get_example_data
 
-old_pipeline = is_old_pipeline()
 
 class TestAVSUCDReader(DataReaderTestBase):
 
@@ -47,39 +45,6 @@ class TestAVSUCDReader(DataReaderTestBase):
 
         self.check_deepcopying(self.scene, self.bounds)
 
-@unittest.skipIf(not old_pipeline,
-                    "ExodusReader is not supported VTK 6.0 onwards.")
-class TestExodusReader(DataReaderTestBase):
-
-    def setup_reader(self):
-
-        """"Setup the reader in here.  This is called after the engine
-        has been created and started.  The engine is available as
-        self.e.  This method is called by setUp().
-        """
-        # Read a Exodus data file.
-        r = UnstructuredGridReader()
-        r.initialize(get_example_data('edgeFaceElem.exii'))
-        self.e.add_source(r)
-        self.bounds =(-3.0, 3.0, -3.0, 3.0, -3.0, 3.0)
-
-    def test_exodus_data_reader(self):
-        "Test if the test fixture works"
-        #Now test.
-
-        self.check(self.scene, self.bounds)
-
-    def test_save_and_restore(self):
-        """Test if saving a visualization and restoring it works."""
-
-        self.check_saving(self.e, self.scene, self.bounds)
-
-    def test_deepcopied(self):
-        """Test if the MayaVi2 visualization can be deep-copied."""
-        ############################################################
-        # Test if the MayaVi2 visualization can be deep-copied.
-
-        self.check_deepcopying(self.scene, self.bounds)
 
 #TODO: Update the ExodusIIReader test for scenarios as for the other readers
 #in this module.

--- a/mayavi/tests/test_vtk_file_reader.py
+++ b/mayavi/tests/test_vtk_file_reader.py
@@ -13,8 +13,6 @@ from mayavi.sources.vtk_file_reader import VTKFileReader
 # Local imports.
 from mayavi.tests.common import get_example_data
 
-vtk_major_version = vtk.vtkVersion.GetVTKMajorVersion()
-vtk_minor_version = vtk.vtkVersion.GetVTKMinorVersion()
 
 class TestVTKFileReader(unittest.TestCase):
     def setUp(self):

--- a/tvtk/array_handler.py
+++ b/tvtk/array_handler.py
@@ -31,8 +31,6 @@ try:
 except ImportError:
     HAS_ARRAY_EXT = False
 
-from tvtk.common import is_old_pipeline
-
 # Useful constants for VTK arrays.
 VTK_ID_TYPE_SIZE = vtk.vtkIdTypeArray().GetDataTypeSize()
 if VTK_ID_TYPE_SIZE == 4:
@@ -434,33 +432,16 @@ def vtk2array(vtk_array):
     else:
         img_data.GetPointData().SetScalars(vtk_array)
 
-    if is_old_pipeline():
-        img_data.SetNumberOfScalarComponents(shape[1])
-        if typ == vtkConstants.VTK_ID_TYPE:
-            # Hack necessary because vtkImageData can't handle VTK_ID_TYPE.
-            img_data.SetScalarType(vtkConstants.VTK_LONG)
-            r_dtype = get_numeric_array_type(vtkConstants.VTK_LONG)
-        elif typ == vtkConstants.VTK_BIT:
-            img_data.SetScalarType(vtkConstants.VTK_CHAR)
-            r_dtype = get_numeric_array_type(vtkConstants.VTK_CHAR)
-        else:
-            img_data.SetScalarType(typ)
-            r_dtype = get_numeric_array_type(typ)
-        img_data.Update()
+    if typ == vtkConstants.VTK_ID_TYPE:
+        r_dtype = get_numeric_array_type(vtkConstants.VTK_LONG)
+    elif typ == vtkConstants.VTK_BIT:
+        r_dtype = get_numeric_array_type(vtkConstants.VTK_CHAR)
     else:
-        if typ == vtkConstants.VTK_ID_TYPE:
-            r_dtype = get_numeric_array_type(vtkConstants.VTK_LONG)
-        elif typ == vtkConstants.VTK_BIT:
-            r_dtype = get_numeric_array_type(vtkConstants.VTK_CHAR)
-        else:
-            r_dtype = get_numeric_array_type(typ)
-        img_data.Modified()
+        r_dtype = get_numeric_array_type(typ)
+    img_data.Modified()
 
     exp = vtk.vtkImageExport()
-    if is_old_pipeline():
-        exp.SetInput(img_data)
-    else:
-        exp.SetInputData(img_data)
+    exp.SetInputData(img_data)
 
     # Create an array of the right size and export the image into it.
     im_arr = numpy.empty((shape[0]*shape[1],), r_dtype)

--- a/tvtk/common.py
+++ b/tvtk/common.py
@@ -76,14 +76,6 @@ def is_version_9():
     return vtk_major_version > 8
 
 
-def is_version_62():
-    return vtk_major_version == 6 and vtk_minor_version == 2
-
-
-def is_version_58():
-    return vtk_major_version == 5 and vtk_minor_version == 8
-
-
 def configure_connection(obj, inp):
     """ Configure topology for vtk pipeline obj."""
     if hasattr(inp, 'output_port'):

--- a/tvtk/common.py
+++ b/tvtk/common.py
@@ -63,10 +63,6 @@ def get_tvtk_name(vtk_name):
         return vtk_name
 
 
-def is_version_7():
-    return vtk_major_version > 6
-
-
 def is_version_9():
     return vtk_major_version > 8
 

--- a/tvtk/common.py
+++ b/tvtk/common.py
@@ -10,7 +10,6 @@ import re
 import vtk
 
 vtk_major_version = vtk.vtkVersion.GetVTKMajorVersion()
-vtk_minor_version = vtk.vtkVersion.GetVTKMinorVersion()
 
 
 ######################################################################

--- a/tvtk/pyface/light_manager.py
+++ b/tvtk/pyface/light_manager.py
@@ -29,7 +29,7 @@ from traits.api import HasTraits, Range, false, \
 from traitsui.api import View, Group, Handler, ListEditor, Item
 from tvtk.api import tvtk
 from tvtk.tvtk_base import vtk_color_trait, RevPrefixMap
-from tvtk.common import is_old_pipeline, configure_input, configure_input_data
+from tvtk.common import configure_input, configure_input_data
 from apptools.persistence import state_pickler
 
 ######################################################################
@@ -229,10 +229,7 @@ class CameraLight(HasTraits):
         self.source.intensity = val
 
     def _color_changed(self, val):
-        if is_old_pipeline():
-            self.source.color = val
-        else:
-            self.source.set_color(val)
+        self.source.set_color(val)
         self.glyph.set_color(val)
 
     def _elevation_changed(self, val):

--- a/tvtk/pyface/picker.py
+++ b/tvtk/pyface/picker.py
@@ -29,7 +29,6 @@ from tvtk.tvtk_base import RevPrefixMap, false_bool_trait
 from tvtk.pyface.tvtk_scene import TVTKScene
 from tvtk.common import configure_input
 from apptools.persistence import state_pickler
-from tvtk.common import vtk_major_version
 import numpy as np
 
 
@@ -446,12 +445,8 @@ class Picker(HasTraits):
             # Need to create the probe each time because otherwise it
             # does not seem to work properly.
             probe = tvtk.ProbeFilter()
-            if vtk_major_version >= 6:
-                probe.set_source_data(data)
-                probe.set_input_data(self.probe_data)
-            else:
-                probe.source = data
-                probe.input = self.probe_data
+            probe.set_source_data(data)
+            probe.set_input_data(self.probe_data)
             probe.update()
             data = probe.output.point_data
             bounds = cp.mapper.input.bounds

--- a/tvtk/pyface/tvtk_scene.py
+++ b/tvtk/pyface/tvtk_scene.py
@@ -25,9 +25,6 @@ from traits.api import HasPrivateTraits, HasTraits, Any, Int, \
 from tvtk.pyface import light_manager
 
 
-VTK_VER = tvtk.Version().vtk_version
-
-
 def set_magnification(w2if, magnification):
     if hasattr(w2if, 'magnification'):
         w2if.magnification = magnification
@@ -549,57 +546,7 @@ class TVTKScene(HasPrivateTraits):
         ex.render_window = self._renwin
         ex.background = bg
 
-        if VTK_VER[:3] in ['4.2', '4.4']:
-            # The vtkRIBExporter is broken in respect to VTK light
-            # types.  Therefore we need to convert all lights into
-            # scene lights before the save and later convert them
-            # back.
-
-            ########################################
-            # Internal functions
-            def x3to4(x):
-                # convert 3-vector to 4-vector (w=1 -> point in space)
-                return (x[0], x[1], x[2], 1.0 )
-            def x4to3(x):
-                # convert 4-vector to 3-vector
-                return (x[0], x[1], x[2])
-
-            def cameralight_transform(light, xform, light_type):
-                # transform light by 4x4 matrix xform
-                origin = x3to4(light.position)
-                focus = x3to4(light.focal_point)
-                neworigin = xform.multiply_point(origin)
-                newfocus = xform.multiply_point(focus)
-                light.position = x4to3(neworigin)
-                light.focal_point = x4to3(newfocus)
-                light.light_type = light_type
-            ########################################
-
-            save_lights_type = []
-            for light in self.light_manager.lights:
-                save_lights_type.append(light.source.light_type)
-
-            # Convert lights to scene lights.
-            cam = self.camera
-            xform = tvtk.Matrix4x4()
-            xform.deep_copy(cam.camera_light_transform_matrix)
-            for light in self.light_manager.lights:
-                cameralight_transform(light.source, xform, "scene_light")
-
-            # Write the RIB file.
-            self._exporter_write(ex)
-
-            # Now re-convert lights to camera lights.
-            xform.invert()
-            for i, light in enumerate(self.light_manager.lights):
-                cameralight_transform(light.source, xform, save_lights_type[i])
-
-            # Change the camera position. Otherwise VTK would render
-            # one broken frame after the export.
-            cam.roll(0.5)
-            cam.roll(-0.5)
-        else:
-            self._exporter_write(ex)
+        self._exporter_write(ex)
 
     def save_wavefront(self, file_name):
         """Save scene to a Wavefront OBJ file.  Two files are

--- a/tvtk/pyface/ui/wx/scene.py
+++ b/tvtk/pyface/ui/wx/scene.py
@@ -702,27 +702,9 @@ class Scene(TVTKScene, Widget):
             fs.close()
             self._fullscreen = None
         elif fs is None:
-            ver = tvtk.Version()
-            popup = False
-            if wx.Platform == '__WXMSW__':
-                popup = True
-            elif ver.vtk_major_version > 5:
-                popup = True
-            elif (ver.vtk_major_version == 5) and \
-                 ((ver.vtk_minor_version >= 1) or \
-                  (ver.vtk_build_version > 2)):
-                popup = True
-            if popup:
-                # There is a bug with earlier versions of VTK that
-                # breaks reparenting a window which is why we test for
-                # the version above.
-                f = PopupScene(self)
-                self._fullscreen = f
-                f.fullscreen()
-            else:
-                f = FullScreen(self)
-                f.run() # This will block.
-                self._fullscreen = None
+            f = PopupScene(self)
+            self._fullscreen = f
+            f.fullscreen()
 
     def _disable_fullscreen(self):
         fs = self._fullscreen

--- a/tvtk/tests/test_class_tree.py
+++ b/tvtk/tests/test_class_tree.py
@@ -54,19 +54,7 @@ class TestClassTree(unittest.TestCase):
         if (hasattr(vtk, 'vtkTuple')):
             names = [x.name for x in t.tree[0]]
             names.sort()
-            if vtk_major_version < 6:
-                expect = ['object', 'vtkColor3', 'vtkColor4', 'vtkDenseArray',
-                          'vtkObjectBase', 'vtkRect',
-                          'vtkSparseArray', 'vtkTuple',
-                          'vtkTypedArray', 'vtkVector', 'vtkVector2',
-                          'vtkVector3']
-            elif vtk_major_version == 6:
-                expect = ['object', 'vtkColor3', 'vtkColor4', 'vtkDenseArray',
-                          'vtkObjectBase', 'vtkQuaternion', 'vtkRect',
-                          'vtkSparseArray', 'vtkTuple',
-                          'vtkTypedArray', 'vtkVector', 'vtkVector2',
-                          'vtkVector3']
-            elif vtk_major_version == 7:
+            if vtk_major_version == 7:
                 expect = ['object', 'vtkColor3', 'vtkColor4', 'vtkDenseArray',
                           'vtkQuaternion', 'vtkRect',
                           'vtkSparseArray', 'vtkTuple',

--- a/tvtk/tests/test_tvtk.py
+++ b/tvtk/tests/test_tvtk.py
@@ -21,7 +21,7 @@ import numpy
 import vtk
 
 from tvtk import tvtk_base
-from tvtk.common import get_tvtk_name, configure_input_data, is_version_7
+from tvtk.common import get_tvtk_name, configure_input_data
 from numpy.testing import assert_array_equal
 
 from traits.api import TraitError

--- a/tvtk/tests/test_visual.py
+++ b/tvtk/tests/test_visual.py
@@ -4,7 +4,6 @@ import numpy as np
 from numpy.testing import assert_allclose
 
 from tvtk.tools import visual
-from tvtk.common import vtk_major_version
 
 
 def get_bounds(pos, sz):

--- a/tvtk/tests/test_vtk_parser.py
+++ b/tvtk/tests/test_vtk_parser.py
@@ -50,16 +50,8 @@ class TestVTKParser(unittest.TestCase):
             self.assertIn(p.get_toggle_methods(),
                           [{'Debug': False, 'GlobalWarningDisplay': 1},
                            {'Debug': False, 'GlobalWarningDisplay': 0}])
-        if (vtk_major_version >= 5 and vtk_minor_version >= 10) or \
-           (vtk_major_version >= 6):
-            self.assertEqual(p.get_state_methods(), {})
-            self.assertEqual(p.get_get_methods(), ['GetCommand', 'GetMTime'])
-        elif vtk_major_version >= 5 and vtk_minor_version >= 6:
-            self.assertEqual(p.get_state_methods(), {})
-            self.assertEqual(p.get_get_methods(), ['GetMTime'])
-        else:
-            self.assertEqual(p.get_state_methods(), {'ReferenceCount':(1, None)})
-            self.assertEqual(p.get_get_methods(), ['GetMTime'])
+        self.assertEqual(p.get_state_methods(), {})
+        self.assertEqual(p.get_get_methods(), ['GetCommand', 'GetMTime'])
 
         self.assertEqual(p.get_get_set_methods(), {})
 
@@ -163,21 +155,15 @@ class TestVTKParser(unittest.TestCase):
 
         res = ['BackfaceRender', 'DeepCopy', 'Render']
         if hasattr(obj, 'GetTexture'):
-            if vtk_major_version >= 6:
-                res = ['AddShaderVariable', 'BackfaceRender', 'DeepCopy',
-                       'ReleaseGraphicsResources', 'RemoveAllTextures',
-                       'RemoveTexture', 'Render']
-                if (vtk_major_version >= 7 or vtk_minor_version >= 2) and \
-                        vtk_major_version < 9:
-                    res.append('VTKTextureUnit')
-                if vtk_major_version >= 9:
-                    res.extend(['SetBaseColorTexture', 'SetEmissiveTexture',
-                                'SetNormalTexture', 'SetORMTexture'])
-            else:
-                res = ['AddShaderVariable', 'BackfaceRender', 'DeepCopy',
-                       'LoadMaterial', 'LoadMaterialFromString',
-                       'ReleaseGraphicsResources', 'RemoveAllTextures', 'RemoveTexture',
-                       'Render']
+            res = ['AddShaderVariable', 'BackfaceRender', 'DeepCopy',
+                    'ReleaseGraphicsResources', 'RemoveAllTextures',
+                    'RemoveTexture', 'Render']
+            if (vtk_major_version >= 7 or vtk_minor_version >= 2) and \
+                    vtk_major_version < 9:
+                res.append('VTKTextureUnit')
+            if vtk_major_version >= 9:
+                res.extend(['SetBaseColorTexture', 'SetEmissiveTexture',
+                            'SetNormalTexture', 'SetORMTexture'])
         if hasattr(obj, 'PostRender'):
             res.append('PostRender')
             res.sort()
@@ -227,28 +213,12 @@ class TestVTKParser(unittest.TestCase):
                               ([None], (('float', 'float', 'float'),))],
                              p.get_method_signature(o.SetColor))
 
-        # Get VTK version to handle changed APIs.
-        vtk_ver = vtk.vtkVersion().GetVTKVersion()
-
         # Test vtkObjects args.
         o = vtk.vtkContourFilter()
-        if vtk_major_version < 6:
-            sig = p.get_method_signature(o.SetInput)
-        else:
-            sig = p.get_method_signature(o.SetInputData)
+        sig = p.get_method_signature(o.SetInputData)
         if len(sig) == 1:
             self.assertEqual([([None], ['vtkDataSet'])],
                              sig)
-        elif vtk_ver[:3] in ['4.2', '4.4']:
-            self.assertEqual([([None], ['vtkDataObject']),
-                              ([None], ('int', 'vtkDataObject')),
-                              ([None], ['vtkDataSet']),
-                              ([None], ('int', 'vtkDataSet'))
-                              ], sig)
-        elif vtk_ver[:2] == '5.' or vtk_ver[:3] == '4.5':
-            self.assertEqual([([None], ['vtkDataObject']),
-                              ([None], ('int', 'vtkDataObject')),
-                              ], sig)
 
         self.assertEqual([(['vtkPolyData'], None),
                           (['vtkPolyData'], ['int'])],
@@ -271,8 +241,6 @@ class TestVTKParser(unittest.TestCase):
         p = self.p
         p.parse(vtk.vtkDataObject)
         self.assertTrue('UpdateExtent' not in p.get_state_methods())
-        if vtk_major_version < 6:
-            self.assertTrue('UpdateExtent' in p.get_get_set_methods())
 
         p.parse(vtk.vtkImageImport)
         self.assertTrue('DataExtent' not in p.get_state_methods())

--- a/tvtk/tools/mlab.py
+++ b/tvtk/tools/mlab.py
@@ -92,8 +92,6 @@ functions::
 # Copyright (c) 2005-2020, Enthought, Inc.
 # License: BSD Style.
 
-from distutils.version import StrictVersion
-
 import numpy
 
 from traits.api import HasTraits, List, Instance, Any, Float, Bool, \
@@ -108,7 +106,6 @@ from tvtk.tools import ivtk
 # Set this to False to not use LOD Actors.
 USE_LOD_ACTOR = True
 
-VTK_VER = StrictVersion(tvtk.Version().vtk_version)
 
 ######################################################################
 # Utility functions.
@@ -641,10 +638,7 @@ class Title(MLabBase):
         super(Title, self).__init__(**traits)
 
         ta = self.text_actor
-        if VTK_VER > '5.1':
-            ta.trait_set(text_scale_mode='prop', height=0.05, input=self.text)
-        else:
-            ta.trait_set(scaled_text=True, height=0.05, input=self.text)
+        ta.trait_set(text_scale_mode='prop', height=0.05, input=self.text)
         pc = ta.position_coordinate
         pc.coordinate_system = 'normalized_viewport'
         pc.value = 0.25, 0.925, 0.0

--- a/tvtk/vtk_parser.py
+++ b/tvtk/vtk_parser.py
@@ -13,7 +13,7 @@ import types
 # Local imports (these are relative imports for a good reason).
 from . import class_tree
 from . import vtk_module as vtk
-from .common import is_version_62, is_version_9
+from .common import is_version_9
 
 
 class VTKMethodParser:
@@ -312,12 +312,6 @@ class VTKMethodParser:
           A VTK method object.
 
         """
-        # VTK 6.2 false built in funcs/methods are ignored
-        if is_version_62():
-            built_in_func = isinstance(method, types.BuiltinFunctionType)
-            built_in_meth = isinstance(method, types.BuiltinMethodType)
-            if not (built_in_func or built_in_meth):
-                return None
         # Remove all the C++ function signatures.
         doc = method.__doc__
         if doc is None:

--- a/tvtk/wrapper_gen.py
+++ b/tvtk/wrapper_gen.py
@@ -16,8 +16,7 @@ from itertools import chain
 
 # Local imports (these are relative imports because the package is not
 # installed when these modules are imported).
-from .common import (get_tvtk_name, camel2enthought, is_version_58,
-                     vtk_major_version)
+from .common import get_tvtk_name, camel2enthought, vtk_major_version
 
 from . import vtk_parser
 from . import indenter
@@ -1791,12 +1790,6 @@ class WrapperGenerator:
 
         default, rng = self.parser.get_get_set_methods()[vtk_attr_name]
 
-        if is_version_58():
-            message = ("vtkAxesTransformRepresentation: "
-                       "tolerance not updatable "
-                       "(VTK 5.8 bug - value not properly initialized)")
-            print(message)
-            default = rng[0]
         t_def = ('traits.Trait({default}, traits.Range{rng}, '
                  'enter_set=True, auto_set=False)').format(default=default,
                                                            rng=rng)


### PR DESCRIPTION
This PR removes code that handles unsupported vtk versions i.e. any vtk version less than 7. This means that we are removing support for the old pipeline, which is what most of the changes in this PR are about.

See related #1082 .