### PR TITLE
MAINT: Build wheel against latest VTK, test against older

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -1,0 +1,121 @@
+name: Wheel
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+
+# Build a pure-Python wheel per OS against the latest VTK (the generated TVTK
+# classes differ per platform: X11 vs Cocoa vs Win32), then test each against
+# older VTK runtimes -- a prerequisite for distributing wheels on PyPI.
+jobs:
+  build:
+    name: Build wheel (latest VTK, ${{ matrix.os }})
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
+    steps:
+    - uses: actions/checkout@v7.0.0
+      with:
+        persist-credentials: false
+        # full history so setuptools_scm can derive the version from tags
+        fetch-depth: 0
+    - uses: actions/setup-python@v6.3.0
+      with:
+        python-version: '3.14'
+    - name: Build sdist and wheel
+      # build isolation installs the latest VTK ("vtk>=9" in
+      # build-system.requires), so the TVTK classes are generated against it
+      run: |
+        python -m pip install --upgrade pip build
+        python -m build
+        ls -alh dist/
+    - name: Check the wheel tag and record the build-time VTK
+      run: python scripts/check_wheel.py dist/*.whl
+    - uses: actions/upload-artifact@v7
+      with:
+        name: wheel-${{ matrix.os }}
+        path: dist/*.whl
+
+  test:
+    # Each OS tests its own wheel.  Rows mirror tests.yml so failures are
+    # attributable to the VTK mismatch, not the environment.  No checkout:
+    # pytest --pyargs runs the installed wheel, which must ship everything
+    # the tests need.
+    name: Test wheel ${{ matrix.os }} ${{ matrix.python-version }} ${{ matrix.qt-api }} ${{ matrix.vtk || 'vtk (latest)' }}
+    needs: build
+    strategy:
+      matrix:
+        include:
+          # Controls at the build-time VTK
+          - os: ubuntu-latest
+            python-version: '3.14'
+            qt-api: 'pyside6'
+          - os: macos-latest
+            python-version: '3.14'
+            qt-api: 'pyside6'
+          - os: windows-latest
+            python-version: '3.14'
+            qt-api: 'pyside6'
+          # Older VTK than the wheel was built with
+          - os: ubuntu-latest
+            python-version: '3.12'
+            qt-api: 'pyside6'
+            vtk: 'vtk==9.5'
+            numpy: 'numpy==2.3' # in1d (used by vtk) removed in 2.4+
+          - os: ubuntu-latest
+            python-version: '3.11'
+            qt-api: 'pyside6'
+            vtk: 'vtk==9.4'
+            numpy: 'numpy==2.3'
+          - os: ubuntu-latest
+            python-version: '3.10'
+            qt-api: 'pyqt6'
+            vtk: 'vtk==9.3'
+          - os: ubuntu-latest
+            python-version: '3.10'
+            qt-api: 'pyqt5'
+            vtk: 'vtk==9.2.5'
+      fail-fast: false
+    defaults:
+      run:
+        shell: bash
+    timeout-minutes: 30
+
+    runs-on: ${{ matrix.os }}
+
+    env:
+      ETS_TOOLKIT: qt4
+      QT_API: ${{ matrix.qt-api }}
+      TVTK_VERBOSE: 'true'
+      VTK_PARSER_VERBOSE: 'true'
+      PYTHONUNBUFFERED: '1'
+
+    steps:
+    - uses: pyvista/setup-headless-display-action@v4
+      with:
+        qt: true
+    - uses: actions/setup-python@v6.3.0
+      with:
+        python-version: ${{ matrix.python-version }}
+    - uses: actions/download-artifact@v8
+      with:
+        name: wheel-${{ matrix.os }}
+        path: dist
+    - name: Install dependencies and the wheel
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade ${{ matrix.qt-api }} "${{ matrix.numpy || 'numpy' }}" "${{ matrix.vtk || 'vtk' }}" pillow pytest pytest-timeout --only-binary="numpy,vtk"
+        python -m pip install dist/*.whl
+    - name: Import smoke test
+      run: |
+        python -c "import vtk; from tvtk.api import tvtk; print('Runtime VTK:', vtk.vtkVersion().GetVTKVersion()); print(tvtk.ConeSource())"
+    - run: pytest -v --timeout=10 --pyargs mayavi
+    - run: pytest -sv --timeout=60 --pyargs tvtk

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -140,9 +140,35 @@ jobs:
     - run: pytest -sv --timeout=60 --pyargs tvtk
       working-directory: ${{ env.PYTEST_DIR }}
 
+  check:
+    name: Check dists
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        shell: bash
+    steps:
+    - uses: actions/download-artifact@v8
+      with:
+        pattern: wheel-*
+        merge-multiple: true
+        path: dist
+    - uses: actions/download-artifact@v8
+      with:
+        name: sdist
+        path: dist
+    - uses: actions/setup-python@v6.3.0
+      with:
+        python-version: '3.14'
+    - run: |
+        python -m pip install --upgrade pip twine
+        ls -alh dist/
+        twine check --strict dist/*
+
   publish:
     name: Publish to PyPI
-    needs: [build, test]
+    needs: [build, test, check]
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     # Trusted publishing (OIDC); the "pypi" environment must be configured

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -5,6 +5,8 @@ concurrency:
 
 on:
   pull_request:
+  release:
+    types: [published]
 
 # Build a pure-Python wheel per OS against the latest VTK (the generated TVTK
 # classes differ per platform: X11 vs Cocoa vs Win32), then test each against
@@ -43,6 +45,11 @@ jobs:
       with:
         name: wheel-${{ matrix.os }}
         path: dist/*.whl
+    - uses: actions/upload-artifact@v7
+      if: matrix.os == 'ubuntu-latest'
+      with:
+        name: sdist
+        path: dist/*.tar.gz
 
   test:
     # Each OS tests its own wheel.  Rows mirror tests.yml so failures are
@@ -117,5 +124,41 @@ jobs:
     - name: Import smoke test
       run: |
         python -c "import vtk; from tvtk.api import tvtk; print('Runtime VTK:', vtk.vtkVersion().GetVTKVersion()); print(tvtk.ConeSource())"
+    - name: Pick a test directory on the install drive
+      # apptools persistence cannot relativize paths across Windows drives,
+      # so run tests from the drive holding site-packages (C:), not the
+      # workspace (D:)
+      run: |
+        if [[ "$RUNNER_OS" == "Windows" ]]; then
+          mkdir -p /c/mayavi-tests
+          echo "PYTEST_DIR=C:\\mayavi-tests" | tee -a $GITHUB_ENV
+        else
+          echo "PYTEST_DIR=$PWD" | tee -a $GITHUB_ENV
+        fi
     - run: pytest -v --timeout=10 --pyargs mayavi
+      working-directory: ${{ env.PYTEST_DIR }}
     - run: pytest -sv --timeout=60 --pyargs tvtk
+      working-directory: ${{ env.PYTEST_DIR }}
+
+  publish:
+    name: Publish to PyPI
+    needs: [build, test]
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    # Trusted publishing (OIDC); the "pypi" environment must be configured
+    # on PyPI and in the repo settings
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+    - uses: actions/download-artifact@v8
+      with:
+        pattern: wheel-*
+        merge-multiple: true
+        path: dist
+    - uses: actions/download-artifact@v8
+      with:
+        name: sdist
+        path: dist
+    - run: ls -alh dist/
+    - uses: pypa/gh-action-pypi-publish@release/v1

--- a/mayavi/modules/volume.py
+++ b/mayavi/modules/volume.py
@@ -58,7 +58,9 @@ def find_volume_mappers():
                 try:
                     klass = getattr(tvtk, name)
                     inst = klass()
-                except TypeError:
+                # AttributeError: wrapped class is not in the runtime VTK
+                # (TVTK classes may be generated against a newer VTK)
+                except (TypeError, AttributeError):
                     pass
                 else:
                     res.append(name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,9 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mayavi"
-dynamic = ["version"]
+# dependencies computed in setup.py: wheels cap VTK at the build-time
+# version's next minor, the sdist stays uncapped (PEP 643)
+dynamic = ["version", "dependencies"]
 description = "3D scientific data visualization library and application"
 readme = "README.rst"
 requires-python = ">=3.10"
@@ -39,21 +41,6 @@ classifiers = [
     "Topic :: Software Development",
     "Topic :: Software Development :: Libraries",
 ]
-dependencies = [
-    "apptools",
-    "configobj",
-    "envisage",
-    "numpy",
-    "pyface>=6.1.1",
-    "pygments",  # only needed for the Qt backend but we add it anyway
-    "traits>=6.0.0",
-    "traitsui>=7.0.0",
-    "packaging",
-    "importlib_resources; python_version<'3.11'",
-    "vtk",
-    "puremagic",
-]
-
 [project.optional-dependencies]
 app = ["envisage"]
 

--- a/scripts/check_wheel.py
+++ b/scripts/check_wheel.py
@@ -1,0 +1,33 @@
+"""Sanity-check a built mayavi wheel (used by the Wheel CI workflow).
+
+Checks that the wheel is pure Python but platform-tagged (manylinux on
+Linux), shows the VTK requirement, and prints the VTK version the TVTK
+classes were generated against.
+"""
+
+import io
+import os
+import sys
+import zipfile
+
+
+def main(whl):
+    name = os.path.basename(whl)
+    print('Wheel:', name)
+    # pure Python (py3-none) but platform-tagged (not "any")
+    assert '-py3-none-' in name and not name.endswith('-any.whl'), name
+    if sys.platform == 'linux':  # PyPI rejects plain linux_* tags
+        assert '-manylinux_' in name, name
+    with zipfile.ZipFile(whl) as w:
+        meta = next(n for n in w.namelist()
+                    if n.endswith('.dist-info/METADATA'))
+        for line in w.read(meta).decode().splitlines():
+            if line.startswith('Requires-Dist') and 'vtk' in line:
+                print(line)
+        inner = io.BytesIO(w.read('tvtk/tvtk_classes.zip'))
+    with zipfile.ZipFile(inner) as z:
+        print(z.read('tvtk_classes/vtk_version.py').decode())
+
+
+if __name__ == '__main__':
+    main(*sys.argv[1:])

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,8 @@
 # Copyright (c) 2008-2022 by Enthought, Inc.
 # All rights reserved.
 
-from setuptools import Command, setup
+from setuptools import Command, Distribution, setup
+from setuptools.command.bdist_wheel import bdist_wheel
 from setuptools.command.build_py import build_py
 from setuptools.command.develop import develop
 
@@ -243,6 +244,27 @@ class MyDevelop(develop):
         super().run()
 
 
+class MyDistribution(Distribution):
+    """Claim ext modules so the whole build/install/wheel path uses the
+    platlib layout: the code is pure Python, but the generated TVTK classes
+    are platform-specific (X11 vs Cocoa vs Win32)."""
+
+    def has_ext_modules(self):
+        return True
+
+
+class MyBdistWheel(bdist_wheel):
+    """Tag wheels py3-none-<platform> (pure Python, platform-specific)."""
+
+    def get_tag(self):
+        _, _, plat = super().get_tag()
+        # PyPI rejects plain linux_* tags; with no native code any glibc
+        # floor is valid, so use manylinux_2_17 (understood by pip >= 20.3)
+        if plat.startswith('linux_'):
+            plat = plat.replace('linux_', 'manylinux_2_17_', 1)
+        return 'py3', 'none', plat
+
+
 ###########################################################################
 # Similar to package_data, but installed before build
 build_package_data = {
@@ -258,15 +280,51 @@ for package, files in build_package_data.items():
 
 ###########################################################################
 
-# The actual setup call.  All static metadata now lives in pyproject.toml;
-# setup.py only carries the imperative build hooks (TVTK class generation and
-# the doc-building commands).
+# Dependencies are dynamic (PEP 643): tvtk_classes.zip bakes in the
+# build-time VTK API.  Older runtimes degrade gracefully but newer ones may
+# remove API the generated code references, so wheels cap VTK at the next
+# minor.  The sdist generates against the installer's VTK, so no cap.
+DEPENDENCIES = [
+    'apptools',
+    'configobj',
+    'envisage',
+    'numpy',
+    'pyface>=6.1.1',
+    'pygments',  # only needed for the Qt backend but we add it anyway
+    'traits>=6.0.0',
+    'traitsui>=7.0.0',
+    'packaging',
+    "importlib_resources; python_version<'3.11'",
+    'puremagic',
+]
+
+
+def vtk_requirement():
+    """The VTK requirement, with an upper bound when building a wheel."""
+    if 'sdist' in sys.argv[1:]:
+        return 'vtk'
+    try:
+        import vtk
+    except ImportError:
+        # no VTK at metadata time: leave uncapped rather than error (class
+        # generation will fail later anyway unless reusing a fresh ZIP)
+        return 'vtk'
+    version = vtk.vtkVersion()
+    return 'vtk<%d.%d' % (version.GetVTKMajorVersion(),
+                          version.GetVTKMinorVersion() + 1)
+
+
+# Static metadata lives in pyproject.toml; setup.py carries only the dynamic
+# dependencies and the imperative build hooks.
 if __name__ == '__main__':
     setup(
+        distclass=MyDistribution,
         cmdclass={
+            'bdist_wheel': MyBdistWheel,
             'build_py': MyBuildPy,
             'develop': MyDevelop,
             'gen_docs': GenDocs,
             'build_docs': BuildDocs,
         },
+        install_requires=DEPENDENCIES + [vtk_requirement()],
     )

--- a/tvtk/tests/test_tvtk.py
+++ b/tvtk/tests/test_tvtk.py
@@ -162,7 +162,12 @@ class TestTVTK(unittest.TestCase):
         for t, g in p._updateable_traits_:
             if g == "GetEdgeOpacity":
                 continue  # broken for some reason?
-            val = getattr(p._vtk_obj, g)()
+            vtk_get = getattr(p._vtk_obj, g, None)
+            if vtk_get is None:
+                # getter from a newer VTK than the runtime one (TVTK
+                # classes may be generated against a newer VTK)
+                continue
+            val = vtk_get()
             if t in ['representation', 'interpolation']:
                 self.assertEqual(val, getattr(p, t + '_'))
             else:

--- a/tvtk/tests/test_tvtk.py
+++ b/tvtk/tests/test_tvtk.py
@@ -968,7 +968,7 @@ class TestTVTKModule(unittest.TestCase):
             for trait_name in obj._full_traitnames_list_:
                 try:
                     trait = getattr(obj, trait_name)
-                except (TypeError, TraitError):
+                except (TypeError, TraitError, AttributeError):
                     pass  # this is tested in another test
                 else:
                     if isinstance(trait, str) and trait.endswith('_p_void'):
@@ -997,6 +997,11 @@ class TestTVTKModule(unittest.TestCase):
                 try:
                     trait = getattr(obj, trait_name)
                 except Exception as exception:
+                    if (isinstance(exception, AttributeError)
+                            and tvtk_base.vtk_version_mismatch()):
+                        # property backed by a VTK getter that does not
+                        # exist in the (older) runtime VTK
+                        continue
                     errors_getting_trait.append(
                         (tvtk_klass_name, trait_name, str(exception)))
 

--- a/tvtk/tvtk_access.py
+++ b/tvtk/tvtk_access.py
@@ -28,9 +28,6 @@ if not ( exists(tvtk_class_dir) and isdir(tvtk_class_dir)
         "Unable to find either a directory: %s or a file: %s "
         "with the TVTK classes." % (tvtk_class_dir, _zip) )
 
-# Check if the VTK version is the same as that used to build TVTK.
-from tvtk.tvtk_classes.vtk_version import vtk_build_version
-
 # Make sure VTK is installed.
 try:
     import vtk
@@ -40,14 +37,9 @@ except ImportError as m:
          % (m, '_'*80)
     raise ImportError(msg)
 
-vtk_version = vtk.vtkVersion().GetVTKVersion()[:3]
-if vtk_version != vtk_build_version:
-    msg = '*'*80 + "\n" + \
-          'WARNING: Imported VTK version (%s) does not match the one used\n'\
-          '         to build the TVTK classes (%s). This may cause problems.\n'\
-          '         Please rebuild TVTK.\n'%(vtk_version, vtk_build_version) +\
-          '*'*80 + '\n'
-    print(msg)
+# Note: no check that the imported VTK matches the version the TVTK classes
+# were generated against (tvtk_classes/vtk_version.py) -- wheels are generated
+# against the latest VTK and are expected to run against older ones.
 
 # Now setup TVTK itself.
 from tvtk.tvtk_classes import tvtk_helper

--- a/tvtk/tvtk_base.py
+++ b/tvtk/tvtk_base.py
@@ -54,6 +54,28 @@ def FileEditor(*args, **kw):
 
 
 ######################################################################
+# VTK version mismatch detection.
+######################################################################
+
+_vtk_version_mismatch = None
+
+
+def vtk_version_mismatch():
+    """True when the runtime VTK differs from the VTK the TVTK classes
+    were generated against (e.g. a wheel built against a newer VTK)."""
+    global _vtk_version_mismatch
+    if _vtk_version_mismatch is None:
+        try:
+            from tvtk.tvtk_classes.vtk_version import vtk_build_version
+        except ImportError:
+            _vtk_version_mismatch = False
+        else:
+            _vtk_version_mismatch = (
+                vtk.vtkVersion().GetVTKVersion()[:3] != vtk_build_version)
+    return _vtk_version_mismatch
+
+
+######################################################################
 # The TVTK object cache.
 ######################################################################
 
@@ -590,6 +612,12 @@ class TVTKBase(traits.HasStrictTraits):
                     setattr(self, name, val)
                 except traits.TraitError:
                     if name in self._allow_update_failure_:
+                        pass
+                    elif vtk_version_mismatch():
+                        # The trait definitions were generated against a
+                        # different VTK, so values read from the runtime
+                        # object may no longer validate (type/range drift
+                        # across VTK versions); keep the generated default.
                         pass
                     else:
                         raise

--- a/tvtk/vtk_parser.py
+++ b/tvtk/vtk_parser.py
@@ -174,7 +174,12 @@ class VTKMethodParser:
 
     def get_methods(self, klass):
         """Returns all the relevant methods of the given VTK class."""
-        methods = dir(klass)[:]
+        # VTK API methods are CamelCase; drop the snake_case aliases and
+        # pipeline dunders (__call__, __rshift__, ...) that VTK >= 9.4 adds
+        # to dir().  Otherwise they generate duplicate/garbage wrappers that
+        # delegate to attributes older runtime VTKs do not have (e.g.
+        # update() calling self._vtk_obj.update, which VTK < 9.4 lacks).
+        methods = [m for m in dir(klass) if m[:1].isupper()]
         if hasattr(klass, '__members__'):
             # Only VTK versions < 4.5 have these.
             for m in klass.__members__:

--- a/tvtk/wrapper_gen.py
+++ b/tvtk/wrapper_gen.py
@@ -1755,6 +1755,14 @@ class WrapperGenerator:
             True, True, '_write_graph_mapper_icon_size'
         ),
 
+        # Parametric coords are intrinsic geometry, not configuration, and
+        # reading them from a default-constructed vtkHigherOrder* cell
+        # segfaults on VTK <= 9.4, so expose a read-only property and never
+        # sync the value in update_traits.
+        r'[a-zA-Z0-9]+\.ParametricCoords$': (
+            False, False, '_write_any_parametric_coords'
+        ),
+
         # In VTK 8.x, HyperTreeGridCellCenter's Get/Set VertexCells is supposed
         # to be a boolean but the initialized value can be an arbitrary
         # integer.
@@ -1980,6 +1988,16 @@ class WrapperGenerator:
         name = self._reform_name(vtk_attr_name)
         vtk_set_meth = getattr(klass, 'Set' + vtk_attr_name)
         self._write_trait(out, name, t_def, vtk_set_meth, mapped=False)
+
+    def _write_any_parametric_coords(self, klass, out, vtk_attr_name):
+        if vtk_attr_name != 'ParametricCoords':
+            raise RuntimeError("Not sure why you ask for me! "
+                               "I only deal with ParametricCoords. "
+                               "Panicking.")
+
+        name = self._reform_name(vtk_attr_name)
+        vtk_get_meth = getattr(klass, 'Get' + vtk_attr_name)
+        self._write_property(out, name, vtk_get_meth, None)
 
     def _write_graph_mapper_icon_size(self, klass, out, vtk_attr_name):
         if vtk_attr_name != 'IconSize':

--- a/tvtk/wrapper_gen.py
+++ b/tvtk/wrapper_gen.py
@@ -1748,6 +1748,13 @@ class WrapperGenerator:
             True, True, '_write_smart_volume_mapper_vector_component'
         ),
 
+        # On VTK < 9.6, vtkGraphMapper.GetIconSize returns an unwrapped
+        # int* (a pointer repr string in Python), so updating from the
+        # runtime object must be allowed to fail.
+        'vtkGraphMapper.IconSize$': (
+            True, True, '_write_graph_mapper_icon_size'
+        ),
+
         # In VTK 8.x, HyperTreeGridCellCenter's Get/Set VertexCells is supposed
         # to be a boolean but the initialized value can be an arbitrary
         # integer.
@@ -1970,6 +1977,17 @@ class WrapperGenerator:
         t_def = ('traits.Trait({default}, traits.Range{rng}, '
                  'enter_set=True, auto_set=False)').format(default=default,
                                                            rng=rng)
+        name = self._reform_name(vtk_attr_name)
+        vtk_set_meth = getattr(klass, 'Set' + vtk_attr_name)
+        self._write_trait(out, name, t_def, vtk_set_meth, mapped=False)
+
+    def _write_graph_mapper_icon_size(self, klass, out, vtk_attr_name):
+        if vtk_attr_name != 'IconSize':
+            raise RuntimeError("Not sure why you ask for me! "
+                               "I only deal with IconSize. Panicking.")
+
+        t_def = ('traits.Array(enter_set=True, auto_set=False, '
+                 'shape=(None,), dtype="int", value=(1, 1), cols=2)')
         name = self._reform_name(vtk_attr_name)
         vtk_set_meth = getattr(klass, 'Set' + vtk_attr_name)
         self._write_trait(out, name, t_def, vtk_set_meth, mapped=False)


### PR DESCRIPTION
Trying a strategy to distribute a `py3-<plat>` wheel: 

1. Build against newest VTK, one per OS (macOS, Linux, Windows)
2. Pin in the wheel `vtk<` that version (using dynamic dependencies in the wheel build)
3. Test in CIs that this wheel actually works for our test suite against the older VTK versions

This should make things easier on end users, assuming it works okay. I think we can rely on the CI scheme to tell us if it has a good chance of success. If it's a failure, we can revert. But I think it's worth trying!