### PR TITLE
Fix the test lockup on VTK-9.0.3.

### DIFF
--- a/.github/workflows/run-mayavi-tests.yml
+++ b/.github/workflows/run-mayavi-tests.yml
@@ -35,7 +35,7 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install pyqt5
         python -m pip install numpy
-        python -m pip install vtk
+        python -m pip install vtk==9.0.1
         python -m pip install pillow
         python -m pip install nose
         python -m pip install -e .[app]

--- a/.github/workflows/run-mayavi-tests.yml
+++ b/.github/workflows/run-mayavi-tests.yml
@@ -35,7 +35,7 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install pyqt5
         python -m pip install numpy
-        python -m pip install vtk==9.0.1
+        python -m pip install vtk==9.0.2
         python -m pip install pillow
         python -m pip install nose
         python -m pip install -e .[app]

--- a/.github/workflows/run-mayavi-tests.yml
+++ b/.github/workflows/run-mayavi-tests.yml
@@ -35,7 +35,7 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install pyqt5
         python -m pip install numpy
-        python -m pip install vtk==9.0.2
+        python -m pip install vtk
         python -m pip install pillow
         python -m pip install nose
         python -m pip install -e .[app]

--- a/.github/workflows/run-mayavi-tests.yml
+++ b/.github/workflows/run-mayavi-tests.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [3.6]
-    
+
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -35,7 +35,7 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install pyqt5
         python -m pip install numpy
-        python -m pip install vtk==8.1.2
+        python -m pip install vtk
         python -m pip install pillow
         python -m pip install nose
         python -m pip install -e .[app]

--- a/tvtk/tests/test_garbage_collection.py
+++ b/tvtk/tests/test_garbage_collection.py
@@ -1,9 +1,10 @@
 """ Tests for the garbage collection of objects in tvtk package.
 """
 # Authors: Deepak Surti, Ioannis Tziakos
-# Copyright (c) 2015, Enthought, Inc.
+# Copyright (c) 2015-2021, Enthought, Inc.
 # License: BSD Style.
 
+import sys
 import unittest
 from traits.etsconfig.api import ETSConfig
 
@@ -12,9 +13,12 @@ from tvtk.pyface.api import DecoratedScene, Scene
 from tvtk.pyface.scene_model import SceneModel
 from tvtk.tests.common import TestGarbageCollection
 
+
 class TestTVTKGarbageCollection(TestGarbageCollection):
     """ See: tvtk.tests.common.TestGarbageCollection
     """
+    @unittest.skipIf(sys.platform.startswith('win'),
+                     'CI with windows fails due to lack of OpenGL')
     def test_tvtk_scene(self):
         """ Tests if TVTK scene can be garbage collected."""
         def create_fn():
@@ -24,9 +28,9 @@ class TestTVTKGarbageCollection(TestGarbageCollection):
             o.closing = True
 
         self.check_object_garbage_collected(create_fn, close_fn)
-    
-    @unittest.skipIf(
-        ETSConfig.toolkit=='wx', 'Test segfaults using WX (issue #216)')
+
+    @unittest.skipIf(ETSConfig.toolkit == 'wx',
+                     'Test segfaults using WX (issue #216)')
     def test_scene(self):
         """ Tests if Scene can be garbage collected."""
         def create_fn():
@@ -37,8 +41,8 @@ class TestTVTKGarbageCollection(TestGarbageCollection):
 
         self.check_object_garbage_collected(create_fn, close_fn)
 
-    @unittest.skipIf(
-        ETSConfig.toolkit=='wx', 'Test segfaults using WX (issue #216)')
+    @unittest.skipIf(ETSConfig.toolkit == 'wx',
+                     'Test segfaults using WX (issue #216)')
     def test_decorated_scene(self):
         """ Tests if Decorated Scene can be garbage collected."""
         def create_fn():
@@ -48,7 +52,7 @@ class TestTVTKGarbageCollection(TestGarbageCollection):
             o.closing = True
 
         self.check_object_garbage_collected(create_fn, close_fn)
-    
+
     def test_scene_model(self):
         """ Tests if SceneModel can be garbage collected."""
         def create_fn():

--- a/tvtk/tests/test_tvtk.py
+++ b/tvtk/tests/test_tvtk.py
@@ -18,10 +18,10 @@ import types
 import inspect
 import re
 import numpy
-import vtk
 
 from tvtk import tvtk_base
 from tvtk.common import get_tvtk_name, configure_input_data
+from tvtk import vtk_module as vtk
 from numpy.testing import assert_array_equal
 
 from traits.api import TraitError
@@ -780,13 +780,15 @@ class TestTVTK(unittest.TestCase):
 # the functioning of the other tests.
 class TestTVTKModule(unittest.TestCase):
 
-    def tearDown(self):
+    @classmethod
+    def tearDownClass(cls):
         tvtk_helper._cache.clear()
         vtk.vtkObject.GlobalWarningDisplayOn()
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         vtk.vtkObject.GlobalWarningDisplayOff()
-        self.names = []
+        cls.names = []
         # Filter the ones that are abstract or not implemented
         for name in dir(vtk):
             if (not name.startswith('vtk') or name.startswith('vtkQt') or
@@ -801,7 +803,7 @@ class TestTVTKModule(unittest.TestCase):
                 except (TypeError, NotImplementedError):
                     continue
                 else:
-                    self.names.append(name)
+                    cls.names.append(name)
 
     def test_all_instantiable(self):
         """Test if all the TVTK classes can be instantiated"""
@@ -853,6 +855,8 @@ class TestTVTKModule(unittest.TestCase):
                 pass
 
             for trait_name in obj.editable_traits():
+                if trait_name in ['_in_set', '_vtk_obj']:
+                    continue
                 vtk_attr_name = to_camel_case(trait_name)
                 min_value, max_value = get_min_max_value(vtk_klass,
                                                          vtk_attr_name)

--- a/tvtk/tests/test_tvtk_scene.py
+++ b/tvtk/tests/test_tvtk_scene.py
@@ -5,6 +5,7 @@
 # Copyright (c) 2015, Enthought, Inc.
 # License: BSD Style.
 
+import sys
 import unittest
 import weakref
 import gc
@@ -15,6 +16,8 @@ from tvtk.tests.common import restore_gc_state
 
 class TestTVTKScene(unittest.TestCase):
 
+    @unittest.skipIf(sys.platform.startswith('win'),
+                     'CI with windows fails due to lack of OpenGL')
     def test_tvtk_scene_garbage_collected(self):
 
         # given

--- a/tvtk/tests/test_vtk_parser.py
+++ b/tvtk/tests/test_vtk_parser.py
@@ -15,10 +15,11 @@ error messages but they are usually harmless.
 
 import unittest
 from tvtk import vtk_parser
+from tvtk import vtk_module as vtk
 
 import time # Only used when timing.
 import sys  # Only used when debugging.
-import vtk
+
 
 # This is a little expensive to create so we cache it.
 _cache = vtk_parser.VTKMethodParser()

--- a/tvtk/tools/tvtk_doc.py
+++ b/tvtk/tools/tvtk_doc.py
@@ -17,8 +17,6 @@ docs are shown.
 # License: BSD Style.
 
 # Standard library imports.
-import vtk
-import types
 import inspect
 import sys
 
@@ -29,6 +27,7 @@ from traitsui.api import View, Group, Item, EnumEditor,\
                                     ListEditor, TextEditor
 from tvtk.api import tvtk
 from tvtk.common import get_tvtk_name
+import tvtk.vtk_module as vtk
 
 ################################################################################
 # Utility functions.

--- a/tvtk/vtk_module.py
+++ b/tvtk/vtk_module.py
@@ -27,7 +27,7 @@ except ImportError:
 vtk_version = vtkVersion.GetVTKVersion()
 SKIP = []
 
-if vtk_version == '9.0.3':
+if vtk_version in ['9.0.3', '9.0.2']:
     # Cause problems if used so ignore these.
     SKIP = ['vtkDataEncoder', 'vtkWebApplication']
     del vtkDataEncoder, vtkWebApplication

--- a/tvtk/vtk_module.py
+++ b/tvtk/vtk_module.py
@@ -9,7 +9,7 @@ need to be wrapped.
 """
 
 # Author: Prabhu Ramachandran <prabhu [at] aero.iitb.ac.in>
-# Copyright (c) 2007-2020,  Enthought, Inc.
+# Copyright (c) 2007-2021,  Enthought, Inc.
 # License: BSD Style.
 
 from vtk import *
@@ -22,3 +22,12 @@ try:
     from tvtk_local import *
 except ImportError:
     pass
+
+
+vtk_version = vtkVersion.GetVTKVersion()
+SKIP = []
+
+if vtk_version == '9.0.3':
+    # Cause problems if used so ignore these.
+    SKIP = ['vtkDataEncoder', 'vtkWebApplication']
+    del vtkDataEncoder, vtkWebApplication


### PR DESCRIPTION
Some VTK classes are broken in this version and the tvtk.vtk_module
offers a simple way for us to exclude some of these classes when we go
over every VTK class.  This should fix #1096.