### PR TITLE
Fix headless build

### DIFF
--- a/mayavi/tests/test_garbage_collection.py
+++ b/mayavi/tests/test_garbage_collection.py
@@ -4,6 +4,8 @@
 # Copyright (c) 2015, Enthought, Inc.
 # License: BSD Style.
 
+import unittest
+
 from numpy import sqrt, sin, mgrid
 from traits.api import Instance, HasTraits
 from traitsui.api import View, Item
@@ -15,9 +17,12 @@ from mayavi.core.engine import Engine
 from mayavi.core.null_engine import NullEngine
 from mayavi.tools.mlab_scene_model import MlabSceneModel
 
+
 class TestMayaviGarbageCollection(TestGarbageCollection):
     """ See: tvtk.tests.common.TestGarbageCollection
     """
+    @unittest.skipIf(ETSConfig.toolkit == 'null',
+                     'Test should not run when the ETS toolkit is null')
     def test_mlab_scene_model_with_gui(self):
         """ Tests if MlabSceneModel with GUI can be garbage collected."""
         class MlabApp(HasTraits):

--- a/mayavi/tools/engine_manager.py
+++ b/mayavi/tools/engine_manager.py
@@ -3,6 +3,7 @@ Central registry for figures with mlab.
 """
 
 # Standard library imports
+import os
 import warnings
 
 # Enthought librairies imports
@@ -20,6 +21,7 @@ from .preferences_mirror import PreferencesMirror
 # The mlab options.
 options = PreferencesMirror()
 options.preferences = preference_manager.mlab
+env_toolkit = os.environ.get('ETS_TOOLKIT', '')
 
 
 ######################################################################
@@ -33,7 +35,7 @@ def check_backend():
 
     toolkit()  # This forces the selection of a toolkit.
     if (options.backend != 'test' and not options.offscreen) and \
-            ETSConfig.toolkit in ('null', ''):
+       (ETSConfig.toolkit in ('null', '') and env_toolkit != 'null'):
         msg = '''Could not import backend for traitsui.  Make sure you
         have a suitable UI toolkit like PyQt/PySide or wxPython
         installed.'''

--- a/setup.py
+++ b/setup.py
@@ -267,16 +267,6 @@ class MyBuild(build.build):
     def run(self):
         build_tvtk_classes_zip()
         build.build.run(self)
-        try:
-            self.run_command('gen_docs')
-        except:
-            log.warn("Couldn't generate documentation:\n%s" %
-                     traceback.format_exception(*sys.exc_info()))
-        try:
-            self.run_command('build_docs')
-        except:
-            log.warn("Couldn't build documentation:\n%s" %
-                     traceback.format_exception(*sys.exc_info()))
 
 
 class MyDevelop(develop.develop):

--- a/tvtk/tests/test_garbage_collection.py
+++ b/tvtk/tests/test_garbage_collection.py
@@ -17,8 +17,10 @@ from tvtk.tests.common import TestGarbageCollection
 class TestTVTKGarbageCollection(TestGarbageCollection):
     """ See: tvtk.tests.common.TestGarbageCollection
     """
-    @unittest.skipIf(sys.platform.startswith('win'),
-                     'CI with windows fails due to lack of OpenGL')
+    @unittest.skipIf(
+        sys.platform.startswith('win') or ETSConfig.toolkit == 'null',
+        'CI with windows fails due to lack of OpenGL, or toolkit is null.'
+    )
     def test_tvtk_scene(self):
         """ Tests if TVTK scene can be garbage collected."""
         def create_fn():
@@ -29,8 +31,8 @@ class TestTVTKGarbageCollection(TestGarbageCollection):
 
         self.check_object_garbage_collected(create_fn, close_fn)
 
-    @unittest.skipIf(ETSConfig.toolkit == 'wx',
-                     'Test segfaults using WX (issue #216)')
+    @unittest.skipIf(ETSConfig.toolkit in ('wx', 'null'),
+                     'Test segfaults using WX (issue #216) and fails on null')
     def test_scene(self):
         """ Tests if Scene can be garbage collected."""
         def create_fn():
@@ -41,8 +43,8 @@ class TestTVTKGarbageCollection(TestGarbageCollection):
 
         self.check_object_garbage_collected(create_fn, close_fn)
 
-    @unittest.skipIf(ETSConfig.toolkit == 'wx',
-                     'Test segfaults using WX (issue #216)')
+    @unittest.skipIf(ETSConfig.toolkit in ('wx', 'null'),
+                     'Test segfaults using WX (issue #216) and fails on null')
     def test_decorated_scene(self):
         """ Tests if Decorated Scene can be garbage collected."""
         def create_fn():

--- a/tvtk/tests/test_pyface_utils.py
+++ b/tvtk/tests/test_pyface_utils.py
@@ -1,5 +1,6 @@
 import unittest
 from unittest.mock import Mock, patch
+from traits.etsconfig.api import ETSConfig
 
 from pyface.api import FileDialog, NO, OK
 
@@ -12,6 +13,8 @@ class TestPopupSave(unittest.TestCase):
         m.path = 'mock'
         return m
 
+    @unittest.skipIf(ETSConfig.toolkit == 'null',
+                     'Test meaningless with null toolkit.')
     def test_popup_save_with_user_ok(self):
         with patch('pyface.api.FileDialog') as fd:
             fd.return_value = self._make_mock_file_dialog(OK)
@@ -20,6 +23,8 @@ class TestPopupSave(unittest.TestCase):
 
         self.assertEqual(x, 'mock')
 
+    @unittest.skipIf(ETSConfig.toolkit == 'null',
+                     'Test meaningless with null toolkit.')
     def test_popup_save_with_user_not_ok(self):
         with patch('pyface.api.FileDialog') as fd:
             fd.return_value = self._make_mock_file_dialog(NO)

--- a/tvtk/tests/test_tvtk_scene.py
+++ b/tvtk/tests/test_tvtk_scene.py
@@ -10,14 +10,17 @@ import unittest
 import weakref
 import gc
 
+from traits.etsconfig.api import ETSConfig
 from tvtk.pyface.tvtk_scene import TVTKScene
 from tvtk.tests.common import restore_gc_state
 
 
 class TestTVTKScene(unittest.TestCase):
 
-    @unittest.skipIf(sys.platform.startswith('win'),
-                     'CI with windows fails due to lack of OpenGL')
+    @unittest.skipIf(
+        sys.platform.startswith('win') or ETSConfig.toolkit == 'null',
+        'CI with windows fails due to lack of OpenGL, or toolkit is null.'
+    )
     def test_tvtk_scene_garbage_collected(self):
 
         # given


### PR DESCRIPTION
- Ensure that tests can run when toolkit is null.
- Do not generate docs on build as this will fail on headless servers.