### PR TITLE
MAINT: fix float use in wave.py

### DIFF
--- a/examples/tvtk/visual/wave.py
+++ b/examples/tvtk/visual/wave.py
@@ -5,7 +5,7 @@
 
 from math import sin, pi
 
-from numpy import zeros, float, arange
+from numpy import zeros, arange
 
 from tvtk.tools.visual import show, Curve, iterate, MVector
 


### PR DESCRIPTION
Numpy updates has deprecated many uses and this has cause problems when trying to import float from it such as what we encountered in #1250. In this instance, the "float" is imported to be used in np.zeros, thus we can simply change them to use the python builtin float by removing this import. Closes #1250 

After correcting this, the import error is fixed but we will have a TypeError: order must be str, not bool #1249 which we will fix later