### PR TITLE
Support VTK_LONG_LONG

### DIFF
--- a/tvtk/array_handler.py
+++ b/tvtk/array_handler.py
@@ -225,7 +225,6 @@ def get_vtk_to_numeric_typemap():
         vtkConstants.VTK_LONG: LONG_TYPE_CODE,
         vtkConstants.VTK_UNSIGNED_LONG: ULONG_TYPE_CODE,
         vtkConstants.VTK_LONG_LONG: numpy.int64,
-        vtkConstants.VTK_UNSIGNED_LONG_LONG: numpy.uint64,
         vtkConstants.VTK_ID_TYPE: ID_TYPE_CODE,
         vtkConstants.VTK_FLOAT: numpy.float32,
         vtkConstants.VTK_DOUBLE: numpy.float64
@@ -251,7 +250,6 @@ def get_sizeof_vtk_array(vtk_array_type):
         vtkConstants.VTK_LONG: VTK_LONG_TYPE_SIZE,
         vtkConstants.VTK_UNSIGNED_LONG: VTK_LONG_TYPE_SIZE,
         vtkConstants.VTK_LONG_LONG: 8,
-        vtkConstants.VTK_UNSIGNED_LONG_LONG: 8,
         vtkConstants.VTK_ID_TYPE: VTK_ID_TYPE_SIZE,
         vtkConstants.VTK_FLOAT: 4,
         vtkConstants.VTK_DOUBLE: 8

--- a/tvtk/array_handler.py
+++ b/tvtk/array_handler.py
@@ -224,6 +224,8 @@ def get_vtk_to_numeric_typemap():
         vtkConstants.VTK_UNSIGNED_INT: numpy.uint32,
         vtkConstants.VTK_LONG: LONG_TYPE_CODE,
         vtkConstants.VTK_UNSIGNED_LONG: ULONG_TYPE_CODE,
+        vtkConstants.VTK_LONG_LONG: numpy.int64,
+        vtkConstants.VTK_UNSIGNED_LONG_LONG: numpy.uint64,
         vtkConstants.VTK_ID_TYPE: ID_TYPE_CODE,
         vtkConstants.VTK_FLOAT: numpy.float32,
         vtkConstants.VTK_DOUBLE: numpy.float64
@@ -248,6 +250,8 @@ def get_sizeof_vtk_array(vtk_array_type):
         vtkConstants.VTK_UNSIGNED_INT: 4,
         vtkConstants.VTK_LONG: VTK_LONG_TYPE_SIZE,
         vtkConstants.VTK_UNSIGNED_LONG: VTK_LONG_TYPE_SIZE,
+        vtkConstants.VTK_LONG_LONG: 8,
+        vtkConstants.VTK_UNSIGNED_LONG_LONG: 8,
         vtkConstants.VTK_ID_TYPE: VTK_ID_TYPE_SIZE,
         vtkConstants.VTK_FLOAT: 4,
         vtkConstants.VTK_DOUBLE: 8

--- a/tvtk/tests/test_array_handler.py
+++ b/tvtk/tests/test_array_handler.py
@@ -66,7 +66,6 @@ class TestArrayHandler(unittest.TestCase):
         t_z.append(numpy.array([0, 255], numpy.uint8))
         t_z.append(numpy.array([0, 65535], numpy.uint16))
         t_z.append(numpy.array([0, 4294967295], numpy.uint32))
-        t_z.append(numpy.array([0, 18446744073709551615], numpy.uint64))
         t_z.append(numpy.array([-1.0e38, 0, 1.0e38], 'f'))
         t_z.append(numpy.array([-1.0e299, 0, 1.0e299], 'd'))
 

--- a/tvtk/tests/test_array_handler.py
+++ b/tvtk/tests/test_array_handler.py
@@ -61,9 +61,12 @@ class TestArrayHandler(unittest.TestCase):
         #t_z.append(numpy.array([-128, 0, 127], numpy.character))
         t_z.append(numpy.array([-32768, 0, 32767], numpy.int16))
         t_z.append(numpy.array([-2147483648, 0, 2147483647], numpy.int32))
+        t_z.append(numpy.array([
+            -9223372036854775808, 0, 9223372036854775807], numpy.int64))
         t_z.append(numpy.array([0, 255], numpy.uint8))
         t_z.append(numpy.array([0, 65535], numpy.uint16))
         t_z.append(numpy.array([0, 4294967295], numpy.uint32))
+        t_z.append(numpy.array([0, 18446744073709551615], numpy.uint64))
         t_z.append(numpy.array([-1.0e38, 0, 1.0e38], 'f'))
         t_z.append(numpy.array([-1.0e299, 0, 1.0e299], 'd'))
 


### PR DESCRIPTION
This PR adds supports for VTK_LONG_LONG ~and VTK_UNSIGNED_LONG_LONG~ to tvtk/array_handler.py.

It is necessary because some files can contain arrays of these types.
In particular, VTU files exported using ParaView can have Int64 ~and UInt64~, as attached below.
[mesh.vtu.zip](https://github.com/enthought/mayavi/files/8126686/mesh.vtu.zip)

I also added some lines in tvtk/tests/test_array_handler.py and confirmed the VTU file attached was successfully loaded using the modified code.

Edit: I removed the description related to VTK_UNSIGNED_LONG_LONG, which is not necessary (at least) for my usage.