### PR TITLE
CI: Dont fail other runs, fail on other commits

### DIFF
--- a/.github/workflows/run-mayavi-tests.yml
+++ b/.github/workflows/run-mayavi-tests.yml
@@ -1,4 +1,7 @@
 name: Tests
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.type }}
+  cancel-in-progress: true
 
 on:
   pull_request
@@ -9,6 +12,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [3.6]
+      fail-fast: false
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
This makes GitHub Actions behave nicely like other CIs:

1. If one job fails, don't fail the other jobs (it's nice to get feedback from all)
2. If a new commit is pushed, kill the existing runs to save cycles