### PR TITLE
BUG: Fix bug with picker.

### DIFF
--- a/tvtk/pyface/picker.py
+++ b/tvtk/pyface/picker.py
@@ -344,7 +344,7 @@ class Picker(HasTraits):
         if self.widgets is False:
             self.setup_widgets()
 
-        if self.data.valid:
+        if self.data.valid_:
             self.text_widget.enabled = 1
             self.pick_handler.handle_pick(self.data)
             self.data.text_actor._get_text_property().trait_set(
@@ -466,12 +466,14 @@ class Picker(HasTraits):
     def close_picker(self):
         """This method makes the picker actor invisible when a non
         data point is selected"""
-        self.p_actor.visibility = 0
-        self.data.renwin.renderer.remove_actor(self.p_actor)
-        self.data.text_actor.visibility = 0
-        self.data.renwin.renderer.remove_actor(self.data.text_actor)
-        self.text_widget.enabled = 0
-        self.widgets = False
+        if self.widgets:
+            self.p_actor.visibility = 0
+            self.data.renwin.renderer.remove_actor(self.p_actor)
+            self.data.text_actor.visibility = 0
+            self.data.renwin.renderer.remove_actor(self.data.text_actor)
+            self.text_widget.enabled = 0
+            self.widgets = False
+            self.data.renwin.render()
 
     #################################################################
     # Non-public interface.

--- a/tvtk/pyface/ui/qt4/scene.py
+++ b/tvtk/pyface/ui/qt4/scene.py
@@ -105,6 +105,7 @@ class _VTKRenderWindowInteractor(QVTKRenderWindowInteractor):
 
         if key in [QtCore.Qt.Key_E, QtCore.Qt.Key_Q, QtCore.Qt.Key_Escape]:
             scene._disable_fullscreen()
+            scene.picker.close_picker()
             return
 
         if key in [QtCore.Qt.Key_W]:

--- a/tvtk/pyface/ui/wx/decorated_scene.py
+++ b/tvtk/pyface/ui/wx/decorated_scene.py
@@ -27,7 +27,7 @@ import wx
 from pyface.api import ImageResource
 from pyface.action.api import ToolBarManager, Group, Action
 from tvtk.api import tvtk
-from traits.api import Bool, Instance, List, Either
+from traits.api import Bool, Instance, List, Either, TraitError
 
 # Local imports.
 from .scene import Scene, popup_save
@@ -197,11 +197,13 @@ class DecoratedScene(Scene):
             m = self.marker
             s = value[0] + value[1] + value[2]
             if s <= 1.0:
-                p.color = (1,1,1)
-                m.set_outline_color(1,1,1)
+                p.color = (1, 1, 1)
             else:
-                p.color = (0,0,0)
-                m.set_outline_color(0,0,0)
+                p.color = (0, 0, 0)
+            try:
+                m.outline_color = p.color  #VTK 9+
+            except TraitError:
+                m.set_outline_color(*p.color)
             self.render()
 
 

--- a/tvtk/pyface/ui/wx/scene.py
+++ b/tvtk/pyface/ui/wx/scene.py
@@ -366,6 +366,7 @@ class Scene(TVTKScene, Widget):
                 return
             if key.lower() in ['q', 'e'] or keycode == wx.WXK_ESCAPE:
                 self._disable_fullscreen()
+                self.picker.close_picker()
             if key.lower() in ['w']:
                 event.Skip()
                 return


### PR DESCRIPTION
When picking, there is no way to remove the picker UI except picking
away from an actor.  However, when this happens an exception was raised
due to a silly bug.  This also changes the behavior now so we press
escape/q/e keys it will no longer display the picker UI.  Also fixes a
bug with the wxPython scene for VTK 9.x.