### PR TITLE
MAINT: Compat with traitsui 8

### DIFF
--- a/.github/workflows/run-mayavi-tests.yml
+++ b/.github/workflows/run-mayavi-tests.yml
@@ -40,17 +40,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Install Linux packages for Qt5 support
-      run: |
-        sudo apt-get update
-        sudo apt-get install qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools
-        sudo apt-get install libxkbcommon-x11-0
-        sudo apt-get install libxcb-icccm4
-        sudo apt-get install libxcb-image0
-        sudo apt-get install libxcb-keysyms1
-        sudo apt-get install libxcb-randr0
-        sudo apt-get install libxcb-render-util0
-        sudo apt-get install libxcb-xinerama0
+    - name: Install Linux packages for Qt5/Qt6 support and start Xvfb
+      uses: pyvista/setup-headless-display-action@main
+      with:
+        qt: true
       if: startsWith(matrix.os, 'ubuntu')
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
@@ -68,10 +61,6 @@ jobs:
     - name: Install mayavi and tvtk
       run: python -um pip install -ve .[app]
     - name: Test Mayavi package
-      uses: GabrielBB/xvfb-action@v1
-      with:
-        run: pytest -v mayavi
+      run: pytest -v mayavi
     - name: Test tvtk package
-      uses: GabrielBB/xvfb-action@v1
-      with:
-        run: pytest -sv tvtk
+      run: pytest -sv tvtk

--- a/tvtk/pyface/ui/qt4/actor_editor.py
+++ b/tvtk/pyface/ui/qt4/actor_editor.py
@@ -12,7 +12,10 @@ from pyface.qt import QtGui
 
 # Enthought library imports.
 from traits.api import Any, Bool, Callable, Dict, Str
-from traitsui.qt4.editor import Editor
+try:
+    from traitsui.qt4.editor import Editor
+except ModuleNotFoundError:
+    from traitsui.qt.editor import Editor
 from traitsui.basic_editor_factory import BasicEditorFactory
 
 from .decorated_scene import DecoratedScene

--- a/tvtk/pyface/ui/qt4/scene_editor.py
+++ b/tvtk/pyface/ui/qt4/scene_editor.py
@@ -13,7 +13,10 @@ from pyface.qt import QtGui
 
 # Enthought library imports.
 from traits.api import Any, Bool, Callable
-from traitsui.qt4.editor import Editor
+try:
+    from traitsui.qt.editor import Editor
+except ModuleNotFoundError:  # traitsui < 8
+    from traitsui.qt4.editor import Editor
 from traitsui.basic_editor_factory import BasicEditorFactory
 
 from .decorated_scene import DecoratedScene


### PR DESCRIPTION
Hopefully fixes stuff [like this](https://dev.azure.com/mne-tools/mne-kit-gui/_build/results?buildId=25188&view=logs&jobId=8e630eb1-cb11-5b3c-6e81-b13952459f99&j=8e630eb1-cb11-5b3c-6e81-b13952459f99&t=a4e4a5fe-c39b-5530-1fa2-653201144d29):

```
______________________________ test_kit2fiff_gui _______________________________
mne_kit_gui/tests/test_kit2fiff_gui.py:123: in test_kit2fiff_gui
    ui, frame = mne_kit_gui.kit2fiff()
mne_kit_gui/__init__.py:69: in kit2fiff
    from ._kit2fiff_gui import Kit2FiffFrame
mne_kit_gui/_kit2fiff_gui.py:27: in <module>
    from tvtk.pyface.scene_editor import SceneEditor
/usr/local/miniconda/envs/mne-kit-gui/lib/python3.11/site-packages/tvtk/pyface/scene_editor.py:12: in <module>
    SceneEditor = toolkit_object('scene_editor:SceneEditor')
/usr/local/miniconda/envs/mne-kit-gui/lib/python3.11/site-packages/pyface/base_toolkit.py:127: in __call__
    module = import_module(mname, package)
/usr/local/miniconda/envs/mne-kit-gui/lib/python3.11/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
/usr/local/miniconda/envs/mne-kit-gui/lib/python3.11/site-packages/tvtk/pyface/ui/qt4/scene_editor.py:16: in <module>
    from traitsui.qt4.editor import Editor
E   ModuleNotFoundError: No module named 'traitsui.qt4.editor'
```
