### PR TITLE
Exclude vtk 9.5 until segfaults have been addressed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,6 @@
 requires = [
     "numpy>=2.0.0rc2,<3",
     "setuptools",
-    "vtk>=9",
+    "vtk>=9,<9.5",
     "wheel"
 ]

--- a/tvtk/pyface/ui/qt4/decorated_scene.py
+++ b/tvtk/pyface/ui/qt4/decorated_scene.py
@@ -134,8 +134,6 @@ class DecoratedScene(Scene):
         """ Returns the tool_bar_manager for this scene.
         """
         tbm = ToolBarManager( *self.actions )
-        tbm.image_size = (32, 20)
-        tbm.show_tool_names = False
         return tbm
 
 

--- a/tvtk/pyface/ui/qt4/decorated_scene.py
+++ b/tvtk/pyface/ui/qt4/decorated_scene.py
@@ -134,6 +134,8 @@ class DecoratedScene(Scene):
         """ Returns the tool_bar_manager for this scene.
         """
         tbm = ToolBarManager( *self.actions )
+        tbm.image_size = (32, 20)
+        tbm.show_tool_names = False
         return tbm
 
 


### PR DESCRIPTION
Installing mayavi with vtk 9.5 leads to issues, see https://github.com/enthought/mayavi/issues/1346 and https://github.com/enthought/mayavi/issues/1350
Restricting ``"vtk < 9.5"`` in the requirements resolves them.

It seems version specific segfaults must be addressed by excluding some vtk classes, as it was always done in https://github.com/enthought/mayavi/blob/main/tvtk/vtk_module.py

In my opinion, vtk versions should always be restricted up to the newest, tested version.
New vtk releases often led to installation issues in the past.
This is especially frustrating, as there are only infrequent updates to the mayavi PyPI version (sometimes over a year apart).
