### PR TITLE
BUG: Set vertices for glyph source.

### DIFF
--- a/.github/workflows/run-mayavi-tests.yml
+++ b/.github/workflows/run-mayavi-tests.yml
@@ -35,7 +35,7 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install pyqt5
         python -m pip install numpy
-        python -m pip install vtk
+        python -m pip install vtk==9.0.3
         python -m pip install pillow
         python -m pip install nose
         python -m pip install -e .[app]

--- a/mayavi/tests/test_mlab_source.py
+++ b/mayavi/tests/test_mlab_source.py
@@ -63,7 +63,6 @@ class TestMGlyphSource(unittest.TestCase):
 
     def test_geometry_filter_works(self):
         # This tests the bug #1071 and segfaults without the fix on VTK 9.x.
-        x, y, z, v, s, src = self.get_data()
         f = tvtk.GeometryFilter(extent_clipping=True)
         f.set_input_data_object(self.src.dataset)
         f.update()

--- a/mayavi/tests/test_mlab_source.py
+++ b/mayavi/tests/test_mlab_source.py
@@ -61,6 +61,13 @@ class TestMGlyphSource(unittest.TestCase):
         self.assertEqual(np.alltrue(vec == v), True)
         self.assertEqual(np.alltrue(sc == s.ravel()), True)
 
+    def test_geometry_filter_works(self):
+        # This tests the bug #1071 and segfaults without the fix on VTK 9.x.
+        x, y, z, v, s, src = self.get_data()
+        f = tvtk.GeometryFilter(extent_clipping=True)
+        f.set_input_data_object(self.src.dataset)
+        f.update()
+
     def test_reset_with_same_size_data(self):
         x, y, z, v, s, src = self.get_data()
         self.check_traits()

--- a/mayavi/tools/sources.py
+++ b/mayavi/tools/sources.py
@@ -220,7 +220,7 @@ class MGlyphSource(MlabSource):
         # First set the polys to None to avoid accessing invalid points.
         pd.polys = None
         pd.trait_set(points=points)
-        pd.trait_set(polys=polys)
+        pd.trait_set(verts=polys)
 
         if self.vectors is not None:
             pd.point_data.vectors = self.vectors
@@ -605,8 +605,8 @@ class MArray2DSource(MlabSource):
             ds = self.m_data
         old_scalar = ds.scalar_data
         ds.trait_set(origin=[x.min(), y.min(), 0],
-               spacing=[dx, dy, 1],
-               scalar_data=scalars)
+                     spacing=[dx, dy, 1],
+                     scalar_data=scalars)
         if old_scalar is scalars:
             ds._scalar_data_changed(scalars)
 


### PR DESCRIPTION
We were abusing the polys earlier to set the scalar_scatter cell
information but it seems safer and more correct to use the verts. This
fixes #1071.