### PR TITLE
MAINT: fix np redefined to number

### DIFF
--- a/examples/mayavi/advanced_visualization/numeric_source.py
+++ b/examples/mayavi/advanced_visualization/numeric_source.py
@@ -21,8 +21,7 @@ from mayavi.modules.image_plane_widget import ImagePlaneWidget
 def make_data(dims=(128, 128, 128)):
     """Creates some simple array data of the given dimensions to test
     with."""
-    np = dims[0]*dims[1]*dims[2]
-
+    
     # Create some scalars to render.
     x, y, z = np.ogrid[-5:5:dims[0]*1j,-5:5:dims[1]*1j,-5:5:dims[2]*1j]
     x = x.astype('f')


### PR DESCRIPTION
In examples/mayavi/advanced_visualization/numeric_source, np is somehow redefined as an integer by:

```
np = dims[0]*dims[1]*dims[2]
```

which causes error such as #1238 
this PR removes this line, closes #1238 