### PR TITLE
Workarounds for VTK 9.1.0

### DIFF
--- a/.github/workflows/run-mayavi-tests.yml
+++ b/.github/workflows/run-mayavi-tests.yml
@@ -7,7 +7,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        os: [macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [3.6]
 
     runs-on: ${{ matrix.os }}
@@ -35,7 +35,7 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install pyqt5
         python -m pip install numpy
-        python -m pip install vtk
+        python -m pip install vtk==9.0.3
         python -m pip install pillow
         python -m pip install nose
         python -m pip install -e .[app]

--- a/.github/workflows/run-mayavi-tests.yml
+++ b/.github/workflows/run-mayavi-tests.yml
@@ -35,7 +35,7 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install pyqt5
         python -m pip install numpy
-        python -m pip install vtk
+        python -m pip install vtk==9.0.3
         python -m pip install pillow
         python -m pip install nose
         python -m pip install -e .[app]

--- a/.github/workflows/run-mayavi-tests.yml
+++ b/.github/workflows/run-mayavi-tests.yml
@@ -7,7 +7,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [windows-latest, macos-latest]
         python-version: [3.6]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/run-mayavi-tests.yml
+++ b/.github/workflows/run-mayavi-tests.yml
@@ -35,7 +35,7 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install pyqt5
         python -m pip install numpy
-        python -m pip install vtk==9.0.3
+        python -m pip install vtk
         python -m pip install pillow
         python -m pip install nose
         python -m pip install -e .[app]

--- a/.github/workflows/run-mayavi-tests.yml
+++ b/.github/workflows/run-mayavi-tests.yml
@@ -7,7 +7,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        os: [windows-latest, macos-latest]
+        os: [macos-latest]
         python-version: [3.6]
 
     runs-on: ${{ matrix.os }}

--- a/tvtk/code_gen.py
+++ b/tvtk/code_gen.py
@@ -1,11 +1,18 @@
 """This module generates tvtk (Traited VTK) classes from the VTK-Python API.
 
+This can be evoked for example by:
+
+..code-block:: console
+
+    $ python -ic "from tvtk.code_gen import main; main()" -szv
+
+On failures you can then for example do ``import pdb; pdb.pm()`` to do
+post-mortem debugging.
 """
 # Author: Prabhu Ramachandran
 # Copyright (c) 2004-2020, Enthought, Inc.
 # License: BSD Style.
 
-import vtk_module as vtk
 import os
 import os.path
 import zipfile
@@ -13,6 +20,7 @@ import tempfile
 import shutil
 import glob
 import logging
+import traceback
 from optparse import OptionParser
 import sys
 
@@ -22,10 +30,12 @@ try:
     from .common import get_tvtk_name, camel2enthought
     from .wrapper_gen import WrapperGenerator
     from .special_gen import HelperGenerator
+    from . import vtk_module as vtk
 except SystemError:
     from common import get_tvtk_name, camel2enthought
     from wrapper_gen import WrapperGenerator
     from special_gen import HelperGenerator
+    import vtk_module as vtk
 
 
 logger = logging.getLogger(__name__)
@@ -132,8 +142,9 @@ class TVTKGenerator:
                             self._write_wrapper_class(node, tvtk_name)
                         except Exception:
                             print('\n\nFailed on %s\n(#%d of %d nodes, #%d of '
-                                  '%d subnodes)\n'
-                                  % (tvtk_name, ti, len(tree), ni, len(nodes)))
+                                  '%d subnodes):\n%s\n'
+                                  % (tvtk_name, ti, len(tree), ni, len(nodes),
+                                     traceback.format_exc()))
                             raise
                         helper_gen.add_class(tvtk_name, helper_file)
 

--- a/tvtk/indenter.py
+++ b/tvtk/indenter.py
@@ -234,11 +234,14 @@ class VTKDocMassager:
 
           The documentation string.
         """
-        orig_name = doc[2:doc.find('(')]
+        if doc.startswith('V.'):  # VTK < 9.1.0, e.g., V.GetAddre...
+            doc = doc[2:]
+        # VTK > 9.1.0 has just GetAddre...
+        orig_name = doc[:doc.find('(')]
         name = camel2enthought(orig_name)
         my_sig = self._rename_class(doc[:doc.find('\n\n')])
         my_sig = self.cpp_method_re.sub('', my_sig)
-        my_sig = my_sig.replace('V.'+orig_name, 'V.'+name)
+        my_sig = my_sig.replace('V.'+orig_name, 'V.'+name).replace(orig_name+'(', name+'(')
         ret = self.massage(self._remove_sig(doc))
         if ret:
             return my_sig + '\n' + ret

--- a/tvtk/indenter.py
+++ b/tvtk/indenter.py
@@ -226,7 +226,7 @@ class VTKDocMassager:
     def get_method_doc(self, doc):
         """Return processed method documentation string from `doc`.
 
-        The method signature is appopriately massaged.
+        The method signature is appropriately massaged.
 
         Parameters
         ----------
@@ -235,13 +235,13 @@ class VTKDocMassager:
           The documentation string.
         """
         if doc.startswith('V.'):  # VTK < 9.1.0, e.g., V.GetAddre...
-            doc = doc[2:]
+            doc = doc.replace('V.', '')
         # VTK > 9.1.0 has just GetAddre...
         orig_name = doc[:doc.find('(')]
         name = camel2enthought(orig_name)
         my_sig = self._rename_class(doc[:doc.find('\n\n')])
         my_sig = self.cpp_method_re.sub('', my_sig)
-        my_sig = my_sig.replace('V.'+orig_name, 'V.'+name).replace(orig_name+'(', name+'(')
+        my_sig = my_sig.replace(orig_name+'(', name+'(')
         ret = self.massage(self._remove_sig(doc))
         if ret:
             return my_sig + '\n' + ret

--- a/tvtk/indenter.py
+++ b/tvtk/indenter.py
@@ -143,7 +143,7 @@ class VTKDocMassager:
     def __init__(self):
         self.renamer = re.compile(r'(vtk[A-Z0-9]\S+)')
         self.ren_func = lambda m: get_tvtk_name(m.group(1))
-        self.func_re = re.compile(r'([a-z0-9]+[A-Z])')
+        self.func_re = re.compile(r'([A-Z][a-z0-9]+[A-Z]\w+)')
         self.cpp_method_re = re.compile(r'C\+\+: .*?;\n*')
 
     #################################################################
@@ -281,9 +281,8 @@ class VTKDocMassager:
                 if word[:3] == 'vtk':
                     nw.append(word)
                 else:
-                    if self.func_re.search(word):
-                        nw.append(camel2enthought(word))
-                    else:
-                        nw.append(word)
+                    nw.append(self.func_re.sub(
+                        lambda mo: camel2enthought(mo.group()), word
+                    ))
             nl.append(' '.join(nw))
         return '\n'.join(nl)

--- a/tvtk/tests/test_indenter.py
+++ b/tvtk/tests/test_indenter.py
@@ -214,8 +214,8 @@ class TestVTKDocMassager(unittest.TestCase):
               'vtkLODProperty, vtkXMLDataReader, vtk3DSImporter\n'\
               'SetRepresentationToWireframe, Write3DPropsAsRasterImage'
         ret = dm.get_method_doc(doc)
-        correct = 'V.get_output(int) -> StructuredPoints\n'\
-                  'V.get_output() -> StructuredPoints\n\n'\
+        correct = 'get_output(int) -> StructuredPoints\n'\
+                  'get_output() -> StructuredPoints\n\n'\
                   'LODProperty, XMLDataReader, ThreeDSImporter\n'\
                   'set_representation_to_wireframe, '\
                   'write3d_props_as_raster_image'
@@ -227,8 +227,8 @@ class TestVTKDocMassager(unittest.TestCase):
               'V.GetOutput() -> vtkStructuredPoints\n'\
               'C++: vtkStructuredPoints *GetOutput ();\n\n'
         ret = dm.get_method_doc(doc)
-        correct = 'V.get_output(int) -> StructuredPoints\n'\
-                  'V.get_output() -> StructuredPoints\n'
+        correct = 'get_output(int) -> StructuredPoints\n'\
+                  'get_output() -> StructuredPoints\n'
         self.assertEqual(ret, correct)
 
 

--- a/tvtk/tests/test_wrapper_gen.py
+++ b/tvtk/tests/test_wrapper_gen.py
@@ -60,10 +60,11 @@ class TestWrapperGenerator(unittest.TestCase):
 
     def test_unicode_return_value(self):
         wg = self.wg
-
         meth = vtk.vtkDelimitedTextReader.GetUnicodeRecordDelimiters
+        expect = 'unicode' if '-> unicode' in meth.__doc__ else 'string'
         sig = wg.parser.get_method_signature(meth)
-        self.assertEqual(sig[0][0][0], 'unicode')
+        self.assertEqual(sig[0][0][0], expect)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tvtk/vtk_parser.py
+++ b/tvtk/vtk_parser.py
@@ -407,8 +407,14 @@ class VTKMethodParser:
                         arg = ', '.join(args)
             # sanitize type hints
             if arg is not None:
+                # thing:value -> value
                 arg = re.sub(r'\w+:', lambda mo: '', arg)
-                arg = re.sub(r'str\b', lambda mo: 'string', arg)
+                # str -> string
+                arg = re.sub(r'\bstr\b', lambda mo: 'string', arg)
+                # float=1.0 -> float
+                arg = re.sub(r'=[\-e0-9.]+', lambda mo: '', arg)
+                # Callback -> function
+                arg = re.sub(r'\bCallback\b', lambda mo: 'function', arg)
 
             if ret is not None and ret.startswith('(') and '...' in ret:
                 # A tuple (new in VTK-5.7)

--- a/tvtk/wrapper_gen.py
+++ b/tvtk/wrapper_gen.py
@@ -595,17 +595,17 @@ class WrapperGenerator:
             if klass.__name__ == 'vtkCellQuality' \
                     and m == 'QualityMeasure':
                 vtk_val = 1
-            if klass.__name__ == 'vtkRenderView' \
+            elif klass.__name__ == 'vtkRenderView' \
                     and m == 'InteractionMode':
                 vtk_val = 1
-            if klass.__name__ == 'vtkMatrixMathFilter' \
+            elif klass.__name__ == 'vtkMatrixMathFilter' \
                     and m == 'Operation':
                 vtk_val = 1
-            if klass.__name__ == 'vtkResliceImageViewer' \
+            elif klass.__name__ == 'vtkResliceImageViewer' \
                     and m == 'ResliceMode':
                 vtk_val = 'axis_aligned'
-            if  klass.__name__ == 'vtkThreshold' \
-                   and m == 'PointsDataType':
+            elif klass.__name__ == 'vtkThreshold' \
+                 and m == 'PointsDataType':
                 vtk_val = 10
 
             if (not hasattr(klass, 'Set' + m)):
@@ -614,8 +614,8 @@ class WrapperGenerator:
                 # vtkExtentTranslator::SetSplitMode does not exist.
                 # In this case wrap it specially.
                 vtk_val = 1
-            if  vtk_val == 0 and m in ['DataScalarType', 'OutputScalarType',
-                                       'UpdateExtent']:
+            if vtk_val == 0 and m in ['DataScalarType', 'OutputScalarType',
+                                      'UpdateExtent']:
                 vtk_val = 2
 
             # Sometimes, some methods have default values that are
@@ -623,20 +623,20 @@ class WrapperGenerator:
             # these.
             extra_val = None
             if vtk_val == 0 and klass.__name__ == 'vtkGenericEnSightReader' \
-                   and m == 'ByteOrder':
+               and m == 'ByteOrder':
                 extra_val = 2
             if vtk_val == 0 and klass.__name__ == 'vtkImageData' \
-                   and m == 'ScalarType':
+               and m == 'ScalarType':
                 extra_val = list(range(0, 22))
             if vtk_val == 0 and klass.__name__ == 'vtkImagePlaneWidget' \
-                   and m == 'PlaneOrientation':
+               and m == 'PlaneOrientation':
                 extra_val = 3
             if (vtk_val == 0) and (klass.__name__ == 'vtkThreshold') \
-                   and (m == 'AttributeMode'):
+               and (m == 'AttributeMode'):
                 extra_val = -1
             if (sys.platform == 'darwin') and (vtk_val == 0) \
-                   and (klass.__name__ == 'vtkRenderWindow') \
-                   and (m == 'StereoType'):
+               and (klass.__name__ == 'vtkRenderWindow') \
+               and (m == 'StereoType'):
                 extra_val = 0
 
             if not vtk_val:
@@ -652,7 +652,7 @@ class WrapperGenerator:
                 # vtkExtentTranslator::SetSplitMode does not exist.
                 # In this case wrap it specially.
                 vtk_val = 1
-            if  vtk_val == 0 and m in ['DataScalarType', 'OutputScalarType',
+            if vtk_val == 0 and m in ['DataScalarType', 'OutputScalarType',
                                        'UpdateExtent']:
                 vtk_val = 2
 
@@ -661,18 +661,22 @@ class WrapperGenerator:
             # these.
             extra_val = None
             if vtk_val == 0 and klass.__name__ == 'vtkGenericEnSightReader' \
-                   and m == 'ByteOrder':
+               and m == 'ByteOrder':
                 extra_val = 2
-            if vtk_val == 0 and klass.__name__ == 'vtkImageData' \
-                   and m == 'ScalarType':
+            elif (vtk_val == 0 and
+                  klass.__name__ == 'vtkPolyDataEdgeConnectivityFilter' and
+                  m == 'RegionGrowing'):
+                extra_val = 0
+            elif vtk_val == 0 and klass.__name__ == 'vtkImageData' \
+                 and m == 'ScalarType':
                 extra_val = list(range(0, 22))
-            if vtk_val == 0 and klass.__name__ == 'vtkImagePlaneWidget' \
+            elif vtk_val == 0 and klass.__name__ == 'vtkImagePlaneWidget' \
                    and m == 'PlaneOrientation':
                 extra_val = 3
-            if (vtk_val == 0) and (klass.__name__ == 'vtkThreshold') \
+            elif (vtk_val == 0) and (klass.__name__ == 'vtkThreshold') \
                    and (m == 'AttributeMode'):
                 extra_val = -1
-            if (sys.platform == 'darwin') and (vtk_val == 0) \
+            elif (sys.platform == 'darwin') and (vtk_val == 0) \
                    and (klass.__name__ == 'vtkRenderWindow') \
                    and (m == 'StereoType'):
                 extra_val = 0

--- a/tvtk/wrapper_gen.py
+++ b/tvtk/wrapper_gen.py
@@ -1315,6 +1315,8 @@ class WrapperGenerator:
         indent = self.indent
         out.write(indent.format(decl))
         indent.incr()
+        # sanitize \ in doc (e.g., chart_xyz.get_axes_text_property)
+        doc = doc.replace('\\', '\\\\')
         if doc:
             out.write(indent.format('"""\n' + doc + '"""\n'))
         out.write(indent.format(body))


### PR DESCRIPTION
This PR is now ready to go with a few caveats. As commented by @prabhuramachandran in https://github.com/enthought/mayavi/pull/1097#issuecomment-965122185, we are observing segfaults when we test against vtk 9.1.0 from PyPI. See GitHub Actions CI output on commits https://github.com/enthought/mayavi/pull/1097/commits/a63b08a17c761e4e40fdc42040090356534e3773, https://github.com/enthought/mayavi/pull/1097/commits/a053a108a4b39cde7937f675a1265e75402fe29b or https://github.com/enthought/mayavi/pull/1097/commits/53345b160d54b6ef2771b7850e9b48e703c76652. The segfaults with the VTK 9.1.0 are happening on all platforms.

For now, we are choosing to ignore those failures and we are only testing against vtk 9.0.3 on CI but note that we have tested these changes locally on Mac OS and Windows.

<details>

<summary>Original PR description by @larsoner</summary>

Depends/builds on #1050. Now I can at least get it to build+install on 9.1.0-rc2, but now I get:
```
mne/viz/tests/test_3d.py ..F
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> traceback >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
mne/viz/tests/test_3d.py:125: in test_plot_sparse_source_estimates
    brain = plot_source_estimates(
<decorator-gen-163>:24: in plot_source_estimates
    ???
mne/viz/_3d.py:1795: in plot_source_estimates
    return _plot_stc(
mne/viz/_3d.py:1877: in _plot_stc
    brain = Brain(**kwargs)
../PySurfer/surfer/viz.py:488: in __init__
    brain = _Hemisphere(subject_id, **kwargs)
../PySurfer/surfer/viz.py:3078: in __init__
    self._geo_mesh = mlab.pipeline.triangular_mesh_source(
../mayavi/mayavi/tools/sources.py:1401: in triangular_mesh_source
    data_source.reset(x=x, y=y, z=z, triangles=triangles, scalars=scalars)
../mayavi/mayavi/tools/sources.py:831: in reset
    pd.polys = None
E   traits.trait_errors.TraitError: Cannot set the undefined 'polys' attribute of a 'PolyData' object.
```
Two issues I had to fix on top of #1050 

1. `V.` was missing in the signatures, so I had to work around it
2. Arguments had type hints, so I had to sanitize those

I'm not 100% sure I did either of these correctly, but again it at least let me build and try doing something, and even `import mayavi` (which indicates that `tvtk.Version.vtk_version` is exposed properly as a trait/property now). The fact that PolyData is broken is not a good sign, though.

This is about all the time I can devote to this, it would be good if someone else could look and fix things for 9.1.0...

</details>