### PR TITLE
Fixes #1185.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -20,5 +20,6 @@ recursive-include tvtk/pipeline/images *.*
 recursive-include tvtk/plugins/scene *.ini
 recursive-include tvtk/pyface/images *.*
 recursive-include tvtk/tools/images *.*
+exclude tvtk/tvtk_classes.zip
 prune docs/build
 prune docs/pdf


### PR DESCRIPTION
Just exclude the zip file so the sdist does not ship it. This way the file on pypi is much smaller.