### PR TITLE
Require VTK >= 9.4 (SPEC0), unify workarounds, and add CLAUDE.md

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,19 +28,15 @@ jobs:
             vtk: 'vtk==9.5'
             numpy: 'numpy==2.3' # in1d (used by vtk) removed in 2.4+
           - python-version: '3.11'
-            qt-api: 'pyside6'
+            qt-api: 'pyqt6'
             os: ubuntu-latest
             vtk: 'vtk==9.4'
             numpy: 'numpy==2.3'
-          - python-version: '3.10'
-            qt-api: 'pyqt6'
-            os: ubuntu-latest
-            vtk: 'vtk==9.3'
           # Oldest supported Python, VTK, and Qt bindings
           - python-version: '3.10'
             qt-api: 'pyqt5'
             os: ubuntu-latest
-            vtk: 'vtk==9.2.5'
+            vtk: 'vtk==9.4'
           # No display server / Qt toolkit at all
           - python-version: '3.14'
             os: ubuntu-latest

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -79,17 +79,13 @@ jobs:
             numpy: 'numpy==2.3' # in1d (used by vtk) removed in 2.4+
           - os: ubuntu-latest
             python-version: '3.11'
-            qt-api: 'pyside6'
+            qt-api: 'pyqt6'
             vtk: 'vtk==9.4'
             numpy: 'numpy==2.3'
           - os: ubuntu-latest
             python-version: '3.10'
-            qt-api: 'pyqt6'
-            vtk: 'vtk==9.3'
-          - os: ubuntu-latest
-            python-version: '3.10'
             qt-api: 'pyqt5'
-            vtk: 'vtk==9.2.5'
+            vtk: 'vtk==9.4'
       fail-fast: false
     defaults:
       run:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,86 @@
+# Mayavi / TVTK development notes
+
+Mayavi is a 3D scientific visualization application/library; TVTK is its
+traits-aware wrapping of VTK.  Both live in this repo and ship together in
+one package.
+
+## Layout
+
+- `tvtk/` — the VTK wrapper layer.  Wrapper classes are **generated at
+  build time** by introspecting the installed VTK and are packed into
+  `tvtk/tvtk_classes.zip` (never committed, excluded from the sdist).
+  - Generation pipeline: `code_gen.py` (driver) → `vtk_parser.py`
+    (introspects classes/methods/defaults) → `wrapper_gen.py` (emits trait
+    definitions) → `special_gen.py` (emits `tvtk_helper` + hand-written
+    classes).
+  - Runtime: `tvtk_access.py` loads the zip lazily; `tvtk_base.py` is the
+    base class (trait syncing via `update_traits`); `vtk_module.py` is the
+    single import point for VTK and removes classes broken on specific
+    runtime VTKs.
+- `mayavi/` — the application/library built on top of tvtk.
+- All VTK bug workarounds are organized in layers — **read
+  `tvtk/WORKAROUNDS.md` before adding one or debugging a generation crash**.
+
+## Versioning and wheels
+
+- Supported VTK floor: `MIN_VTK` in `setup.py` (SPEC 0-style ~2-year
+  window).  When bumping it, cull workarounds per `tvtk/WORKAROUNDS.md`.
+- Wheels are pure Python but **platform-tagged** (`py3-none-manylinux…/
+  macosx…/win_amd64`) because the generated classes differ per OS
+  (X11/Cocoa/Win32).  `MyBdistWheel` in `setup.py` handles the tags.
+- Wheels are generated against the **latest** VTK and must run against all
+  supported older ones.  Version mismatch between generation and runtime is
+  an expected, supported state: `tvtk_base.vtk_version_mismatch()` gates
+  runtime tolerances.  The generation VTK is recorded in
+  `tvtk_classes/vtk_version.py` inside the zip.
+- Dependencies are PEP 643 dynamic (`setup.py`): the wheel gets
+  `vtk>=MIN_VTK,<{next minor of the build VTK}`; the sdist stays uncapped
+  above the floor.
+
+## Building and testing locally
+
+```sh
+# Editable install (generates the zip against your installed VTK, ~3 min)
+pip install --no-build-isolation -ve .
+# Full artifacts (sdist + wheel); build isolation pulls the latest VTK
+python -m build
+# Test suites (CI runs exactly these)
+pytest -v --timeout=10 mayavi
+pytest -sv --timeout=60 tvtk
+```
+
+- Regeneration is skipped if `tvtk/tvtk_classes.zip` is < 120 s old
+  (`_tvtk_built_recently` in `setup.py`).
+- To test against an older VTK: `uv venv -p 3.11 && uv pip install
+  "vtk==9.x.*" <wheel>`, then `pytest --pyargs tvtk mayavi` from *outside*
+  the repo (so the source tree does not shadow the installed wheel — the
+  source tree has no zip).  Note: VTK 9.2.x on macOS arm64 aborts at
+  interpreter exit; use Linux CI for those.
+- Inspect generated code without installing: the wheel contains
+  `tvtk/tvtk_classes.zip`; read members with `zipfile` (nested zip).
+- Generation segfaults: `VTK_PARSER_VERBOSE=1` prints each getter before
+  calling it; see `tvtk/WORKAROUNDS.md`.
+
+## CI (`.github/workflows/`)
+
+- `tests.yml` — same-version matrix: build + test with the *same* VTK
+  (latest on all OSes; older VTK/Python/Qt rows on Linux; one headless row
+  with `ETS_TOOLKIT=null`).
+- `wheel.yml` — mismatch matrix: build per-OS wheels against latest VTK,
+  test them against all supported older VTKs (rows deliberately mirror
+  `tests.yml` so failures are attributable to the mismatch), `twine check
+  --strict`, and trusted publishing to PyPI on GitHub releases
+  (environment `pypi`, `needs: [build, test, check]`).
+- Windows test jobs run pytest from `C:\` (site-packages drive): apptools
+  persistence cannot relativize paths across drives.
+
+## Gotchas
+
+- `tvtk` class loading is lazy (one property per class in `tvtk_helper`);
+  missing classes only fail when touched, and `wrap_vtk` falls back to the
+  nearest wrapped base class for unknown runtime classes.
+- Generated docstrings/signatures use snake_case names (tvtk rewrites VTK
+  docs), but the emitted code must call CamelCase VTK methods — VTK's own
+  snake_case aliases only exist on >= 9.4.
+- `mayavi/__init__.py` reads the version from installed package metadata;
+  the version itself comes from git tags via setuptools_scm.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=77",
     "setuptools_scm>=8",
-    "vtk>=9",
+    "vtk>=9.4",
     "numpy",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -299,19 +299,23 @@ DEPENDENCIES = [
 ]
 
 
+# Oldest supported VTK, per SPEC 0-style two-year support window
+MIN_VTK = '9.4'
+
+
 def vtk_requirement():
     """The VTK requirement, with an upper bound when building a wheel."""
     if 'sdist' in sys.argv[1:]:
-        return 'vtk'
+        return 'vtk>=%s' % MIN_VTK
     try:
         import vtk
     except ImportError:
         # no VTK at metadata time: leave uncapped rather than error (class
         # generation will fail later anyway unless reusing a fresh ZIP)
-        return 'vtk'
+        return 'vtk>=%s' % MIN_VTK
     version = vtk.vtkVersion()
-    return 'vtk<%d.%d' % (version.GetVTKMajorVersion(),
-                          version.GetVTKMinorVersion() + 1)
+    return 'vtk>=%s,<%d.%d' % (MIN_VTK, version.GetVTKMajorVersion(),
+                               version.GetVTKMinorVersion() + 1)
 
 
 # Static metadata lives in pyproject.toml; setup.py carries only the dynamic

--- a/tvtk/WORKAROUNDS.md
+++ b/tvtk/WORKAROUNDS.md
@@ -14,6 +14,12 @@ layer that can express it.
 - Every workaround MUST have a comment naming the VTK version(s) it applies
   to, ideally with an upstream issue/MR link.  When the floor passes that
   version, the workaround should be culled.
+- **Culling requires the right evidence for the bug class.**  Deterministic
+  bugs (method removed, API changed) can be verified by probing any one
+  platform.  *Uninitialized-value* bugs are platform-dependent — garbage
+  memory on Linux can read as a perfectly sane value on macOS — so they may
+  only be culled with probes from every platform (in practice: let CI's
+  Linux jobs vote) or a fix confirmed in the VTK changelog.
 - Wheels are generated against the *latest* VTK and must run against all
   supported older ones (see `.github/workflows/wheel.yml`), so a workaround
   for an old VTK often must be **unconditional at generation time** (the

--- a/tvtk/WORKAROUNDS.md
+++ b/tvtk/WORKAROUNDS.md
@@ -1,0 +1,107 @@
+# Where VTK workarounds live
+
+TVTK wraps VTK by introspecting the installed VTK at build time and
+generating traits-based wrapper classes into `tvtk_classes.zip`.  VTK has
+bugs — uninitialized values, getters that segfault, API drift between
+versions — and every workaround for those lives in one of the layers below.
+The layers are ordered roughly by preference: fix a problem in the earliest
+layer that can express it.
+
+## Policy
+
+- The supported VTK floor is `MIN_VTK` in `setup.py` (SPEC 0-style: minor
+  versions are supported for ~2 years after release).
+- Every workaround MUST have a comment naming the VTK version(s) it applies
+  to, ideally with an upstream issue/MR link.  When the floor passes that
+  version, the workaround should be culled.
+- Wheels are generated against the *latest* VTK and must run against all
+  supported older ones (see `.github/workflows/wheel.yml`), so a workaround
+  for an old VTK often must be **unconditional at generation time** (the
+  generating VTK is new) but tolerant **at runtime** (the running VTK may be
+  old).  Generation-time version conditionals only affect sdist builds on
+  older VTK.
+
+## Layer 1: `vtk_parser.py` — generation-time introspection guards
+
+The parser instantiates every VTK class and calls its `Get*` methods to
+discover defaults and ranges.  Guards here prevent the *generator itself*
+from crashing or producing garbage:
+
+- `get_methods()`: only CamelCase names are wrapped (drops VTK >= 9.4
+  snake_case aliases and pipeline dunders); skip lists for methods that
+  crash/hang when probed (e.g. vtkIOSSReader getters, vtkDataEncoder).
+- `_find_get_set_methods()`: per-class/method skips, and version-keyed
+  "broken getter -> no default" entries near the end (grep `Broken in`).
+- Windowed classes (`vtkRenderWindow`, VR interactors) are never
+  default-probed on VTK >= 9.5 (realizing + destroying a window segfaults).
+
+Debugging a generation crash: set `VTK_PARSER_VERBOSE=1` (prints each
+`Get*` call before making it; the last line printed is the culprit) and
+optionally `VTK_PARSER_GC=1`.  `faulthandler` is enabled during generation.
+
+## Layer 2: `wrapper_gen.py` `special_traits` — per-attribute overrides
+
+The **preferred registry** for "this specific trait misbehaves": a dict
+mapping regex `vtkClass.Attribute` to `(updateable, allow_update_failure,
+writer_method)`:
+
+- `updateable=False`: `update_traits()` never reads the getter at
+  instantiation (use for getters that crash or return garbage on a fresh
+  object, e.g. `ParametricCoords`).
+- `allow_update_failure=True`: the getter is read but a `TraitError` while
+  syncing is tolerated (use for type/range drift, e.g. `GraphMapper.IconSize`
+  on VTK < 9.6).
+- The writer method controls the emitted trait definition.
+
+`wrapper_gen.py` also carries older inline `if klass.__name__ == ...`
+conditionals in `_gen_state_methods()` (bad defaults, out-of-choice enum
+values).  Prefer `special_traits` for new cases.
+
+## Layer 3: `vtk_module.py` — runtime class removal
+
+For classes that crash or hang *whenever used* on a specific runtime VTK,
+`del` the name keyed on the runtime version.  This hides the class from
+code generation (`code_gen.py` checks `hasattr(vtk, name)`) and from
+`tvtk.<Name>` at runtime; `wrap_vtk` falls back to the nearest wrapped base
+class for objects of removed classes.
+
+## Layer 4: `tvtk_base.py` — runtime tolerances
+
+`update_traits()` (syncing trait values from the wrapped VTK object at
+instantiation) tolerates, in order:
+
+- `AttributeError`/`TypeError` from the getter (method missing on an older
+  runtime VTK, or needs arguments);
+- `TraitError` when the trait is in the generated
+  `_allow_update_failure_` tuple (from `special_traits`);
+- `TraitError` when `vtk_version_mismatch()` is true, i.e. the classes were
+  generated against a different VTK than the one running (the wheel case) —
+  cross-version type/range drift keeps the generated default.
+
+Same-version builds stay strict so generation bugs surface in CI.
+
+## Layer 5: `special_gen.py` and `tvtk/custom/` — hand-written classes
+
+`special_gen.py` writes `tvtk_helper` plus hand-tuned overrides for a few
+classes (`Matrix4x4`/`Property` pickling, `Collection` iteration,
+`DataArray`/`Points` indexing).  A module placed in `tvtk/custom/` takes
+import priority over the generated class of the same name (currently
+empty — the escape hatch of last resort for whole-class replacement).
+
+## Layer 6: `tests/test_tvtk.py` — test-level skips
+
+Only for VTK bugs that cannot be worked around without losing
+functionality (e.g. instantiating windowed classes on >= 9.5 segfaults at
+destruction) or for expected degradation when running version-mismatched
+(getters/properties backed by API the older runtime lacks).  Keep skips
+keyed on `vtk_version` / `vtk_version_mismatch()` and commented.
+
+## Auditing
+
+When bumping `MIN_VTK`, grep these files for version citations and probe
+whether each workaround still reproduces on the new floor:
+
+```
+grep -nE "9\.[0-9]|VTK [0-9]" tvtk/vtk_parser.py tvtk/wrapper_gen.py \
+    tvtk/vtk_module.py tvtk/tvtk_base.py tvtk/tests/test_tvtk.py
+```

--- a/tvtk/code_gen.py
+++ b/tvtk/code_gen.py
@@ -12,7 +12,7 @@ point to the culprit, which often needs to be worked around in
 ``vtk_parser.py::VTKMethodParser._find_get_set_methods``.
 
 Exceptions to behaviors based on VTK versions and bugs etc. live in ``wrapper_gen.py``
-and ``tvtk_parser.py``.
+and ``vtk_parser.py``.
 """
 # Author: Prabhu Ramachandran
 # Copyright (c) 2004-2020, Enthought, Inc.

--- a/tvtk/special_gen.py
+++ b/tvtk/special_gen.py
@@ -221,7 +221,7 @@ class SpecialGenerator:
                     yield tuple([obj.GetComponent(i, x) for x in range(nc)])
 
         def _check_key(self, key, n):
-            if type(key) not in [int, long]:
+            if not isinstance(key, int):
                 raise TypeError("Only integers are valid keys.")
             if key < 0:
                 key =  n + key
@@ -324,7 +324,7 @@ class SpecialGenerator:
             ##############################################
             # Allow int and long keys. Fixes GH Issue 173.
             ##############################################
-            if not isinstance(key, (int, long)):
+            if not isinstance(key, int):
                 raise TypeError("Only int and long are valid keys.")
             if key < 0:
                 key =  n + key

--- a/tvtk/vtk_module.py
+++ b/tvtk/vtk_module.py
@@ -25,45 +25,19 @@ except ImportError:
 
 
 vtk_version = vtkVersion.GetVTKVersion()
-SKIP = []
 
-if vtk_version in ['9.0.3', '9.0.2']:
-    # Cause problems if used so ignore these.
-    SKIP = ['vtkDataEncoder', 'vtkWebApplication']
-    del vtkDataEncoder, vtkWebApplication
-
-if vtk_version == '9.1.0':
-    SKIP = ['vtkOpenGLAvatar']
-    try:
-        del vtkOpenGLAvatar
-    except NameError:
-        pass
-
-if vtk_version == '9.2.0':
-    SKIP = ['vtkPlotBar']
-    try:
-        del vtkPlotBar
-    except NameError:
-        pass
-
-if vtk_version.startswith('9.3'):
-    # Cannot instantiate (TypeError) on Linux at least
-    SKIP = ['vtkDGBoundsResponder', "vtkDGOpenGLRenderer", "vtkDGSidesResponder"]
-    try:
-        del vtkDGBoundsResponder, vtkDGOpenGLRenderer, vtkDGSidesResponder
-    except NameError:
-        pass
-
+# Remove classes that crash or hang when wrapped on a specific runtime VTK.
+# Deleting the name here hides the class from code generation (code_gen.py
+# checks hasattr) and from wrapping.  See tvtk/WORKAROUNDS.md for the full
+# map of where VTK workarounds live.
 if vtk_version in ["9.4.0", "9.4.1", "9.4.2"]:
     # Instantiating these using TVTK causes a crash on VTK 9.4.x so skipping.
-    SKIP = ['vtkIOSSReader', 'vtkIOSSCellGridReader']
     try:
         del vtkIOSSReader, vtkIOSSCellGridReader
     except NameError:
         pass
     if vtk_version == "9.4.2":
         # vtkXOpenGLRenderWindow segfaults when being deconstructed on 9.4.2
-        SKIP += ["vtkXOpenGLRenderWindow"]
         try:
             del vtkXOpenGLRenderWindow
         except NameError:

--- a/tvtk/vtk_parser.py
+++ b/tvtk/vtk_parser.py
@@ -180,10 +180,6 @@ class VTKMethodParser:
         # delegate to attributes older runtime VTKs do not have (e.g.
         # update() calling self._vtk_obj.update, which VTK < 9.4 lacks).
         methods = [m for m in dir(klass) if m[:1].isupper()]
-        if hasattr(klass, '__members__'):
-            # Only VTK versions < 4.5 have these.
-            for m in klass.__members__:
-                methods.remove(m)
         # Ignore the parent methods.
         ignore = self._get_parent_methods(klass)
 
@@ -246,11 +242,6 @@ class VTKMethodParser:
             ignore.extend(['GetProp', 'SetProp'])
         if 'GetViewProps' in methods and 'GetProps' in methods:
             ignore.extend(['GetProps', 'SetProps'])
-        # Remove any deprecated traits.
-        if 'GetScaledText' in methods and 'GetTextScaleMode' in methods:
-            ignore.extend(['GetScaledText', 'SetScaledText',
-                           'ScaledTextOn', 'ScaledTextOff'])
-
         # In VTK >= 9.x, a few vtkIOSSReader getters abort with an
         # uncatchable C++ std::runtime_error ("Could not find property
         # '<NAME>'") when called on the inheriting vtkIOSSCellGridReader,
@@ -706,19 +697,9 @@ class VTKMethodParser:
             obj = None if skip_instance else self._get_instance(klass)
             if obj:
                 for key, value in gsm.items():
-                    # Broken in <= 9.3
-                    if (
-                        (vtk_major_version, vtk_minor_version) <= (9, 3)
-                        and f"{klass_name}.Get{key}" in (
-                            "vtkGenericAttributeCollection.GetAttributesToInterpolate",
-                            "vtkPlotBar.GetLookupTable",
-                            "vtkLagrangianParticleTracker.GetIntegrationModel",
-                        )
-                    ):
-                        default = None
                     # Broken in <= 9.4
                     # https://gitlab.kitware.com/vtk/vtk/-/merge_requests/6729#note_732848
-                    elif (
+                    if (
                         (vtk_major_version, vtk_minor_version) <= (9, 4)
                         and f"{klass_name}.Get{key}" in (
                             "vtkHigherOrderTetra.GetParametricCoords",

--- a/tvtk/wrapper_gen.py
+++ b/tvtk/wrapper_gen.py
@@ -86,8 +86,6 @@ def get_trait_def(value, **kwargs):
         dtype = dtypes.pop().__name__ if len(dtypes) == 1 else None
         if dtype == 'int' and sys.platform.startswith('win'):
             dtype = 'int64'
-        elif dtype == 'long':
-            dtype = 'int64'
         dtype = '"{}"'.format(dtype) if dtype is not None else 'None'
 
         cols = len(value)
@@ -147,18 +145,10 @@ def patch_default(vtk_get_meth, vtk_set_meth, default):
     # Some method even has a signature of (["int", "int"], "vtkInformation")
     arg_formats = []
 
-    # Collect the signatures of the get method
-    # We only use the arguments
-    # TODO: Unclear why this would be used... but for example if the Get method
-    # takes a string as an argument, we don't want that to be what we expect the
-    # *output* to be (which can be for example vtkDataArray*). But presumably
-    # this was here for a reason so let's just add exceptions for things that are
-    # known to be problematic on VTK 9.5.2...
+    # Only the Set method's signatures are used: the Get signature's return
+    # type is unreliable for guessing a default (e.g. vtkDataArray* returns,
+    # or getters that take a string argument).
     all_sigs = []
-    #if vtk_get_meth.__name__ not in ("GetGlobalIds", "GetHigherOrderDegrees", "GetNormals", "GetPedigreeIds", "GetProcessIds", "GetRationalWeights", "GetScalars", "GetTCoords", "GetTensors", "GetVectors", "GetTangents"):
-    #    all_sigs.extend(
-    #        vtk_parser.VTKMethodParser.get_method_signature(vtk_get_meth)
-    #    )
 
     # Collect the signatures of the set method
     all_sigs.extend(
@@ -286,12 +276,6 @@ class WrapperGenerator:
             from traitsui.editors.api import InstanceEditor as Editor
             return Editor(view_name="handler.view")
 
-        try:
-            long
-        except NameError:
-            # Silly workaround for Python3.
-            long = int
-
         inf = float('inf')
 
         """
@@ -414,10 +398,6 @@ class WrapperGenerator:
         # want the node's version to be changed).
         d = copy.deepcopy(data)
 
-        # Add support for property trait delegation.
-        #Commented out because of problems.
-        #self._generate_delegates(node, d, out)
-
         toggle, state, get_set = d['toggle'], d['state'], d['get_set']
 
         # Remove unwanted stuff.
@@ -518,27 +498,6 @@ class WrapperGenerator:
 
         self.indent.decr()
 
-    def _generate_delegates(self, node, n_data, out):
-        """This method generates delegates for specific classes.  It
-        modifies the n_data dictionary."""
-        prop_name = {'vtkActor': 'vtkProperty',
-                     'vtkActor2D': 'vtkProperty2D',
-                     'vtkVolume': 'vtkVolumeProperty'}
-        if node.name in prop_name:
-            prop_node = self.get_tree().get_node(prop_name[node.name])
-            prop_data = prop_node.data
-            # Update the data of the node so the view includes the
-            # property traits.
-            code = ''
-            for key in n_data:
-                props = prop_data[key]
-                n_data[key].update(props)
-                # Write the delegates.
-                for p in props:
-                    code += '%s = tvtk_base.vtk_property_delegate\n'%p
-            code += '\n'
-            out.write(self.indent.format(code))
-
     def _gen_toggle_methods(self, klass, out):
         meths = self.parser.get_toggle_methods()
         updateable_traits = {}
@@ -600,10 +559,7 @@ class WrapperGenerator:
 
             # Setting the default value of the traits of these classes
             # Else they are not instantiable
-            if klass.__name__ == 'vtkCellQuality' \
-                    and m == 'QualityMeasure':
-                vtk_val = 1
-            elif klass.__name__ == 'vtkRenderView' \
+            if klass.__name__ == 'vtkRenderView' \
                     and m == 'InteractionMode':
                 vtk_val = 1
             elif klass.__name__ == 'vtkMatrixMathFilter' \
@@ -617,48 +573,10 @@ class WrapperGenerator:
                 vtk_val = 10
 
             if (not hasattr(klass, 'Set' + m)):
-                # Sometimes (very rarely) the VTK method is
-                # inconsistent.  For example in VTK-4.4
-                # vtkExtentTranslator::SetSplitMode does not exist.
-                # In this case wrap it specially.
-                vtk_val = 1
-            if vtk_val == 0 and m in ['DataScalarType', 'OutputScalarType',
-                                      'UpdateExtent']:
-                vtk_val = 2
-
-            # Sometimes, some methods have default values that are
-            # outside the specified choices.  This is to special case
-            # these.
-            extra_val = None
-            if vtk_val == 0 and klass.__name__ == 'vtkGenericEnSightReader' \
-               and m == 'ByteOrder':
-                extra_val = 2
-            if vtk_val == 0 and klass.__name__ == 'vtkImageData' \
-               and m == 'ScalarType':
-                extra_val = list(range(0, 22))
-            if vtk_val == 0 and klass.__name__ == 'vtkImagePlaneWidget' \
-               and m == 'PlaneOrientation':
-                extra_val = 3
-            if (vtk_val == 0) and (klass.__name__ == 'vtkThreshold') \
-               and (m == 'AttributeMode'):
-                extra_val = -1
-            if (sys.platform == 'darwin') and (vtk_val == 0) \
-               and (klass.__name__ == 'vtkRenderWindow') \
-               and (m == 'StereoType'):
-                extra_val = 0
-
-            if not vtk_val:
-                default = self._reform_name(meths[m][0][0])
-                if extra_val is None:
-                    t_def = """tvtk_base.RevPrefixMap(%(d)s, default_value='%(default)s')""" % locals()
-                elif hasattr(extra_val, '__iter__'):
-                    extra_val = str(extra_val)[1:-1]
-
-            if (not hasattr(klass, 'Set' + m)):
-                # Sometimes (very rarely) the VTK method is
-                # inconsistent.  For example in VTK-4.4
-                # vtkExtentTranslator::SetSplitMode does not exist.
-                # In this case wrap it specially.
+                # Sometimes (very rarely) the VTK method is inconsistent:
+                # the state methods (SetXToY, XOn/XOff) exist but there is
+                # no plain SetX (e.g. vtkExtentTranslator::SetSplitMode,
+                # still true on VTK 9.x).  In this case wrap it specially.
                 vtk_val = 1
             if vtk_val == 0 and m in ['DataScalarType', 'OutputScalarType',
                                        'UpdateExtent']:
@@ -1712,7 +1630,7 @@ class WrapperGenerator:
         r'[a-zA-Z0-9]+\.ScalarType$': (
             False, False, '_write_any_scalar_type'),
 
-        # In VTK > 4.5, Set/GetInput have multiple signatures
+        # Set/GetInput have multiple signatures
         r'[a-zA-Z0-9]+\.Input$': (
             False, False, '_write_any_input'),
 
@@ -1730,29 +1648,19 @@ class WrapperGenerator:
         'vtkHardwareSelector.PropColorValue$': (
             True, True, '_write_hardware_selector_prop_color_value'),
 
-        # In VTK 5.8, tolerance is initialised as 0 while the range
-        # is 1-100
-        'vtkAxesTransformRepresentation.Tolerance$': (
-            True, True, '_write_axes_transform_representation_tolerance'),
-
-        # In VTK 7.x, vtkSpanSpace.GetResolution is supposed to be between
-        # 1 and 2147483647L but can be much larger when un-initialized.
-        'vtkSpanSpace.Resolution$': (
-            True, True, '_write_span_space_resolution'
-        ),
-
-        # In VTK 8.x, vtkSmartVolumeMapper.Get/Set VectorComponent is
-        # supposed to be between 0 and 3 but is initialized to some random
-        # value.
-        'vtkSmartVolumeMapper.VectorComponent$': (
-            True, True, '_write_smart_volume_mapper_vector_component'
-        ),
-
         # On VTK < 9.6, vtkGraphMapper.GetIconSize returns an unwrapped
         # int* (a pointer repr string in Python), so updating from the
         # runtime object must be allowed to fail.
         'vtkGraphMapper.IconSize$': (
             True, True, '_write_graph_mapper_icon_size'
+        ),
+
+        # GetTranslation3D returns uninitialized memory on a
+        # default-constructed object (seen at least through VTK 9.6), which
+        # would otherwise bake a random default into the generated code and
+        # make builds non-reproducible.
+        'vtkRenderWindowInteractor3D.Translation3D$': (
+            True, True, '_write_rwi3d_translation3d'
         ),
 
         # Parametric coords are intrinsic geometry, not configuration, and
@@ -1763,31 +1671,11 @@ class WrapperGenerator:
             False, False, '_write_any_parametric_coords'
         ),
 
-        # In VTK 8.x, HyperTreeGridCellCenter's Get/Set VertexCells is supposed
-        # to be a boolean but the initialized value can be an arbitrary
-        # integer.
-        'vtkHyperTreeGridCellCenters.VertexCells$': (
-            True, True, '_write_hyper_tree_grid_cell_centers_vertex_cells'
-        ),
-        # In VTK 9.x, EuclideanClusterExtraction's Get/Radius is initialized
-        # to some random value.
-        'vtkEuclideanClusterExtraction.Radius$': (
-            True, True, '_write_euclidean_cluster_extraction_radius'
-        ),
-        # In VTK 9.2, LineIntegralConvolution2D's Get/MaxNoiseValue is initialized
-        # to some random value this happens mostly on MacOS.
-        'vtkLineIntegralConvolution2D.MaxNoiseValue$': (
-            True, True, '_write_line_integral_conv_2d_max_noise_value'
-        ),
-        # In VTK 9.4, CellGridSidesQuery's Get/OutputDimensionControl is initialized
-        # to some random value this happens mostly on MacOS.
+        # In VTK 9.4 (still present in 9.6), CellGridSidesQuery's
+        # Get/OutputDimensionControl is initialized to some random value,
+        # mostly on MacOS.
         'vtkCellGridSidesQuery.OutputDimensionControl$': (
             True, True, '_write_cell_grid_sides_query_od_control'
-        ),
-        # In VTK 9.3, vtkCylinderSource's GetLatLongTesselation gives random values
-        # https://gitlab.kitware.com/vtk/vtk/-/issues/19252
-        'vtkCylinderSource.LatLongTessellation$': (
-            True, True, '_write_cylinder_source_lat_long_tessellation'
         ),
     }
 
@@ -1937,58 +1825,6 @@ class WrapperGenerator:
         self._write_trait(out, name, t_def, vtk_set_meth, mapped=False,
                                force_update='False')
 
-    def _write_axes_transform_representation_tolerance(self, klass, out,
-                                                       vtk_attr_name):
-
-        if vtk_attr_name != 'Tolerance':
-            raise RuntimeError("Not sure why you ask for me! "
-                               "I only deal with Tolerance. Panicking.")
-
-        default, rng = self.parser.get_get_set_methods()[vtk_attr_name]
-
-        t_def = ('traits.Trait({default}, traits.Range{rng}, '
-                 'enter_set=True, auto_set=False)').format(default=default,
-                                                           rng=rng)
-        name = self._reform_name(vtk_attr_name)
-        vtk_set_meth = getattr(klass, 'Set' + vtk_attr_name)
-        self._write_trait(out, name, t_def, vtk_set_meth, mapped=False)
-
-    def _write_smart_volume_mapper_vector_component(self, klass, out,
-                                                    vtk_attr_name):
-        if vtk_attr_name != 'VectorComponent':
-            raise RuntimeError("Not sure why you ask for me! "
-                               "I only deal with VectorComponent. Panicking.")
-
-        default, rng = self.parser.get_get_set_methods()[vtk_attr_name]
-
-        # TODO: Still an issue in 9.x?
-        message = ("vtkSmartVolumeMapper: "
-                    "VectorComponent not updatable "
-                    "(VTK 8.x bug - value not properly initialized)")
-        print(message)
-        default = rng[0]
-        t_def = ('traits.Trait({default}, traits.Range{rng}, '
-                 'enter_set=True, auto_set=False)').format(default=default,
-                                                           rng=rng)
-        name = self._reform_name(vtk_attr_name)
-        vtk_set_meth = getattr(klass, 'Set' + vtk_attr_name)
-        self._write_trait(out, name, t_def, vtk_set_meth, mapped=False)
-
-    def _write_span_space_resolution(self, klass, out,
-                                     vtk_attr_name):
-        if vtk_attr_name != 'Resolution':
-            raise RuntimeError("Not sure why you ask for me! "
-                               "I only deal with Resolution. Panicking.")
-
-        default, rng = self.parser.get_get_set_methods()[vtk_attr_name]
-
-        t_def = ('traits.Trait({default}, traits.Range{rng}, '
-                 'enter_set=True, auto_set=False)').format(default=default,
-                                                           rng=rng)
-        name = self._reform_name(vtk_attr_name)
-        vtk_set_meth = getattr(klass, 'Set' + vtk_attr_name)
-        self._write_trait(out, name, t_def, vtk_set_meth, mapped=False)
-
     def _write_any_parametric_coords(self, klass, out, vtk_attr_name):
         if vtk_attr_name != 'ParametricCoords':
             raise RuntimeError("Not sure why you ask for me! "
@@ -2010,65 +1846,12 @@ class WrapperGenerator:
         vtk_set_meth = getattr(klass, 'Set' + vtk_attr_name)
         self._write_trait(out, name, t_def, vtk_set_meth, mapped=False)
 
-    def _write_hyper_tree_grid_cell_centers_vertex_cells(self, klass, out,
-                                                         vtk_attr_name):
-        if vtk_attr_name != 'VertexCells':
-            raise RuntimeError("Not sure why you ask for me! "
-                               "I only deal with VertexCells. Panicking.")
-
-        # TODO: Still an issue in 9.x?
-        message = ("vtkHyperTreeGridCellCenters: "
-                    "VertexCells not updatable "
-                    "(VTK 8.x bug - value not properly initialized)")
-        print(message)
-
-        t_def = 'tvtk_base.true_bool_trait'
-
-        name = self._reform_name(vtk_attr_name)
-        vtk_set_meth = getattr(klass, 'Set' + vtk_attr_name)
-        self._write_trait(out, name, t_def, vtk_set_meth, mapped=False)
-
-    def _write_euclidean_cluster_extraction_radius(
-            self, klass, out, vtk_attr_name
-    ):
-        if vtk_attr_name != 'Radius':
-            raise RuntimeError("Not sure why you ask for me! "
-                               "I only deal with Radius. Panicking.")
-
-        default, rng = self.parser.get_get_set_methods()[vtk_attr_name]
-
-        # TODO: Still an issue in 9.x?
-        message = ("vtkEuclideanClusterExtraction: "
-                    "Radius not updatable "
-                    "(VTK 9.1 bug - value not properly initialized)")
-        print(message)
-        default = rng[0]
-
-        t_def = ('traits.Trait({default}, traits.Range{rng}, '
-                 'enter_set=True, auto_set=False)').format(default=default,
-                                                           rng=rng)
-        name = self._reform_name(vtk_attr_name)
-        vtk_set_meth = getattr(klass, 'Set' + vtk_attr_name)
-        self._write_trait(out, name, t_def, vtk_set_meth, mapped=False)
-
-    def _write_line_integral_conv_2d_max_noise_value(
-        self, klass, out, vtk_attr_name
-    ):
-        if vtk_attr_name != 'MaxNoiseValue':
-            raise RuntimeError("Not sure why you ask for me! "
-                               "I only deal with MaxNoiseValue. Panicking.")
-
-        default, rng = self.parser.get_get_set_methods()[vtk_attr_name]
-
-        if vtk_major_version >= 9:
-            message = ("vtkLineIntegralConvolution2D: "
-                       "MaxNoiseValue not updatable "
-                       "(VTK 9.2 bug - value not properly initialized)")
-            print(message)
-            default = rng[0]
-        t_def = ('traits.Trait({default}, traits.Range{rng}, '
-                 'enter_set=True, auto_set=False)').format(default=default,
-                                                           rng=rng)
+    def _write_rwi3d_translation3d(self, klass, out, vtk_attr_name):
+        if vtk_attr_name != 'Translation3D':
+            raise RuntimeError(f"Wrong attribute name: {vtk_attr_name}")
+        t_def = ('traits.Array(enter_set=True, auto_set=False, '
+                 'shape=(None,), dtype="float", value=(0.0, 0.0, 0.0), '
+                 'cols=3)')
         name = self._reform_name(vtk_attr_name)
         vtk_set_meth = getattr(klass, 'Set' + vtk_attr_name)
         self._write_trait(out, name, t_def, vtk_set_meth, mapped=False)
@@ -2076,27 +1859,7 @@ class WrapperGenerator:
     def _write_cell_grid_sides_query_od_control(self, klass, out, vtk_attr_name):
         if vtk_attr_name != 'OutputDimensionControl':
             raise RuntimeError(f"Wrong attribute name: {vtk_attr_name}")
-        if vtk_major_version >= 9:
-            message = ("vtkCellGridSidesQuery: "
-                       "OutputDimensionControl not updatable "
-                       "(VTK 9.4 bug - value not properly initialized)")
-            print(message)
         t_def = 'tvtk_base.true_bool_trait'
-        name = self._reform_name(vtk_attr_name)
-        vtk_set_meth = getattr(klass, 'Set' + vtk_attr_name)
-        self._write_trait(out, name, t_def, vtk_set_meth, mapped=True)
-
-    def _write_cylinder_source_lat_long_tessellation(
-        self, klass, out, vtk_attr_name
-    ):
-        if vtk_attr_name != 'LatLongTessellation':
-            raise RuntimeError(f"Wrong attribute name: {vtk_attr_name}")
-        if (vtk_major_version, vtk_minor_version) <= (9, 3):
-            message = ("vtkCylinderSource: "
-                       "LatLongTesselation not updatable "
-                       "(VTK 9.3 bug - value not properly initialized)")
-            print(message)
-        t_def = 'tvtk_base.false_bool_trait'
         name = self._reform_name(vtk_attr_name)
         vtk_set_meth = getattr(klass, 'Set' + vtk_attr_name)
         self._write_trait(out, name, t_def, vtk_set_meth, mapped=True)

--- a/tvtk/wrapper_gen.py
+++ b/tvtk/wrapper_gen.py
@@ -1643,6 +1643,30 @@ class WrapperGenerator:
         'vtkImageReader2.HeaderSize$': (
             True, False, '_write_image_reader2_header_size'),
 
+        # NOTE: several entries below work around *uninitialized* values in
+        # VTK.  Those are platform-dependent (garbage memory on Linux can
+        # read as a sane value on macOS), so they must only be culled with
+        # evidence from every platform (or an upstream fix in the VTK
+        # changelog), not a single-platform probe.
+
+        # In VTK 5.8, tolerance is initialised as 0 while the range
+        # is 1-100
+        'vtkAxesTransformRepresentation.Tolerance$': (
+            True, True, '_write_axes_transform_representation_tolerance'),
+
+        # In VTK 7.x, vtkSpanSpace.GetResolution is supposed to be between
+        # 1 and 2147483647L but can be much larger when un-initialized.
+        'vtkSpanSpace.Resolution$': (
+            True, True, '_write_span_space_resolution'
+        ),
+
+        # In VTK 8.x (still on Linux in 9.6), Get/Set VectorComponent is
+        # supposed to be between 0 and 3 but is read from uninitialized
+        # memory.
+        'vtkSmartVolumeMapper.VectorComponent$': (
+            True, True, '_write_smart_volume_mapper_vector_component'
+        ),
+
         # PropColorValue is not initialised, GetPropColorValue
         # gives random values as a tuple of float[3] that are
         'vtkHardwareSelector.PropColorValue$': (
@@ -1671,11 +1695,32 @@ class WrapperGenerator:
             False, False, '_write_any_parametric_coords'
         ),
 
+        # In VTK 8.x, HyperTreeGridCellCenter's Get/Set VertexCells is supposed
+        # to be a boolean but the initialized value can be an arbitrary
+        # integer.
+        'vtkHyperTreeGridCellCenters.VertexCells$': (
+            True, True, '_write_hyper_tree_grid_cell_centers_vertex_cells'
+        ),
+        # In VTK 9.x, EuclideanClusterExtraction's Get/Radius is initialized
+        # to some random value.
+        'vtkEuclideanClusterExtraction.Radius$': (
+            True, True, '_write_euclidean_cluster_extraction_radius'
+        ),
+        # In VTK 9.2, LineIntegralConvolution2D's Get/MaxNoiseValue is initialized
+        # to some random value this happens mostly on MacOS.
+        'vtkLineIntegralConvolution2D.MaxNoiseValue$': (
+            True, True, '_write_line_integral_conv_2d_max_noise_value'
+        ),
         # In VTK 9.4 (still present in 9.6), CellGridSidesQuery's
         # Get/OutputDimensionControl is initialized to some random value,
         # mostly on MacOS.
         'vtkCellGridSidesQuery.OutputDimensionControl$': (
             True, True, '_write_cell_grid_sides_query_od_control'
+        ),
+        # In VTK 9.3, vtkCylinderSource's GetLatLongTesselation gives random values
+        # https://gitlab.kitware.com/vtk/vtk/-/issues/19252
+        'vtkCylinderSource.LatLongTessellation$': (
+            True, True, '_write_cylinder_source_lat_long_tessellation'
         ),
     }
 
@@ -1824,6 +1869,110 @@ class WrapperGenerator:
 
         self._write_trait(out, name, t_def, vtk_set_meth, mapped=False,
                                force_update='False')
+
+    def _write_axes_transform_representation_tolerance(self, klass, out,
+                                                       vtk_attr_name):
+
+        if vtk_attr_name != 'Tolerance':
+            raise RuntimeError("Not sure why you ask for me! "
+                               "I only deal with Tolerance. Panicking.")
+
+        default, rng = self.parser.get_get_set_methods()[vtk_attr_name]
+
+        t_def = ('traits.Trait({default}, traits.Range{rng}, '
+                 'enter_set=True, auto_set=False)').format(default=default,
+                                                           rng=rng)
+        name = self._reform_name(vtk_attr_name)
+        vtk_set_meth = getattr(klass, 'Set' + vtk_attr_name)
+        self._write_trait(out, name, t_def, vtk_set_meth, mapped=False)
+
+    def _write_smart_volume_mapper_vector_component(self, klass, out,
+                                                    vtk_attr_name):
+        if vtk_attr_name != 'VectorComponent':
+            raise RuntimeError("Not sure why you ask for me! "
+                               "I only deal with VectorComponent. Panicking.")
+
+        default, rng = self.parser.get_get_set_methods()[vtk_attr_name]
+
+        default = rng[0]
+        t_def = ('traits.Trait({default}, traits.Range{rng}, '
+                 'enter_set=True, auto_set=False)').format(default=default,
+                                                           rng=rng)
+        name = self._reform_name(vtk_attr_name)
+        vtk_set_meth = getattr(klass, 'Set' + vtk_attr_name)
+        self._write_trait(out, name, t_def, vtk_set_meth, mapped=False)
+
+    def _write_span_space_resolution(self, klass, out,
+                                     vtk_attr_name):
+        if vtk_attr_name != 'Resolution':
+            raise RuntimeError("Not sure why you ask for me! "
+                               "I only deal with Resolution. Panicking.")
+
+        default, rng = self.parser.get_get_set_methods()[vtk_attr_name]
+
+        t_def = ('traits.Trait({default}, traits.Range{rng}, '
+                 'enter_set=True, auto_set=False)').format(default=default,
+                                                           rng=rng)
+        name = self._reform_name(vtk_attr_name)
+        vtk_set_meth = getattr(klass, 'Set' + vtk_attr_name)
+        self._write_trait(out, name, t_def, vtk_set_meth, mapped=False)
+
+    def _write_hyper_tree_grid_cell_centers_vertex_cells(self, klass, out,
+                                                         vtk_attr_name):
+        if vtk_attr_name != 'VertexCells':
+            raise RuntimeError("Not sure why you ask for me! "
+                               "I only deal with VertexCells. Panicking.")
+
+        t_def = 'tvtk_base.true_bool_trait'
+
+        name = self._reform_name(vtk_attr_name)
+        vtk_set_meth = getattr(klass, 'Set' + vtk_attr_name)
+        self._write_trait(out, name, t_def, vtk_set_meth, mapped=False)
+
+    def _write_euclidean_cluster_extraction_radius(
+            self, klass, out, vtk_attr_name
+    ):
+        if vtk_attr_name != 'Radius':
+            raise RuntimeError("Not sure why you ask for me! "
+                               "I only deal with Radius. Panicking.")
+
+        default, rng = self.parser.get_get_set_methods()[vtk_attr_name]
+
+        default = rng[0]
+
+        t_def = ('traits.Trait({default}, traits.Range{rng}, '
+                 'enter_set=True, auto_set=False)').format(default=default,
+                                                           rng=rng)
+        name = self._reform_name(vtk_attr_name)
+        vtk_set_meth = getattr(klass, 'Set' + vtk_attr_name)
+        self._write_trait(out, name, t_def, vtk_set_meth, mapped=False)
+
+    def _write_line_integral_conv_2d_max_noise_value(
+        self, klass, out, vtk_attr_name
+    ):
+        if vtk_attr_name != 'MaxNoiseValue':
+            raise RuntimeError("Not sure why you ask for me! "
+                               "I only deal with MaxNoiseValue. Panicking.")
+
+        default, rng = self.parser.get_get_set_methods()[vtk_attr_name]
+
+        default = rng[0]
+        t_def = ('traits.Trait({default}, traits.Range{rng}, '
+                 'enter_set=True, auto_set=False)').format(default=default,
+                                                           rng=rng)
+        name = self._reform_name(vtk_attr_name)
+        vtk_set_meth = getattr(klass, 'Set' + vtk_attr_name)
+        self._write_trait(out, name, t_def, vtk_set_meth, mapped=False)
+
+    def _write_cylinder_source_lat_long_tessellation(
+        self, klass, out, vtk_attr_name
+    ):
+        if vtk_attr_name != 'LatLongTessellation':
+            raise RuntimeError(f"Wrong attribute name: {vtk_attr_name}")
+        t_def = 'tvtk_base.false_bool_trait'
+        name = self._reform_name(vtk_attr_name)
+        vtk_set_meth = getattr(klass, 'Set' + vtk_attr_name)
+        self._write_trait(out, name, t_def, vtk_set_meth, mapped=True)
 
     def _write_any_parametric_coords(self, klass, out, vtk_attr_name):
         if vtk_attr_name != 'ParametricCoords':


### PR DESCRIPTION
We had multiple places where we had "VTK does a bad thing let's fix it" code. This unifies them. Proof should be in the PRs. Claude Fable 5 drafted code changes and I reviewed.

Let's only support 2 years back (SPEC0) to keep things more maintainable, too -- allowing us to remove even more technical debt / code.