### PR TITLE
Try fixing the crashes on VTK-9.1.0.

### DIFF
--- a/.github/workflows/run-mayavi-tests.yml
+++ b/.github/workflows/run-mayavi-tests.yml
@@ -39,7 +39,7 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install pyqt5
         python -m pip install numpy
-        python -m pip install vtk==9.0.3
+        python -m pip install vtk
         python -m pip install pillow
         python -m pip install nose
         python -m pip install -e .[app]

--- a/mayavi/filters/user_defined.py
+++ b/mayavi/filters/user_defined.py
@@ -3,7 +3,7 @@
 # License: BSD Style.
 
 # Enthought library imports.
-from tvtk.tools.tvtk_doc import TVTKFilterChooser, TVTK_FILTERS
+from tvtk.tools.tvtk_doc import TVTKFilterChooser, get_tvtk_filters
 
 # Local imports.
 from mayavi.filters.filter_base import FilterBase
@@ -73,11 +73,11 @@ class UserDefined(FilterBase):
     def _check_object(self, obj):
         if obj is None:
             return False
-        if obj.__class__.__name__ in TVTK_FILTERS:
+        tvtk_filters = get_tvtk_filters()
+        if obj.__class__.__name__ in tvtk_filters:
             return True
         return False
 
     def _filter_changed(self, old, new):
         self.name = 'UserDefined:%s'%new.__class__.__name__
         super(UserDefined, self)._filter_changed(old, new)
-

--- a/tvtk/tools/tvtk_doc.py
+++ b/tvtk/tools/tvtk_doc.py
@@ -148,6 +148,26 @@ def _setup_tvtk_names():
         TVTK_CLASSES, TVTK_SOURCES, TVTK_FILTERS, TVTK_SINKS = r
 
 
+def get_tvtk_classes():
+    _setup_tvtk_names()
+    return TVTK_CLASSES
+
+
+def get_tvtk_sources():
+    _setup_tvtk_names()
+    return TVTK_SOURCES
+
+
+def get_tvtk_filters():
+    _setup_tvtk_names()
+    return TVTK_FILTERS
+
+
+def get_tvtk_sinks():
+    _setup_tvtk_names()
+    return TVTK_SINKS
+
+
 # ##############################################################################
 # `DocSearch` class.
 # ##############################################################################
@@ -395,8 +415,7 @@ class TVTKClassChooser(HasTraits):
             self.completions = result[:self.n_completion]
 
     def _available_default(self):
-        _setup_tvtk_names()
-        return TVTK_CLASSES
+        return get_tvtk_classes()
 
 
 ################################################################################
@@ -406,8 +425,7 @@ class TVTKSourceChooser(TVTKClassChooser):
     available = List
 
     def _available_default(self):
-        _setup_tvtk_names()
-        return TVTK_SOURCES
+        return get_tvtk_sources()
 
 
 # ##############################################################################
@@ -417,8 +435,7 @@ class TVTKFilterChooser(TVTKClassChooser):
     available = List
 
     def _available_default(self):
-        _setup_tvtk_names()
-        return TVTK_FILTERS
+        return get_tvtk_filters()
 
 
 # ##############################################################################
@@ -428,8 +445,7 @@ class TVTKSinkChooser(TVTKClassChooser):
     available = List
 
     def _available_default(self):
-        _setup_tvtk_names()
-        return TVTK_SINKS
+        return get_tvtk_sinks()
 
 
 def main():

--- a/tvtk/tools/tvtk_doc.py
+++ b/tvtk/tools/tvtk_doc.py
@@ -29,9 +29,13 @@ from tvtk.api import tvtk
 from tvtk.common import get_tvtk_name
 import tvtk.vtk_module as vtk
 
-################################################################################
+# GLOBALS
+TVTK_CLASSES, TVTK_SOURCES, TVTK_FILTERS, TVTK_SINKS = None, None, None, None
+
+
+# ##############################################################################
 # Utility functions.
-################################################################################
+# ##############################################################################
 def get_tvtk_class_names():
     """Returns 4 lists:
 
@@ -95,6 +99,7 @@ def get_tvtk_class_names():
 
     return result
 
+
 def get_func_doc(func, fname):
     """Returns function documentation."""
     if inspect.isfunction(func):
@@ -110,6 +115,7 @@ def get_func_doc(func, fname):
     if d is not None:
         doc += '\n\n' + d + '\n\n'
     return doc
+
 
 def get_tvtk_class_doc(obj):
     """Return's the objects documentation."""
@@ -134,12 +140,17 @@ def get_tvtk_class_doc(obj):
 
     return doc
 
-# GLOBALS
-TVTK_CLASSES, TVTK_SOURCES, TVTK_FILTERS, TVTK_SINKS = get_tvtk_class_names()
 
-################################################################################
+def _setup_tvtk_names():
+    global TVTK_CLASSES, TVTK_SOURCES, TVTK_FILTERS, TVTK_SINKS
+    if TVTK_CLASSES is None:
+        r = get_tvtk_class_names()
+        TVTK_CLASSES, TVTK_SOURCES, TVTK_FILTERS, TVTK_SINKS = r
+
+
+# ##############################################################################
 # `DocSearch` class.
-################################################################################
+# ##############################################################################
 class DocSearch(object):
 
     """A simple class that provides a method to search through class
@@ -290,7 +301,7 @@ class TVTKClassChooser(HasTraits):
     completions = List(Str)
 
     # List of available class names as strings.
-    available = List(TVTK_CLASSES)
+    available = List
 
     ########################################
     # Private traits.
@@ -328,7 +339,7 @@ class TVTKClassChooser(HasTraits):
                 width=800,
                 height=600,
                 title='TVTK class chooser',
-                buttons = ["OK", "Cancel"]
+                buttons=["OK", "Cancel"]
                 )
     ######################################################################
     # `object` interface.
@@ -383,24 +394,42 @@ class TVTKClassChooser(HasTraits):
             self.available = result
             self.completions = result[:self.n_completion]
 
+    def _available_default(self):
+        _setup_tvtk_names()
+        return TVTK_CLASSES
+
 
 ################################################################################
 # `TVTKSourceChooser` class.
 ################################################################################
 class TVTKSourceChooser(TVTKClassChooser):
-    available = List(TVTK_SOURCES)
+    available = List
 
-################################################################################
+    def _available_default(self):
+        _setup_tvtk_names()
+        return TVTK_SOURCES
+
+
+# ##############################################################################
 # `TVTKFilterChooser` class.
-################################################################################
+# ##############################################################################
 class TVTKFilterChooser(TVTKClassChooser):
-    available = List(TVTK_FILTERS)
+    available = List
 
-################################################################################
+    def _available_default(self):
+        _setup_tvtk_names()
+        return TVTK_FILTERS
+
+
+# ##############################################################################
 # `TVTKSinkChooser` class.
-################################################################################
+# ##############################################################################
 class TVTKSinkChooser(TVTKClassChooser):
-    available = List(TVTK_SINKS)
+    available = List
+
+    def _available_default(self):
+        _setup_tvtk_names()
+        return TVTK_SINKS
 
 
 def main():
@@ -409,6 +438,7 @@ def main():
     """
     s = TVTKClassChooser()
     s.configure_traits()
+
 
 if __name__ == '__main__':
     main()

--- a/tvtk/vtk_module.py
+++ b/tvtk/vtk_module.py
@@ -31,3 +31,10 @@ if vtk_version in ['9.0.3', '9.0.2']:
     # Cause problems if used so ignore these.
     SKIP = ['vtkDataEncoder', 'vtkWebApplication']
     del vtkDataEncoder, vtkWebApplication
+
+if vtk_version == '9.1.0':
+    SKIP = ['vtkOpenGLAvatar']
+    try:
+        del vtkOpenGLAvatar
+    except NameError:
+        pass


### PR DESCRIPTION
- The crashes seem to be related to the `vtkOpenGLAvatar` class being instantiated.  
- Do not instantiate all the VTK objects on import which the tvtk_doc module was doing unnecessarily.