### PR TITLE
Replaced deprecated/removed imghdr with puremagic package

### DIFF
--- a/mayavi/__init__.py
+++ b/mayavi/__init__.py
@@ -18,7 +18,8 @@ __requires__ = [
     'traitsui>=7.0.0',
     'packaging',
     'importlib_resources; python_version<"3.11"',
-    'vtk'
+    'vtk',
+    'puremagic'
 ]
 
 __extras_require__ = {

--- a/mayavi/tools/remote/remote_widget.py
+++ b/mayavi/tools/remote/remote_widget.py
@@ -1,4 +1,4 @@
-import imghdr
+import puremagic
 
 
 class RemoteWidget(object):
@@ -50,7 +50,7 @@ class RemoteWidget(object):
 
     def _update_image(self):
         data = self.scene_proxy.get_raw_image()
-        format = imghdr.what('', h=data)
+        format = puremagic.what('', h=data)
         self.show_image(data, format=format.upper())
 
     # ##### VTK Event handling ##########


### PR DESCRIPTION
`imghdr` was deprecated in Python 3.11 and removed in Python 3.13. The Python package `puremagic` offers a drop-in (and maintained) replacement: https://pypi.org/project/puremagic/#imghdr-replacement

https://peps.python.org/pep-0594/#deprecated-modules
