### PR TITLE
Remove redunant variable in explorer example

### DIFF
--- a/examples/mayavi/explorer/explorer_app.py
+++ b/examples/mayavi/explorer/explorer_app.py
@@ -107,7 +107,6 @@ class Explorer3D(HasTraits):
     ######################################################################
     def _make_data(self):
         dims = self.dimensions.tolist()
-        np = dims[0]*dims[1]*dims[2]
         xmin, xmax, ymin, ymax, zmin, zmax = self.volume
         x, y, z = np.ogrid[xmin:xmax:dims[0]*1j,
                            ymin:ymax:dims[1]*1j,


### PR DESCRIPTION
Hi,

additionally to #1163 this stopped the explorer example from working as since commit 0697654 numpy is imported as np which is used as a variable in this function too. I removed the variable because it was not used anyway.