### PR TITLE
ENH: PySide6 support

### DIFF
--- a/.github/workflows/run-mayavi-tests.yml
+++ b/.github/workflows/run-mayavi-tests.yml
@@ -16,6 +16,13 @@ jobs:
         include:
           - python-version: '3.8'
             qt-api: 'pyside6'
+            os: ubuntu-latest
+          - python-version: '3.8'
+            qt-api: 'pyside6'
+            os: windows-latest
+          - python-version: '3.8'
+            qt-api: 'pyside6'
+            os: macos-latest
       fail-fast: false
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/run-mayavi-tests.yml
+++ b/.github/workflows/run-mayavi-tests.yml
@@ -11,10 +11,18 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6]
+        python-version: ['3.6', '3.8']
+        qt-api: ['pyqt5']
+        include:
+          - python-version: '3.8'
+            qt-api: 'pyside6'
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
+
+    env:
+      ETS_TOOLKIT=qt4
+      QT_API={{ matrix.qt-api }}
 
     steps:
     - uses: actions/checkout@v2
@@ -37,7 +45,7 @@ jobs:
     - name: Install dependencies and local packages
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install pyqt5
+        python -m pip install {{ matrix.qt-api }}
         python -m pip install numpy
         python -m pip install vtk
         python -m pip install pillow

--- a/.github/workflows/run-mayavi-tests.yml
+++ b/.github/workflows/run-mayavi-tests.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Install dependencies and local packages
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install {{ matrix.qt-api }}
+        python -m pip install ${{ matrix.qt-api }}
         python -m pip install numpy
         python -m pip install vtk
         python -m pip install pillow

--- a/.github/workflows/run-mayavi-tests.yml
+++ b/.github/workflows/run-mayavi-tests.yml
@@ -22,7 +22,7 @@ jobs:
 
     env:
       ETS_TOOLKIT: qt4
-      QT_API: {{ matrix.qt-api }}
+      QT_API: ${{ matrix.qt-api }}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/run-mayavi-tests.yml
+++ b/.github/workflows/run-mayavi-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.6', '3.8']
+        python-version: ['3.6']
         qt-api: ['pyqt5']
         include:
           - python-version: '3.8'
@@ -21,8 +21,8 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      ETS_TOOLKIT=qt4
-      QT_API={{ matrix.qt-api }}
+      ETS_TOOLKIT: qt4
+      QT_API: {{ matrix.qt-api }}
 
     steps:
     - uses: actions/checkout@v2

--- a/tvtk/pyface/ui/qt4/QVTKRenderWindowInteractor.py
+++ b/tvtk/pyface/ui/qt4/QVTKRenderWindowInteractor.py
@@ -42,7 +42,7 @@ Changes by Fabian Wenzel, Jan. 2016
 
 import sys
 
-from pyface.qt import qt_api
+from pyface.qt import qt_api, is_qt4
 if qt_api == 'pyqt':
     PyQtImpl = "PyQt4"
 elif qt_api == 'pyqt5':
@@ -275,7 +275,7 @@ class QVTKRenderWindowInteractor(QVTKRWIBaseClass):
 
         # add wheel timer to fix scrolling issue with trackpad
         self.wheel_timer = None
-        if PyQtImpl != 'PyQt5':
+        if is_qt4:
             self.wheel_timer = QTimer()
             self.wheel_timer.setSingleShot(True)
             self.wheel_timer.setInterval(25)

--- a/tvtk/pyface/ui/qt4/QVTKRenderWindowInteractor.py
+++ b/tvtk/pyface/ui/qt4/QVTKRenderWindowInteractor.py
@@ -49,6 +49,8 @@ elif qt_api == 'pyqt5':
     PyQtImpl = "PyQt5"
 elif qt_api == 'pyside2':
     PyQtImpl = "PySide2"
+elif qt_api == 'pyside6':
+    PyQtImpl = "PySide6"
 else:
     PyQtImpl = "PySide"
 
@@ -93,6 +95,15 @@ elif PyQtImpl == "PySide2":
     from PySide2.QtWidgets import QWidget, QSizePolicy, QApplication
     from PySide2.QtGui import QWheelEvent
     from PySide2.QtCore import Qt, QTimer, QObject, QSize, QEvent
+elif PyQtImpl == "PySide6":
+    if QVTKRWIBase == "QGLWidget":
+        try:
+            from PySide6.QtWidgets import QOpenGLWidget as QGLWidget
+        except:
+            from PySide6.QtOpenGL import QGLWidget
+    from PySide6.QtWidgets import QWidget, QSizePolicy, QApplication
+    from PySide6.QtGui import QWheelEvent
+    from PySide6.QtCore import Qt, QTimer, QObject, QSize, QEvent
 else:
     raise ImportError("Unknown PyQt implementation " + repr(PyQtImpl))
 

--- a/tvtk/pyface/ui/qt4/decorated_scene.py
+++ b/tvtk/pyface/ui/qt4/decorated_scene.py
@@ -72,8 +72,6 @@ class DecoratedScene(Scene):
     def _closed_fired(self):
         super(DecoratedScene, self)._closed_fired()
         # Remove potential cycles.
-        self._content = None
-        self._panel = None
         tbm = self._tool_bar.tool_bar_manager
         if hasattr(tbm, '_toolbars'):
             # Qt backend. Workaround for PySide2/6 before the cleanup in
@@ -83,6 +81,8 @@ class DecoratedScene(Scene):
                     if item.control is not None:
                         if hasattr(item.control, '_tool_instance'):
                             del item.control._tool_instance
+        self._content = None
+        self._panel = None
         self._tool_bar = None
 
     ##########################################################################

--- a/tvtk/pyface/ui/qt4/decorated_scene.py
+++ b/tvtk/pyface/ui/qt4/decorated_scene.py
@@ -66,6 +66,25 @@ class DecoratedScene(Scene):
             d.pop(x, None)
         return d
 
+    ###########################################################################
+    # 'event' interface.
+    ###########################################################################
+    def _closed_fired(self):
+        super(DecoratedScene, self)._closed_fired()
+        # Remove potential cycles.
+        self._content = None
+        self._panel = None
+        tbm = self._tool_bar.tool_bar_manager
+        if hasattr(tbm, '_toolbars'):
+            # Qt backend. Workaround for PySide2/6 before the cleanup in
+            # enthought/pyface#1143 is available.
+            for bar in tbm._toolbars:
+                for item in bar.tools:
+                    if item.control is not None:
+                        if hasattr(item.control, '_tool_instance'):
+                            del item.control._tool_instance
+        self._tool_bar = None
+
     ##########################################################################
     # Non-public interface.
     ##########################################################################

--- a/tvtk/tests/test_garbage_collection.py
+++ b/tvtk/tests/test_garbage_collection.py
@@ -51,7 +51,7 @@ class TestTVTKGarbageCollection(TestGarbageCollection):
             return DecoratedScene(parent=None)
 
         def close_fn(o):
-            o.closing = True
+            o.close()
 
         self.check_object_garbage_collected(create_fn, close_fn)
 


### PR DESCRIPTION
And testing on Python 3.8.

I include a workaround for a lingering cycle that enthought/pyface#1143 cleans up until it is available to depend on. Both PySide2 and PySide6 present that bug, but not PyQt5 (and presumably other PyQtXs, but I did not check).