### PR TITLE
Improve jupyter backends

### DIFF
--- a/.github/workflows/headless-tests.yml
+++ b/.github/workflows/headless-tests.yml
@@ -30,7 +30,7 @@ jobs:
         python -m pip install pillow
         python -m pip install pytest
         python -m pip install traitsui==7.2.1
-        python setup.py install
+        python -m pip install .
     - name: Test tvtk package
       run: pytest -v --pyargs tvtk
     - name: Test Mayavi package

--- a/.github/workflows/headless-tests.yml
+++ b/.github/workflows/headless-tests.yml
@@ -29,6 +29,7 @@ jobs:
         python -m pip install vtk
         python -m pip install pillow
         python -m pip install pytest
+        python -m pip install traitsui==7.2.1
         python setup.py install
     - name: Test tvtk package
       run: pytest -v --pyargs tvtk

--- a/.github/workflows/run-mayavi-tests.yml
+++ b/.github/workflows/run-mayavi-tests.yml
@@ -42,6 +42,7 @@ jobs:
         python -m pip install vtk
         python -m pip install pillow
         python -m pip install nose
+        python -m pip install traitsui==7.2.1
         python -m pip install -e .[app]
     - name: Test Mayavi package
       uses: GabrielBB/xvfb-action@v1

--- a/mayavi/core/engine.py
+++ b/mayavi/core/engine.py
@@ -2,8 +2,8 @@
 highest level.
 
 """
-# Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
+# Copyright (c) 2005-2022, Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.
@@ -11,14 +11,14 @@ highest level.
 try:
     import vtk
 except ImportError as m:
-    m.args = ('%s\n%s\nDo you have vtk and its Python bindings installed properly?' %
-                    (m.args[0], '_'*80),)
+    m.args = ('%s\n%s\nDo you have vtk and its Python bindings '
+              'installed properly?' % (m.args[0], '_'*80),)
     raise
 
 # Enthought library imports.
 from traits.api import (HasStrictTraits, List, Str,
-        Property, Instance, Event, HasTraits, Callable, Dict,
-        Bool, on_trait_change, WeakRef)
+                        Property, Instance, Event, HasTraits, Callable, Dict,
+                        Bool, on_trait_change, WeakRef)
 from traitsui.api import View, Item
 from apptools.persistence import state_pickler
 from apptools.scripting.api import Recorder, recordable
@@ -43,13 +43,17 @@ def _id_generator():
     while True:
         yield(n)
         n += 1
+
+
 scene_id_generator = _id_generator()
+
 
 def get_args(function):
     """ Simple inspect-like function to inspect the arguments a function
         takes.
     """
     return function.__code__.co_varnames[:function.__code__.co_argcount]
+
 
 ######################################################################
 # `Engine` class
@@ -115,13 +119,14 @@ class Engine(HasStrictTraits):
     _viewer_ref = Dict
 
     # View related traits.
-    current_selection_view = View(Item(name='_current_selection',
-                                       enabled_when='_current_selection is not None',
-                                       style='custom', springy=True,
-                                       show_label=False,),
-                                  resizable=True,
-                                  scrollable=True
-                                  )
+    current_selection_view = View(
+        Item(name='_current_selection',
+             enabled_when='_current_selection is not None',
+             style='custom', springy=True,
+             show_label=False,),
+        resizable=True,
+        scrollable=True
+    )
 
     ######################################################################
     # `object` interface
@@ -134,8 +139,9 @@ class Engine(HasStrictTraits):
 
         # To remove ref cycle with root preferences helper, the trait change
         # handler is an instance method
-        preference_manager.root.on_trait_change(self._show_helper_nodes_changed,
-                                                'show_helper_nodes')
+        preference_manager.root.on_trait_change(
+            self._show_helper_nodes_changed, 'show_helper_nodes'
+        )
 
     def __get_pure_state__(self):
         d = self.__dict__.copy()
@@ -188,7 +194,6 @@ class Engine(HasStrictTraits):
     def add_source(self, src, scene=None):
         """Adds a source to the pipeline. Uses the current scene unless a
         scene is given in the scene keyword argument."""
-        passed_scene = scene
         if scene is not None:
             tvtk_scene = scene.scene
             for sc in self.scenes:
@@ -214,7 +219,6 @@ class Engine(HasStrictTraits):
         to the selected object, or to an object passed as the
         kwarg `obj`.
         """
-        passed_obj = obj
         if obj is None:
             obj = self.current_object
         if not isinstance(obj, Base):
@@ -252,10 +256,10 @@ class Engine(HasStrictTraits):
         # Save the state of VTK's global warning display.
         o = vtk.vtkObject
         w = o.GetGlobalWarningDisplay()
-        o.SetGlobalWarningDisplay(0) # Turn it off.
+        o.SetGlobalWarningDisplay(0)  # Turn it off.
         try:
-            #FIXME: This is for streamline seed point widget position which
-            #does not get serialized correctly
+            # FIXME: This is for streamline seed point widget position which
+            # does not get serialized correctly
             state = state_pickler.get_state(self)
             st = state.scenes[0].children[0].children[0].children[4]
             l_pos = st.seed.widget.position
@@ -304,7 +308,7 @@ class Engine(HasStrictTraits):
         passed_scene = scene
         reader = registry.get_file_reader(filename)
         if reader is None:
-            msg = 'No suitable reader found for the file %s'%filename
+            msg = 'No suitable reader found for the file %s' % filename
             error(msg)
         else:
             src = None
@@ -367,7 +371,7 @@ class Engine(HasStrictTraits):
             if hasattr(scene, 'name'):
                 name = scene.name
             else:
-                name = 'Mayavi Scene %d'%next(scene_id_generator)
+                name = 'Mayavi Scene %d' % next(scene_id_generator)
 
         s = Scene(scene=scene, name=name, parent=self)
         s.start()
@@ -463,7 +467,6 @@ class Engine(HasStrictTraits):
             if hasattr(viewer, 'title'):
                 self.current_scene.sync_trait('name', viewer, 'title')
         return viewer
-
 
     @recordable
     def close_scene(self, scene):
@@ -575,9 +578,9 @@ class Engine(HasStrictTraits):
         """
         self._viewer_ref.clear()
         self.scenes = []
-        preference_manager.root.on_trait_change(self._show_helper_nodes_changed,
-                                                'show_helper_nodes',
-                                                remove=True)
+        preference_manager.root.on_trait_change(
+            self._show_helper_nodes_changed, 'show_helper_nodes', remove=True
+        )
         registry.unregister_engine(self)
 
     def _show_helper_nodes_changed(self):
@@ -587,8 +590,8 @@ class Engine(HasStrictTraits):
     def _get_children_ui_list(self):
         """ Trait getter for children_ui_list Property.
         """
-        if preference_manager.root.show_helper_nodes \
-                    and len(self.scenes) == 0:
+        if (preference_manager.root.show_helper_nodes and
+           len(self.scenes) == 0):
             return [SceneAdderNode(object=self)]
         else:
             return self.scenes

--- a/mayavi/core/pipeline_base.py
+++ b/mayavi/core/pipeline_base.py
@@ -121,10 +121,10 @@ class PipelineBase(Base):
                 if hasattr(actor, 'mapper'):
                     m = actor.mapper
                     if m is not None:
-                        m.update(0)
+                        m.update()
         if hasattr(self, 'components'):
             for component in self.components:
-                    component.render()
+                component.render()
 
     ######################################################################
     # `PipelineBase` interface.

--- a/mayavi/tests/test_mlab_null_engine.py
+++ b/mayavi/tests/test_mlab_null_engine.py
@@ -48,13 +48,34 @@ class TestRealMlabNullEngine(unittest.TestCase):
         for engine in list(registry.engines):
             registry.unregister_engine(engine)
 
-    def test_test_backend(self):
+    def test_test_backend_clf(self):
         """Test if setting the backend to 'test' works."""
         mlab.options.backend = 'test'
         mlab.test_contour3d()
+        e = mlab.get_engine()
+        self.assertEqual(len(e.scenes), 1)
+        self.assertEqual(len(e.scenes[0].children), 1)
         mlab.clf()
+        self.assertEqual(len(e.scenes), 1)
+        self.assertEqual(len(e.scenes[0].children), 0)
         mlab.pipeline.open(get_example_data('cube.vti'))
         mlab.clf()
+        self.assertEqual(len(e.scenes), 1)
+        self.assertEqual(len(e.scenes[0].children), 0)
+
+    def test_points3d_test_backend(self):
+        # Given
+        mlab.options.backend = 'test'
+        # When
+        g = mlab.test_points3d()
+        pd = g.actor.mapper.input
+        # Then
+        self.assertTrue(pd.number_of_polys == 0)
+        # When
+        g.render()
+        # Then
+        self.assertTrue(pd.number_of_polys == 1920)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/mayavi/tools/figure.py
+++ b/mayavi/tools/figure.py
@@ -128,11 +128,13 @@ def clf(figure=None):
             scene = gcf()
         else:
             scene = figure
-        disable_render = scene.scene.disable_render
-        scene.scene.disable_render = True
+        if scene.scene is not None:
+            disable_render = scene.scene.disable_render
+            scene.scene.disable_render = True
         scene.children[:] = []
         scene._mouse_pick_dispatcher.clear_callbacks()
-        scene.scene.disable_render = disable_render
+        if scene.scene is not None:
+            scene.scene.disable_render = disable_render
     except AttributeError:
         pass
     gc.collect()

--- a/mayavi/tools/notebook.py
+++ b/mayavi/tools/notebook.py
@@ -23,7 +23,10 @@ def _ipython_display_(self):
     '''Method attached to Mayavi objects.
 
     Note that here `self` is the Mayavi object that is going to be
-    visualized.
+    visualized. This method is used by IPython to display objects on a
+    notebook, see here:
+    https://ipython.readthedocs.io/en/stable/config/integrating.html#custom-methods
+
     '''
     return _backend.display(self)
 

--- a/mayavi/tools/notebook.py
+++ b/mayavi/tools/notebook.py
@@ -6,13 +6,17 @@ from itertools import count
 from tvtk.api import tvtk
 from tvtk.common import configure_input
 
+from mayavi.core.scene import Scene
 
-_backend = 'ipy'
-_width = None
-_height = None
-_local = True
-_widget_manager = None
+
+_registry = dict()
+_backend = None
 _counter = count()
+
+
+def register_backend(name, klass):
+    global _registry
+    _registry[name] = klass
 
 
 def init(backend='ipy', width=None, height=None, local=True):
@@ -20,144 +24,241 @@ def init(backend='ipy', width=None, height=None, local=True):
 
     **Parameters**
 
-    backend :str: one of ('png', 'x3d', 'ipy')
+    backend :str: one of ('itk', 'ipy', 'x3d', 'png')
     width :int: suggested default width of the element
     height :int: suggested default height of the element
     local :bool: Use local copy of x3dom.js instead of online version.
     """
-    global _backend, _width, _height, _local, _widget_manager
-    backends = ('png', 'x3d', 'ipy')
+    global _backend, _registry
+    backends = _registry.keys()
     error_msg = "Backend must be one of %r, got %s" % (backends, backend)
     assert backend in backends, error_msg
     from mayavi import mlab
     mlab.options.offscreen = True
-    _backend = backend
-    _width, _height = width, height
-    _local = local
-    if backend == 'ipy':
-        _setup_widget_manager()
-    _monkey_patch_for_ipython()
+    _backend = _registry[backend](width, height, local)
     print("Notebook initialized with %s backend." % backend)
 
 
-def _setup_widget_manager():
-    global _widget_manager
-    if _widget_manager is None:
-        from mayavi.tools.remote.ipy_remote import WidgetManager
-        _widget_manager = WidgetManager()
+class JupyterBackend(object):
+    _width = None
+    _height = None
+    _local = True
+
+    def __init__(self, width=None, height=None, local=True):
+        self._width = width
+        self._height = height
+        self._local = local
+        self._monkey_patch_for_ipython()
+
+    def _monkey_patch_for_ipython(self):
+        from mayavi.core.base import Base
+        from tvtk.pyface.tvtk_scene import TVTKScene
+        Base._ipython_display_ = self.__class__._ipython_display_
+        TVTKScene._ipython_display_ = self.__class__._ipython_display_
+
+    def _ipython_display_(self):
+        '''Override to display with this backend.
+
+        Note that here `self` is not an instance of JupyterBackend but of the
+        Mayavi object that is going to be visualized.
+
+        '''
+        pass
 
 
-def _monkey_patch_for_ipython():
-    from mayavi.core.base import Base
-    from tvtk.pyface.tvtk_scene import TVTKScene
-    Base._ipython_display_ = _ipython_display_
-    TVTKScene._ipython_display_ = _ipython_display_
+def get_scene(obj):
+    '''Walks up the object to get to the Scene.
+    '''
+    while obj is not None:
+        if isinstance(obj, Scene):
+            return obj
+        else:
+            obj = obj.parent
+    return None
 
 
-def _ipython_display_(self):
-    """Method for displaying elements on the Jupyter notebook.
-    """
-    from IPython.display import HTML
-    from IPython.display import display as idisplay
+def get_all_actors(obj):
+    '''Walks down a given object and finds all the actors.'''
 
-    if hasattr(self, 'render_window'):
-        scene = self
-    elif hasattr(self, 'scene'):
-        scene = self.scene
-    if _backend == 'png':
-        return idisplay(HTML(scene_to_png(scene)))
-    elif _backend == 'x3d':
-        return idisplay(HTML(scene_to_x3d(scene)))
-    elif _backend == 'ipy':
-        return idisplay(scene_to_ipy(scene))
+    def _get_actors(x):
+        return [tvtk.to_vtk(i) for i in x]
 
-
-def _fix_x3d_header(x3d):
-    id = 'scene_%d' % next(_counter)
-    rep = '<X3D profile="Immersive" version="3.0" id="%s" ' % id
-    if _width is not None:
-        rep += 'width="%dpx" ' % _width
-    if _height is not None:
-        rep += 'height="%dpx" ' % _height
-    rep += '>'
-    if isinstance(x3d, bytes):
-        x3d = x3d.decode("utf-8", "ignore") 
-    x3d = x3d.replace(
-        '<X3D profile="Immersive" version="3.0">',
-        rep
-    )
-    return x3d
+    actors = []
+    if hasattr(obj, 'actors'):
+        actors.extend(_get_actors(obj.actors))
+    if hasattr(obj, 'actor'):
+        actors.extend(_get_actors(obj.actor.actors))
+    if hasattr(obj, 'children'):
+        for x in obj.children:
+            actors.extend(get_all_actors(x))
+    return actors
 
 
-def scene_to_x3d(scene):
-    ex = tvtk.X3DExporter()
-    ex.input = scene.render_window
-    lm = scene.light_manager.light_mode
-    # The default raymond mode is too bright so switch back to vtk mode.
-    scene.light_manager.light_mode = 'vtk'
-    ex.write_to_output_string = True
-    ex.update()
-    ex.write()
-    # Switch back
-    scene.light_manager.light_mode = lm
-    if _local:
-        url_base = "nbextensions/mayavi/x3d"
-    else:
-        url_base = "https://www.x3dom.org/download/1.7.2"
-    x3d_elem = _fix_x3d_header(ex.output_string)
-    html = '''
-    %s
-    <script type="text/javascript">
-    require(["%s/x3dom"], function(x3dom) {
-        var x3dom_css = document.getElementById("x3dom-css");
-        if (x3dom_css === null) {
-            var l = document.createElement("link");
-            l.setAttribute("rel", "stylesheet");
-            l.setAttribute("type", "text/css");
-            l.setAttribute("href", require.toUrl("%s/x3dom.css"));
-            l.setAttribute("id", "x3dom-css");
-            $("head").append(l);
-        }
-        if (typeof x3dom != 'undefined') {
-            x3dom.reload();
-        }
-        else if (typeof window.x3dom != 'undefined') {
-            window.x3dom.reload();
-        }
-    })
-    </script>
-    ''' % (x3d_elem, url_base, url_base)
-    return html
+class ITKBackend(JupyterBackend):
+    _view = None
+
+    def __init__(self, width=None, height=None, local=True):
+        super().__init__(width, height, local)
+        from mayavi import mlab
+        mlab.options.backend = 'test'
+
+        if self.__class__._view is None:
+            try:
+                from itkwidgets import view
+                self.__class__._view = view
+                self._workaround_itkwidgets_bug()
+            except ImportError:
+                print("The itk backend requires itkwidgets to be installed.")
+
+    def _workaround_itkwidgets_bug(self):
+        from itkwidgets import widget_viewer
+        if hasattr(widget_viewer, 'have_mayavi'):
+            widget_viewer.have_mayavi = False
+
+    @classmethod
+    def display(klass, obj):
+        from IPython.display import display as idisplay
+        scene = get_scene(obj)
+        if scene is not None:
+            actors = get_all_actors(scene)
+            return idisplay(klass._view(actors=actors))
+        else:
+            return obj
+
+    def _ipython_display_(self):
+        return ITKBackend.display(self)
 
 
-def scene_to_png(scene):
-    w2if = tvtk.WindowToImageFilter()
-    w2if.input = scene.render_window
-    ex = tvtk.PNGWriter()
-    ex.write_to_memory = True
-    configure_input(ex, w2if)
-    ex.update()
-    ex.write()
-    data = base64.b64encode(ex.result.to_array()).decode('ascii')
-    html = '<img src="data:image/png;base64,%s" alt="PNG image"></img>'
-    return html % data
+class IPyBackend(JupyterBackend):
+    _widget_manager = None
+
+    def __init__(self, width=None, height=None, local=True):
+        super().__init__(width, height, local)
+
+        if self.__class__._widget_manager is None:
+            # This is a singleton, no need to create multiple of these.
+            from mayavi.tools.remote.ipy_remote import WidgetManager
+            self.__class__._widget_manager = WidgetManager()
+
+    @classmethod
+    def display(klass, scene):
+        return klass._widget_manager.scene_to_ipy(scene)
+
+    def _ipython_display_(self):
+        from IPython.display import display as idisplay
+        if hasattr(self, 'render_window'):
+            scene = self
+        elif hasattr(self, 'scene'):
+            scene = self.scene
+        return idisplay(IPyBackend.display(scene))
 
 
-def scene_to_ipy(scene):
-    return _widget_manager.scene_to_ipy(scene)
+class PNGBackend(JupyterBackend):
+
+    @classmethod
+    def display(klass, scene):
+        from IPython.display import HTML
+        from IPython.display import display as idisplay
+
+        return idisplay(HTML(klass.scene_to_png(scene)))
+
+    @classmethod
+    def scene_to_png(klass, scene):
+        w2if = tvtk.WindowToImageFilter()
+        w2if.input = scene.render_window
+        ex = tvtk.PNGWriter()
+        ex.write_to_memory = True
+        configure_input(ex, w2if)
+        ex.update()
+        ex.write()
+        data = base64.b64encode(ex.result.to_array()).decode('ascii')
+        html = '<img src="data:image/png;base64,%s" alt="PNG image"></img>'
+        return html % data
+
+    def _ipython_display_(self):
+        if hasattr(self, 'render_window'):
+            scene = self
+        elif hasattr(self, 'scene'):
+            scene = self.scene
+        return PNGBackend.display(scene)
 
 
-def display(obj, backend=None):
-    """Display given object on Jupyter notebook using given backend.
+class X3DBackend(JupyterBackend):
 
-    This is largely for testing.
-    """
-    global _backend
-    backend = _backend if backend is None else backend
-    if backend == 'ipy':
-        _setup_widget_manager()
-    orig_backend = _backend
-    _backend = backend
-    result = _ipython_display_(obj)
-    _backend = orig_backend
-    return result
+    @classmethod
+    def display(klass, scene):
+        from IPython.display import HTML
+        from IPython.display import display as idisplay
+
+        return idisplay(HTML(klass.scene_to_x3d(scene)))
+
+    @classmethod
+    def _fix_x3d_header(klass, x3d):
+        id = 'scene_%d' % next(_counter)
+        rep = '<X3D profile="Immersive" version="3.0" id="%s" ' % id
+        if klass._width is not None:
+            rep += 'width="%dpx" ' % klass._width
+        if klass._height is not None:
+            rep += 'height="%dpx" ' % klass._height
+        rep += '>'
+        if isinstance(x3d, bytes):
+            x3d = x3d.decode("utf-8", "ignore")
+        x3d = x3d.replace(
+            '<X3D profile="Immersive" version="3.0">',
+            rep
+        )
+        return x3d
+
+    @classmethod
+    def scene_to_x3d(klass, scene):
+        ex = tvtk.X3DExporter()
+        ex.input = scene.render_window
+        lm = scene.light_manager.light_mode
+        # The default raymond mode is too bright so switch back to vtk mode.
+        scene.light_manager.light_mode = 'vtk'
+        ex.write_to_output_string = True
+        ex.update()
+        ex.write()
+        # Switch back
+        scene.light_manager.light_mode = lm
+        if klass._local:
+            url_base = "nbextensions/mayavi/x3d"
+        else:
+            url_base = "https://www.x3dom.org/download/1.7.2"
+        x3d_elem = klass._fix_x3d_header(ex.output_string)
+        html = '''
+        %s
+        <script type="text/javascript">
+        require(["%s/x3dom"], function(x3dom) {
+            var x3dom_css = document.getElementById("x3dom-css");
+            if (x3dom_css === null) {
+                var l = document.createElement("link");
+                l.setAttribute("rel", "stylesheet");
+                l.setAttribute("type", "text/css");
+                l.setAttribute("href", require.toUrl("%s/x3dom.css"));
+                l.setAttribute("id", "x3dom-css");
+                $("head").append(l);
+            }
+            if (typeof x3dom != 'undefined') {
+                x3dom.reload();
+            }
+            else if (typeof window.x3dom != 'undefined') {
+                window.x3dom.reload();
+            }
+        })
+        </script>
+        ''' % (x3d_elem, url_base, url_base)
+        return html
+
+    def _ipython_display_(self):
+        if hasattr(self, 'render_window'):
+            scene = self
+        elif hasattr(self, 'scene'):
+            scene = self.scene
+        return X3DBackend.display(scene)
+
+
+register_backend('itk', ITKBackend)
+register_backend('ipy', IPyBackend)
+register_backend('x3d', X3DBackend)
+register_backend('png', PNGBackend)

--- a/mayavi/tools/notebook.py
+++ b/mayavi/tools/notebook.py
@@ -119,11 +119,18 @@ class ITKBackend(JupyterBackend):
         if hasattr(widget_viewer, 'have_mayavi'):
             widget_viewer.have_mayavi = False
 
+    def _update_pipeline(self, actors):
+        for a in actors:
+            m = a.GetMapper()
+            if m:
+                m.Update()
+
     def display(self, obj):
         from IPython.display import display as idisplay
         scene = get_scene(obj)
         if scene is not None:
             actors = get_all_actors(scene)
+            self._update_pipeline(actors)
             # Works around bug in released itkwidgets-0.32.1.
             # Can remove when this PR is merged and in a release:
             # https://github.com/InsightSoftwareConsortium/itkwidgets/pull/438


### PR DESCRIPTION
- Refactor notebook code and add itkwidgets support. The itkwidgets support allows us to use Mayavi in a headless manner unlike the other backends which require offscreen support.
- Improve implementation of the different backends.
- Fix issues with the test backend.
    - `mlab.clf()` was not clearing the scene.
    - `obj.render()` was not working correctly.
    - The itkwidgets backend would not work correctly in some cases  so we  explicitly flush the pipeline before calling view. 