### PR TITLE
Quick fix for failures with Traits 6.3

### DIFF
--- a/tvtk/tvtk_base.py
+++ b/tvtk/tvtk_base.py
@@ -187,6 +187,7 @@ class RevPrefixMap(PrefixMap):
     def __init__(self, map, *extra_values, **kwargs):
         super().__init__(map, **kwargs)
         self._rmap = {}
+        self._map = {value: value for value in map}
         for key, value in map.items():
             self._rmap[value] = key
         for key in extra_values:


### PR DESCRIPTION
This PR represents a quick fix for failures of the Mayavi test suite with the recently-released Traits 6.3.0.

Note that this is only a band-aid workaround to get the CI up and running again. A better fix would be to rewrite `RevPrefixMap` to inherit directly from `TraitType` (which is designed to be subclassed), and not to either subclass `PrefixMap` (which wasn't designed to be subclassed), or to depend on internal details of `PrefixMap`.
