### PR TITLE
Fix issue with `mlab.process_ui_events`

### DIFF
--- a/.github/workflows/headless-tests.yml
+++ b/.github/workflows/headless-tests.yml
@@ -14,12 +14,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.11']
+        python-version: ['3.10']
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
     env:
       VTK_PARSER_VERBOSE: 'true'
+      ETS_TOOLKIT: 'null'
 
     steps:
     - uses: actions/checkout@v2
@@ -35,10 +36,9 @@ jobs:
         python -m pip install pillow
         python -m pip install pytest
         python -m pip install traitsui==7.2.1
-        python -m pip install https://github.com/enthought/apptools/zipball/master
     - name: Install mayavi and tvtk
       run: python -m pip install -v .
     - name: Test tvtk package
       run: pytest -v --pyargs tvtk
     - name: Test Mayavi package
-      run: ETS_TOOLKIT=null pytest -v --pyargs mayavi
+      run: pytest -v --pyargs mayavi

--- a/.github/workflows/headless-tests.yml
+++ b/.github/workflows/headless-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.10']
+        python-version: ['3.11']
       fail-fast: false
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/headless-tests.yml
+++ b/.github/workflows/headless-tests.yml
@@ -35,6 +35,7 @@ jobs:
         python -m pip install pillow
         python -m pip install pytest
         python -m pip install traitsui==7.2.1
+        python -m pip install https://github.com/enthought/apptools/zipball/master
     - name: Install mayavi and tvtk
       run: python -m pip install -v .
     - name: Test tvtk package

--- a/mayavi/core/common.py
+++ b/mayavi/core/common.py
@@ -15,7 +15,7 @@ import traceback
 # Enthought library imports.
 from apptools.persistence.state_pickler import create_instance
 from traits.etsconfig.api import ETSConfig
-if (ETSConfig.toolkit in ('null', '')) or os.environ.get('CI'):
+if (ETSConfig.toolkit == 'null') or os.environ.get('CI'):
     pyface = None
 else:
     from pyface import api as pyface

--- a/mayavi/tests/test_core_common.py
+++ b/mayavi/tests/test_core_common.py
@@ -6,6 +6,8 @@ Tests for the mayavi.core.common module.
 # License: BSD Style.
 
 import os
+from subprocess import check_output
+import sys
 import unittest
 
 from traitsui.api import View
@@ -18,6 +20,40 @@ from mayavi.modules.outline import Outline
 from mayavi.modules.surface import Surface
 
 from mayavi.core.null_engine import NullEngine
+
+
+def test_core_common_pyface_import_honors_env_var():
+    # Given
+    cmd = [sys.executable, "-c",
+           "import mayavi.core.common as C; print(C.pyface)"]
+
+    # When
+    out = check_output(cmd, env={})
+    result = out.strip().decode('utf-8')
+
+    # Then
+    assert result != 'None'
+
+    # When
+    out = check_output(cmd, env={'ETS_TOOLKIT': 'qt'})
+    result = out.strip().decode('utf-8')
+
+    # Then
+    assert result != 'None'
+
+    # When
+    out = check_output(cmd, env={'ETS_TOOLKIT': 'null'})
+    result = out.strip().decode('utf-8')
+
+    # Then
+    assert result == 'None'
+
+    # When
+    out = check_output(cmd, env={'ETS_TOOLKIT': 'qt', 'CI': '1'})
+    result = out.strip().decode('utf-8')
+
+    # Then
+    assert result == 'None'
 
 
 class TestCoreCommon(unittest.TestCase):

--- a/mayavi/tests/test_core_common.py
+++ b/mayavi/tests/test_core_common.py
@@ -27,29 +27,41 @@ def test_core_common_pyface_import_honors_env_var():
     cmd = [sys.executable, "-c",
            "import mayavi.core.common as C; print(C.pyface)"]
 
+    def _make_env(ets=None, ci=None):
+        env = dict(os.environ)
+        if 'ETS_TOOLKIT' in env:
+            del env['ETS_TOOLKIT']
+        if 'CI' in env:
+            del env['CI']
+        if ets is not None:
+            env['ETS_TOOLKIT'] = ets
+        if ci is not None:
+            env['CI'] = ci
+        return env
+
     # When
-    out = check_output(cmd, env={})
+    out = check_output(cmd, env=_make_env())
     result = out.strip().decode('utf-8')
 
     # Then
     assert result != 'None'
 
     # When
-    out = check_output(cmd, env={'ETS_TOOLKIT': 'qt'})
+    out = check_output(cmd, env=_make_env(ets='qt'))
     result = out.strip().decode('utf-8')
 
     # Then
     assert result != 'None'
 
     # When
-    out = check_output(cmd, env={'ETS_TOOLKIT': 'null'})
+    out = check_output(cmd, env=_make_env(ets='null'))
     result = out.strip().decode('utf-8')
 
     # Then
     assert result == 'None'
 
     # When
-    out = check_output(cmd, env={'ETS_TOOLKIT': 'qt', 'CI': '1'})
+    out = check_output(cmd, env=_make_env(ets='qt', ci='1'))
     result = out.strip().decode('utf-8')
 
     # Then


### PR DESCRIPTION
The method was basically doing nothing when no UI toolkit was explicitly set. Since this import is early it would so happen that the toolkit was not set at this point. As a result `mlab.process_ui_events` was doing nothing. In keeping with the Zen of Python, we now do not import pyface only when the toolkit is explicitly set to 'null' or the CI env var is set.