### PR TITLE
MAINT: Drop the year from per-file copyright notices

### DIFF
--- a/docs/source/mayavi/auto/adjust_cropping_extents.py
+++ b/docs/source/mayavi/auto/adjust_cropping_extents.py
@@ -22,7 +22,7 @@ on creating GUIs with Traits:
 
 """
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2010, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/docs/source/mayavi/auto/atomic_orbital.py
+++ b/docs/source/mayavi/auto/atomic_orbital.py
@@ -20,7 +20,7 @@ in TVTK. The reader is referred to :ref:`data-structures-used-by-mayavi`
 for more details.
 """
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Create the data ############################################################

--- a/docs/source/mayavi/auto/boy.py
+++ b/docs/source/mayavi/auto/boy.py
@@ -8,7 +8,7 @@ function: :func:`mayavi.mlab.mesh`.
 """
 
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/docs/source/mayavi/auto/bunny.py
+++ b/docs/source/mayavi/auto/bunny.py
@@ -1,7 +1,7 @@
 """
 Viewing Stanford 3D Scanning Repository bunny model
 """
-# Copyright (c) 2014-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # Standard library imports
 import os
 from os.path import join

--- a/docs/source/mayavi/auto/canyon.py
+++ b/docs/source/mayavi/auto/canyon.py
@@ -9,7 +9,7 @@ This example is interesting as it shows how numpy can be used to load
 and crop data completly foreign to Mayavi.
 """
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Retrieve the grand Canyon topological data ##################################

--- a/docs/source/mayavi/auto/canyon_decimation.py
+++ b/docs/source/mayavi/auto/canyon_decimation.py
@@ -23,7 +23,7 @@ warped from 2D data. To decimated more general meshes, you can use the
 less-efficient decimate-pro filter (see :ref:`example_julia_set_decimation`).
 """
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2008-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Retrieve the grand Canyon topological data ###################################

--- a/docs/source/mayavi/auto/chemistry.py
+++ b/docs/source/mayavi/auto/chemistry.py
@@ -13,7 +13,7 @@ Good use of the `vmin` and `vmax` argument to
 The original is an electron localization function from Axel Kohlmeyer.
 """
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2008-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Retrieve the electron localization data for H2O #############################

--- a/docs/source/mayavi/auto/coil_design_application.py
+++ b/docs/source/mayavi/auto/coil_design_application.py
@@ -30,7 +30,7 @@ The material required to understand this example is covered in section
 
 """
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2009, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Major scientific library imports

--- a/docs/source/mayavi/auto/compute_in_thread.py
+++ b/docs/source/mayavi/auto/compute_in_thread.py
@@ -5,7 +5,7 @@ and update the mayavi pipeline. It also shows how to create a numpy array
 data and visualize it as image data using a few modules.
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2007-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports

--- a/docs/source/mayavi/auto/contour.py
+++ b/docs/source/mayavi/auto/contour.py
@@ -5,7 +5,7 @@ contour related modules.
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports

--- a/docs/source/mayavi/auto/contour_contour.py
+++ b/docs/source/mayavi/auto/contour_contour.py
@@ -2,7 +2,7 @@
 """This example shows how you can produce contours on an IsoSurface.
 """
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports

--- a/docs/source/mayavi/auto/datasets.py
+++ b/docs/source/mayavi/auto/datasets.py
@@ -28,7 +28,7 @@ The following images are created:
 
 """
 # Author: Gael Varoquaux <gael dot varoquaux at normalesup.org>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD style.
 
 from numpy import array, random, linspace, pi, ravel, cos, sin, empty

--- a/docs/source/mayavi/auto/delaunay_graph.py
+++ b/docs/source/mayavi/auto/delaunay_graph.py
@@ -42,7 +42,7 @@ display an unoriented graph, it is best to use the `2ddash` mode of
 """
 # Author: Gary Ruben
 #         Gael Varoquaux <gael dot varoquaux at normalesup dot org>
-# Copyright (c) 2009, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD style.
 
 from mayavi import mlab

--- a/docs/source/mayavi/auto/dragon.py
+++ b/docs/source/mayavi/auto/dragon.py
@@ -1,7 +1,7 @@
 """
 Viewing Stanford 3D Scanning Repository dragon model
 """
-# Copyright (c) 2014-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # Standard library imports
 import os
 from os.path import join

--- a/docs/source/mayavi/auto/glyph.py
+++ b/docs/source/mayavi/auto/glyph.py
@@ -5,7 +5,7 @@ split the pipeline using a MaskPoints filter and then view the filtered data
 with the Glyph module.
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports

--- a/docs/source/mayavi/auto/image_cursor_filter.py
+++ b/docs/source/mayavi/auto/image_cursor_filter.py
@@ -27,7 +27,7 @@ within the `Class name` field of the dialog.
 
 # Authors: Emmanuelle Gouillart <emmanuelle.gouillart@normalesup.org>
 # and Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2009, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/docs/source/mayavi/auto/julia_set.py
+++ b/docs/source/mayavi/auto/julia_set.py
@@ -7,7 +7,7 @@ The Julia set is a fractal (see http://en.wikipedia.org/wiki/Julia_set
 """
 
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/docs/source/mayavi/auto/julia_set_decimation.py
+++ b/docs/source/mayavi/auto/julia_set_decimation.py
@@ -25,7 +25,7 @@ more efficient to use the greedy-terrain-decimator, see the
 """
 
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/docs/source/mayavi/auto/lorenz.py
+++ b/docs/source/mayavi/auto/lorenz.py
@@ -11,7 +11,7 @@ field data source with the ExtractVectorComponent filter, and applying
 an IsoSurface module on this scalar component.
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import numpy as np

--- a/docs/source/mayavi/auto/lorenz_ui.py
+++ b/docs/source/mayavi/auto/lorenz_ui.py
@@ -9,7 +9,7 @@ For explanations and more examples of interactive application building
 with Mayavi, please refer to section :ref:`building_applications`.
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import ast

--- a/docs/source/mayavi/auto/lucy.py
+++ b/docs/source/mayavi/auto/lucy.py
@@ -1,7 +1,7 @@
 """
 Viewing Stanford 3D Scanning Repository lucy model
 """
-# Copyright (c) 2014-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # Standard library imports
 import os
 from os.path import join

--- a/docs/source/mayavi/auto/magnetic_field.py
+++ b/docs/source/mayavi/auto/magnetic_field.py
@@ -18,7 +18,7 @@ For another visualization of magnetic field, see the
 :ref:`example_magnetic_field_lines`.
 """
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2009, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/docs/source/mayavi/auto/magnetic_field_lines.py
+++ b/docs/source/mayavi/auto/magnetic_field_lines.py
@@ -16,7 +16,7 @@ visualization with Mayavi and scipy, see
 :ref:`example_magnetic_field`.
 """
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import numpy as np

--- a/docs/source/mayavi/auto/mayavi_traits_ui.py
+++ b/docs/source/mayavi/auto/mayavi_traits_ui.py
@@ -13,7 +13,7 @@ edit the currently-selected object.
 """
 
 # Authors: Prabhu Ramachandran <prabhu [at] aero.iitb.ac.in>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard imports.

--- a/docs/source/mayavi/auto/mlab_3D_to_2D.py
+++ b/docs/source/mayavi/auto/mlab_3D_to_2D.py
@@ -108,7 +108,7 @@ Now that the prelimenaries are out of the way, lets get started.
 """
 
 # Author: S. Chris Colbert <sccolbert@gmail.com>
-# Copyright (c) 2009, S. Chris Colbert
+# Copyright (c) S. Chris Colbert
 # License: BSD Style
 
 # this import is here because we need to ensure that matplotlib uses the

--- a/docs/source/mayavi/auto/mlab_interactive_dialog.py
+++ b/docs/source/mayavi/auto/mlab_interactive_dialog.py
@@ -21,7 +21,7 @@ This example is discussed in details in the section
 :ref:`embedding_mayavi_traits`.
 """
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/docs/source/mayavi/auto/mlab_traits_ui.py
+++ b/docs/source/mayavi/auto/mlab_traits_ui.py
@@ -8,7 +8,7 @@ the simplest possible dialog: a single Mayavi scene in a window.
 
 # Authors: Prabhu Ramachandran <prabhu [at] aero.iitb.ac.in>
 #          Gael Varoquaux
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard imports.

--- a/docs/source/mayavi/auto/mlab_visual.py
+++ b/docs/source/mayavi/auto/mlab_visual.py
@@ -19,7 +19,7 @@ If you want to modify the data plotted by the mlab (as in the
 
 """
 # Author: Prabhu Ramachandran <prabhu [at] aero.iitb.ac.in>
-# Copyright (c) 2009, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from mayavi import mlab

--- a/docs/source/mayavi/auto/multiple_engines.py
+++ b/docs/source/mayavi/auto/multiple_engines.py
@@ -11,7 +11,7 @@ To define default arguments, it makes use of the Traits initialization
 style, rather than overriding the __init__.
 """
 # Author:  Gael Varoquaux <gael _dot_ varoquaux _at_ normalesup _dot_ org>
-# Copyright (c) 2009, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from traits.api import HasTraits, Instance, on_trait_change

--- a/docs/source/mayavi/auto/nongui.py
+++ b/docs/source/mayavi/auto/nongui.py
@@ -16,7 +16,7 @@ Or::
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports

--- a/docs/source/mayavi/auto/numeric_source.py
+++ b/docs/source/mayavi/auto/numeric_source.py
@@ -5,7 +5,7 @@ visualize it as image data using a few modules.
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports

--- a/docs/source/mayavi/auto/offscreen.py
+++ b/docs/source/mayavi/auto/offscreen.py
@@ -14,7 +14,7 @@ It can be run as::
 """
 
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from os.path import join, abspath, dirname

--- a/docs/source/mayavi/auto/plotting_many_lines.py
+++ b/docs/source/mayavi/auto/plotting_many_lines.py
@@ -19,7 +19,7 @@ connected to the following one.
 """
 
 # Author: Gael Varoquaux <gael dot varoquaux at normalesup dot org>
-# Copyright (c) 2010, Enthought
+# Copyright (c) Enthought, Inc.
 # License: BSD style
 
 import numpy as np

--- a/docs/source/mayavi/auto/poll_file.py
+++ b/docs/source/mayavi/auto/poll_file.py
@@ -16,7 +16,7 @@ this script to point to other data which you can edit.
 """
 
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2006-2020, Enthought Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard imports.

--- a/docs/source/mayavi/auto/polydata.py
+++ b/docs/source/mayavi/auto/polydata.py
@@ -13,7 +13,7 @@ It can be alternatively run as::
 """
 
 # Author: Prabhu Ramachandran <prabhu at aero dot iitb dot ac dot in>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD style.
 
 from numpy import array

--- a/docs/source/mayavi/auto/protein.py
+++ b/docs/source/mayavi/auto/protein.py
@@ -38,7 +38,7 @@ http://mmcif.pdb.org/dictionaries/pdb-correspondence/pdb2mmcif.html
 """
 
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2008-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # The pdb code for the protein.

--- a/docs/source/mayavi/auto/scatter_plot.py
+++ b/docs/source/mayavi/auto/scatter_plot.py
@@ -25,7 +25,7 @@ Alternatively it can be run as::
 """
 
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2007 Prabhu Ramachandran.
+# Copyright (c) Prabhu Ramachandran
 # License: BSD Style.
 
 import numpy as np

--- a/docs/source/mayavi/auto/select_red_balls.py
+++ b/docs/source/mayavi/auto/select_red_balls.py
@@ -20,7 +20,7 @@ the corresponding ball.
 """
 
 # Author: Gael Varoquaux <gael dot varoquaux at normalesup.org>
-# Copyright (c) 2009, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD style.
 
 import numpy as np

--- a/docs/source/mayavi/auto/simple_structured_grid.py
+++ b/docs/source/mayavi/auto/simple_structured_grid.py
@@ -12,7 +12,7 @@ To visualize the resulting dataset, we apply several modules, using the
 mlab.pipeline interface (see :ref:`controlling-the-pipeline-with-mlab-scripts`)
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008, Prabhu Ramachandran.
+# Copyright (c) Prabhu Ramachandran
 # License: BSD Style.
 
 from numpy import mgrid, empty, sin, pi

--- a/docs/source/mayavi/auto/spherical_harmonics.py
+++ b/docs/source/mayavi/auto/spherical_harmonics.py
@@ -15,7 +15,7 @@ the radius of the previous sphere.
 """
 
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from mayavi import mlab

--- a/docs/source/mayavi/auto/standalone.py
+++ b/docs/source/mayavi/auto/standalone.py
@@ -4,7 +4,7 @@ using Envisage or the Mayavi Envisage application.
 
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2007-2026, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from os.path import join, abspath

--- a/docs/source/mayavi/auto/streamline.py
+++ b/docs/source/mayavi/auto/streamline.py
@@ -3,7 +3,7 @@
 streamlines and an iso surface.
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports

--- a/docs/source/mayavi/auto/structured_grid.py
+++ b/docs/source/mayavi/auto/structured_grid.py
@@ -15,7 +15,7 @@ Alternatively, it can be run as::
 
 # Authors: Eric Jones <eric at enthought dot com>
 #          Prabhu Ramachandran <prabhu at aero dot iitb dot ac dot in>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD style.
 
 import numpy as np

--- a/docs/source/mayavi/auto/structured_points2d.py
+++ b/docs/source/mayavi/auto/structured_points2d.py
@@ -12,7 +12,7 @@ Alternatively, it can be run as::
 
 """
 # Author: Prabhu Ramachandran <prabhu at aero dot iitb dot ac dot in>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD style.
 
 from numpy import arange, sqrt, sin

--- a/docs/source/mayavi/auto/structured_points3d.py
+++ b/docs/source/mayavi/auto/structured_points3d.py
@@ -12,7 +12,7 @@ Alternatively, it can be run as::
 
 """
 # Author: Prabhu Ramachandran <prabhu at aero dot iitb dot ac dot in>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD style.
 
 from tvtk.api import tvtk

--- a/docs/source/mayavi/auto/subclassing_mayavi_application.py
+++ b/docs/source/mayavi/auto/subclassing_mayavi_application.py
@@ -10,7 +10,7 @@ This should be run as::
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports

--- a/docs/source/mayavi/auto/superquad_with_gui.py
+++ b/docs/source/mayavi/auto/superquad_with_gui.py
@@ -17,7 +17,7 @@ and watch as the figure transforms accordingly!
 """
 
 # Author: Pratik Mallya <pmallya@enthought.com>
-# Copyright (c) 2008-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import numpy as np

--- a/docs/source/mayavi/auto/surf_regular_mlab.py
+++ b/docs/source/mayavi/auto/surf_regular_mlab.py
@@ -4,7 +4,7 @@ mayavi2.
 """
 
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2006-2020, Enthought Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import numpy as np

--- a/docs/source/mayavi/auto/surface_from_irregular_data.py
+++ b/docs/source/mayavi/auto/surface_from_irregular_data.py
@@ -20,7 +20,7 @@ mlab.points3d. We then use the delaunay2d filter to extract the mesh by
 nearest-neighboor matching, and visualize it using the surface module.
 """
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2009, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import numpy as np

--- a/docs/source/mayavi/auto/tvtk_in_mayavi.py
+++ b/docs/source/mayavi/auto/tvtk_in_mayavi.py
@@ -17,7 +17,7 @@ complex VTK pipeline built with Mayavi, see
 """
 
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from mayavi import mlab

--- a/docs/source/mayavi/auto/user_mayavi.py
+++ b/docs/source/mayavi/auto/user_mayavi.py
@@ -32,7 +32,7 @@ The file may also be placed anywhere on sys.path and called
 
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2006-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from mayavi.core.registry import registry

--- a/docs/source/mayavi/auto/volume_slicer.py
+++ b/docs/source/mayavi/auto/volume_slicer.py
@@ -29,7 +29,7 @@ specific scene interactor styles. Indeed, non-technical users can be
 confused with too rich interaction.
 """
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2009, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import numpy as np

--- a/docs/source/mayavi/auto/wigner.py
+++ b/docs/source/mayavi/auto/wigner.py
@@ -17,7 +17,7 @@ We add a set of axes and outlines to the plot. We have to play we extents
 and ranges in order to make them fit with the data.
 """
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/docs/source/mayavi/conf.py
+++ b/docs/source/mayavi/conf.py
@@ -57,7 +57,7 @@ master_doc = 'index'
 
 # General substitutions.
 project = 'mayavi'
-copyright = u'2008-2018, Enthought Inc.'
+copyright = 'Enthought, Inc.'
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.

--- a/docs/source/render_images.py
+++ b/docs/source/render_images.py
@@ -3,7 +3,7 @@ Script to render the images for the Mayavi user guide.
 
 """
 # Author: Gael Varoquaux <gael dot varoquaux at normalesup dot org>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/docs/source/tvtk/conf.py
+++ b/docs/source/tvtk/conf.py
@@ -45,7 +45,7 @@ master_doc = 'index'
 
 # General substitutions.
 project = 'tvtk'
-copyright = '2008-2016, Enthought Inc.'
+copyright = 'Enthought, Inc.'
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.

--- a/examples/mayavi/advanced_visualization/contour.py
+++ b/examples/mayavi/advanced_visualization/contour.py
@@ -5,7 +5,7 @@ contour related modules.
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports

--- a/examples/mayavi/advanced_visualization/contour_contour.py
+++ b/examples/mayavi/advanced_visualization/contour_contour.py
@@ -2,7 +2,7 @@
 """This example shows how you can produce contours on an IsoSurface.
 """
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports

--- a/examples/mayavi/advanced_visualization/datasets.py
+++ b/examples/mayavi/advanced_visualization/datasets.py
@@ -28,7 +28,7 @@ The following images are created:
 
 """
 # Author: Gael Varoquaux <gael dot varoquaux at normalesup.org>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD style.
 
 from numpy import array, random, linspace, pi, ravel, cos, sin, empty

--- a/examples/mayavi/advanced_visualization/delaunay_graph.py
+++ b/examples/mayavi/advanced_visualization/delaunay_graph.py
@@ -42,7 +42,7 @@ display an unoriented graph, it is best to use the `2ddash` mode of
 """
 # Author: Gary Ruben
 #         Gael Varoquaux <gael dot varoquaux at normalesup dot org>
-# Copyright (c) 2009, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD style.
 
 from mayavi import mlab

--- a/examples/mayavi/advanced_visualization/glyph.py
+++ b/examples/mayavi/advanced_visualization/glyph.py
@@ -5,7 +5,7 @@ split the pipeline using a MaskPoints filter and then view the filtered data
 with the Glyph module.
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports

--- a/examples/mayavi/advanced_visualization/image_cursor_filter.py
+++ b/examples/mayavi/advanced_visualization/image_cursor_filter.py
@@ -27,7 +27,7 @@ within the `Class name` field of the dialog.
 
 # Authors: Emmanuelle Gouillart <emmanuelle.gouillart@normalesup.org>
 # and Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2009, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/examples/mayavi/advanced_visualization/magnetic_field.py
+++ b/examples/mayavi/advanced_visualization/magnetic_field.py
@@ -18,7 +18,7 @@ For another visualization of magnetic field, see the
 :ref:`example_magnetic_field_lines`.
 """
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2009, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/examples/mayavi/advanced_visualization/mlab_3D_to_2D.py
+++ b/examples/mayavi/advanced_visualization/mlab_3D_to_2D.py
@@ -108,7 +108,7 @@ Now that the prelimenaries are out of the way, lets get started.
 """
 
 # Author: S. Chris Colbert <sccolbert@gmail.com>
-# Copyright (c) 2009, S. Chris Colbert
+# Copyright (c) S. Chris Colbert
 # License: BSD Style
 
 # this import is here because we need to ensure that matplotlib uses the

--- a/examples/mayavi/advanced_visualization/numeric_source.py
+++ b/examples/mayavi/advanced_visualization/numeric_source.py
@@ -5,7 +5,7 @@ visualize it as image data using a few modules.
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports

--- a/examples/mayavi/advanced_visualization/offscreen.py
+++ b/examples/mayavi/advanced_visualization/offscreen.py
@@ -14,7 +14,7 @@ It can be run as::
 """
 
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from os.path import join, abspath, dirname

--- a/examples/mayavi/advanced_visualization/polydata.py
+++ b/examples/mayavi/advanced_visualization/polydata.py
@@ -13,7 +13,7 @@ It can be alternatively run as::
 """
 
 # Author: Prabhu Ramachandran <prabhu at aero dot iitb dot ac dot in>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD style.
 
 from numpy import array

--- a/examples/mayavi/advanced_visualization/scatter_plot.py
+++ b/examples/mayavi/advanced_visualization/scatter_plot.py
@@ -25,7 +25,7 @@ Alternatively it can be run as::
 """
 
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2007 Prabhu Ramachandran.
+# Copyright (c) Prabhu Ramachandran
 # License: BSD Style.
 
 import numpy as np

--- a/examples/mayavi/advanced_visualization/streamline.py
+++ b/examples/mayavi/advanced_visualization/streamline.py
@@ -3,7 +3,7 @@
 streamlines and an iso surface.
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports

--- a/examples/mayavi/advanced_visualization/structured_grid.py
+++ b/examples/mayavi/advanced_visualization/structured_grid.py
@@ -15,7 +15,7 @@ Alternatively, it can be run as::
 
 # Authors: Eric Jones <eric at enthought dot com>
 #          Prabhu Ramachandran <prabhu at aero dot iitb dot ac dot in>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD style.
 
 import numpy as np

--- a/examples/mayavi/advanced_visualization/structured_points2d.py
+++ b/examples/mayavi/advanced_visualization/structured_points2d.py
@@ -12,7 +12,7 @@ Alternatively, it can be run as::
 
 """
 # Author: Prabhu Ramachandran <prabhu at aero dot iitb dot ac dot in>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD style.
 
 from numpy import arange, sqrt, sin

--- a/examples/mayavi/advanced_visualization/structured_points3d.py
+++ b/examples/mayavi/advanced_visualization/structured_points3d.py
@@ -12,7 +12,7 @@ Alternatively, it can be run as::
 
 """
 # Author: Prabhu Ramachandran <prabhu at aero dot iitb dot ac dot in>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD style.
 
 from tvtk.api import tvtk

--- a/examples/mayavi/advanced_visualization/surf_regular_mlab.py
+++ b/examples/mayavi/advanced_visualization/surf_regular_mlab.py
@@ -4,7 +4,7 @@ mayavi2.
 """
 
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2006-2020, Enthought Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import numpy as np

--- a/examples/mayavi/data_interaction/select_red_balls.py
+++ b/examples/mayavi/data_interaction/select_red_balls.py
@@ -20,7 +20,7 @@ the corresponding ball.
 """
 
 # Author: Gael Varoquaux <gael dot varoquaux at normalesup.org>
-# Copyright (c) 2009, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD style.
 
 import numpy as np

--- a/examples/mayavi/interactive/adjust_cropping_extents.py
+++ b/examples/mayavi/interactive/adjust_cropping_extents.py
@@ -22,7 +22,7 @@ on creating GUIs with Traits:
 
 """
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2010, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/examples/mayavi/interactive/coil_design_application.py
+++ b/examples/mayavi/interactive/coil_design_application.py
@@ -30,7 +30,7 @@ The material required to understand this example is covered in section
 
 """
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2009, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Major scientific library imports

--- a/examples/mayavi/interactive/compute_in_thread.py
+++ b/examples/mayavi/interactive/compute_in_thread.py
@@ -5,7 +5,7 @@ and update the mayavi pipeline. It also shows how to create a numpy array
 data and visualize it as image data using a few modules.
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2007-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports

--- a/examples/mayavi/interactive/lorenz_ui.py
+++ b/examples/mayavi/interactive/lorenz_ui.py
@@ -9,7 +9,7 @@ For explanations and more examples of interactive application building
 with Mayavi, please refer to section :ref:`building_applications`.
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import ast

--- a/examples/mayavi/interactive/mayavi_traits_ui.py
+++ b/examples/mayavi/interactive/mayavi_traits_ui.py
@@ -13,7 +13,7 @@ edit the currently-selected object.
 """
 
 # Authors: Prabhu Ramachandran <prabhu [at] aero.iitb.ac.in>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard imports.

--- a/examples/mayavi/interactive/mlab_interactive_dialog.py
+++ b/examples/mayavi/interactive/mlab_interactive_dialog.py
@@ -21,7 +21,7 @@ This example is discussed in details in the section
 :ref:`embedding_mayavi_traits`.
 """
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/examples/mayavi/interactive/mlab_traits_ui.py
+++ b/examples/mayavi/interactive/mlab_traits_ui.py
@@ -8,7 +8,7 @@ the simplest possible dialog: a single Mayavi scene in a window.
 
 # Authors: Prabhu Ramachandran <prabhu [at] aero.iitb.ac.in>
 #          Gael Varoquaux
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard imports.

--- a/examples/mayavi/interactive/mlab_visual.py
+++ b/examples/mayavi/interactive/mlab_visual.py
@@ -19,7 +19,7 @@ If you want to modify the data plotted by the mlab (as in the
 
 """
 # Author: Prabhu Ramachandran <prabhu [at] aero.iitb.ac.in>
-# Copyright (c) 2009, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from mayavi import mlab

--- a/examples/mayavi/interactive/multiple_engines.py
+++ b/examples/mayavi/interactive/multiple_engines.py
@@ -11,7 +11,7 @@ To define default arguments, it makes use of the Traits initialization
 style, rather than overriding the __init__.
 """
 # Author:  Gael Varoquaux <gael _dot_ varoquaux _at_ normalesup _dot_ org>
-# Copyright (c) 2009, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from traits.api import HasTraits, Instance, on_trait_change

--- a/examples/mayavi/interactive/poll_file.py
+++ b/examples/mayavi/interactive/poll_file.py
@@ -16,7 +16,7 @@ this script to point to other data which you can edit.
 """
 
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2006-2020, Enthought Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard imports.

--- a/examples/mayavi/interactive/subclassing_mayavi_application.py
+++ b/examples/mayavi/interactive/subclassing_mayavi_application.py
@@ -10,7 +10,7 @@ This should be run as::
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports

--- a/examples/mayavi/interactive/superquad_with_gui.py
+++ b/examples/mayavi/interactive/superquad_with_gui.py
@@ -17,7 +17,7 @@ and watch as the figure transforms accordingly!
 """
 
 # Author: Pratik Mallya <pmallya@enthought.com>
-# Copyright (c) 2008-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import numpy as np

--- a/examples/mayavi/interactive/volume_slicer.py
+++ b/examples/mayavi/interactive/volume_slicer.py
@@ -29,7 +29,7 @@ specific scene interactor styles. Indeed, non-technical users can be
 confused with too rich interaction.
 """
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2009, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import numpy as np

--- a/examples/mayavi/mlab/atomic_orbital.py
+++ b/examples/mayavi/mlab/atomic_orbital.py
@@ -20,7 +20,7 @@ in TVTK. The reader is referred to :ref:`data-structures-used-by-mayavi`
 for more details.
 """
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Create the data ############################################################

--- a/examples/mayavi/mlab/boy.py
+++ b/examples/mayavi/mlab/boy.py
@@ -8,7 +8,7 @@ function: :func:`mayavi.mlab.mesh`.
 """
 
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/examples/mayavi/mlab/bunny.py
+++ b/examples/mayavi/mlab/bunny.py
@@ -1,7 +1,7 @@
 """
 Viewing Stanford 3D Scanning Repository bunny model
 """
-# Copyright (c) 2014-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # Standard library imports
 import os
 from os.path import join

--- a/examples/mayavi/mlab/canyon.py
+++ b/examples/mayavi/mlab/canyon.py
@@ -9,7 +9,7 @@ This example is interesting as it shows how numpy can be used to load
 and crop data completly foreign to Mayavi.
 """
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Retrieve the grand Canyon topological data ##################################

--- a/examples/mayavi/mlab/canyon_decimation.py
+++ b/examples/mayavi/mlab/canyon_decimation.py
@@ -23,7 +23,7 @@ warped from 2D data. To decimated more general meshes, you can use the
 less-efficient decimate-pro filter (see :ref:`example_julia_set_decimation`).
 """
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2008-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Retrieve the grand Canyon topological data ###################################

--- a/examples/mayavi/mlab/chemistry.py
+++ b/examples/mayavi/mlab/chemistry.py
@@ -13,7 +13,7 @@ Good use of the `vmin` and `vmax` argument to
 The original is an electron localization function from Axel Kohlmeyer.
 """
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2008-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Retrieve the electron localization data for H2O #############################

--- a/examples/mayavi/mlab/dragon.py
+++ b/examples/mayavi/mlab/dragon.py
@@ -1,7 +1,7 @@
 """
 Viewing Stanford 3D Scanning Repository dragon model
 """
-# Copyright (c) 2014-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # Standard library imports
 import os
 from os.path import join

--- a/examples/mayavi/mlab/julia_set.py
+++ b/examples/mayavi/mlab/julia_set.py
@@ -7,7 +7,7 @@ The Julia set is a fractal (see http://en.wikipedia.org/wiki/Julia_set
 """
 
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/examples/mayavi/mlab/julia_set_decimation.py
+++ b/examples/mayavi/mlab/julia_set_decimation.py
@@ -25,7 +25,7 @@ more efficient to use the greedy-terrain-decimator, see the
 """
 
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/examples/mayavi/mlab/lorenz.py
+++ b/examples/mayavi/mlab/lorenz.py
@@ -11,7 +11,7 @@ field data source with the ExtractVectorComponent filter, and applying
 an IsoSurface module on this scalar component.
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import numpy as np

--- a/examples/mayavi/mlab/lucy.py
+++ b/examples/mayavi/mlab/lucy.py
@@ -1,7 +1,7 @@
 """
 Viewing Stanford 3D Scanning Repository lucy model
 """
-# Copyright (c) 2014-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # Standard library imports
 import os
 from os.path import join

--- a/examples/mayavi/mlab/magnetic_field_lines.py
+++ b/examples/mayavi/mlab/magnetic_field_lines.py
@@ -16,7 +16,7 @@ visualization with Mayavi and scipy, see
 :ref:`example_magnetic_field`.
 """
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import numpy as np

--- a/examples/mayavi/mlab/plotting_many_lines.py
+++ b/examples/mayavi/mlab/plotting_many_lines.py
@@ -19,7 +19,7 @@ connected to the following one.
 """
 
 # Author: Gael Varoquaux <gael dot varoquaux at normalesup dot org>
-# Copyright (c) 2010, Enthought
+# Copyright (c) Enthought, Inc.
 # License: BSD style
 
 import numpy as np

--- a/examples/mayavi/mlab/protein.py
+++ b/examples/mayavi/mlab/protein.py
@@ -38,7 +38,7 @@ http://mmcif.pdb.org/dictionaries/pdb-correspondence/pdb2mmcif.html
 """
 
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2008-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # The pdb code for the protein.

--- a/examples/mayavi/mlab/simple_structured_grid.py
+++ b/examples/mayavi/mlab/simple_structured_grid.py
@@ -12,7 +12,7 @@ To visualize the resulting dataset, we apply several modules, using the
 mlab.pipeline interface (see :ref:`controlling-the-pipeline-with-mlab-scripts`)
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008, Prabhu Ramachandran.
+# Copyright (c) Prabhu Ramachandran
 # License: BSD Style.
 
 from numpy import mgrid, empty, sin, pi

--- a/examples/mayavi/mlab/spherical_harmonics.py
+++ b/examples/mayavi/mlab/spherical_harmonics.py
@@ -15,7 +15,7 @@ the radius of the previous sphere.
 """
 
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from mayavi import mlab

--- a/examples/mayavi/mlab/surface_from_irregular_data.py
+++ b/examples/mayavi/mlab/surface_from_irregular_data.py
@@ -20,7 +20,7 @@ mlab.points3d. We then use the delaunay2d filter to extract the mesh by
 nearest-neighboor matching, and visualize it using the surface module.
 """
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2009, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import numpy as np

--- a/examples/mayavi/mlab/tvtk_in_mayavi.py
+++ b/examples/mayavi/mlab/tvtk_in_mayavi.py
@@ -17,7 +17,7 @@ complex VTK pipeline built with Mayavi, see
 """
 
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from mayavi import mlab

--- a/examples/mayavi/mlab/wigner.py
+++ b/examples/mayavi/mlab/wigner.py
@@ -17,7 +17,7 @@ We add a set of axes and outlines to the plot. We have to play we extents
 and ranges in order to make them fit with the data.
 """
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/examples/mayavi/nongui.py
+++ b/examples/mayavi/nongui.py
@@ -16,7 +16,7 @@ Or::
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports

--- a/examples/mayavi/standalone.py
+++ b/examples/mayavi/standalone.py
@@ -4,7 +4,7 @@ using Envisage or the Mayavi Envisage application.
 
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2007-2026, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from os.path import join, abspath

--- a/examples/mayavi/user_mayavi.py
+++ b/examples/mayavi/user_mayavi.py
@@ -32,7 +32,7 @@ The file may also be placed anywhere on sys.path and called
 
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2006-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from mayavi.core.registry import registry

--- a/examples/tvtk/animated_texture.py
+++ b/examples/tvtk/animated_texture.py
@@ -7,7 +7,7 @@ TVTK sees a view of this array without doing any data transfers.
 
 """
 # Authors: Prabhu Ramachandran, Eric Jones
-# Copyright (c) 2006-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from numpy import arange, zeros, uint8, exp, sqrt, pi

--- a/examples/tvtk/array_animation.py
+++ b/examples/tvtk/array_animation.py
@@ -17,7 +17,7 @@ achieving the same effect but the present form nicely illustrates item
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2004-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from tvtk.api import tvtk

--- a/examples/tvtk/dscene.py
+++ b/examples/tvtk/dscene.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/examples/tvtk/ivtk_example.py
+++ b/examples/tvtk/ivtk_example.py
@@ -6,7 +6,7 @@ pipeline browser and a Python shell!
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # We use this just for the demo.

--- a/examples/tvtk/off_screen.py
+++ b/examples/tvtk/off_screen.py
@@ -8,7 +8,7 @@
     after March 2006).
 """
 # Author: Eric Jones, Prabhu Ramachandran
-# Copyright (c) 2004-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from tvtk.api import tvtk

--- a/examples/tvtk/plugins/test.py
+++ b/examples/tvtk/plugins/test.py
@@ -5,7 +5,7 @@ can use TVTK's scene and browser plugins to create a simple application.
 """
 
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/examples/tvtk/scene.py
+++ b/examples/tvtk/scene.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/examples/tvtk/scene_editor.py
+++ b/examples/tvtk/scene_editor.py
@@ -2,7 +2,7 @@
 available in mayavi.  """
 
 # Author: Prabhu Ramachandran <prabhu [at] aero.iitb.ac.in>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from traits.api import HasTraits, Enum, Instance, Any

--- a/examples/tvtk/simple.py
+++ b/examples/tvtk/simple.py
@@ -5,7 +5,7 @@ VTK/Examples/Tutorial/Step6/Python/Cone6.py.
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2004-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from tvtk.api import tvtk

--- a/examples/tvtk/texture_glyph.py
+++ b/examples/tvtk/texture_glyph.py
@@ -6,7 +6,7 @@ the input of the Glyph using Python lists.
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2004-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from tvtk.api import tvtk

--- a/examples/tvtk/tiny_mesh.py
+++ b/examples/tvtk/tiny_mesh.py
@@ -6,7 +6,7 @@ transparently with TVTK.
 """
 
 # Author: Prabhu Ramachandran and Eric Jones
-# Copyright (c) 2004-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from tvtk.api import tvtk

--- a/integrationtests/mayavi/common.py
+++ b/integrationtests/mayavi/common.py
@@ -1,7 +1,7 @@
 """MayaVi test related utilities.
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports

--- a/integrationtests/mayavi/run.py
+++ b/integrationtests/mayavi/run.py
@@ -2,7 +2,7 @@
 """Script to run all the tests.
 """
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008-2020,  Prabhu Ramachandran
+# Copyright (c) Prabhu Ramachandran
 # License: BSD Style.
 
 import sys

--- a/integrationtests/mayavi/test_array_source.py
+++ b/integrationtests/mayavi/test_array_source.py
@@ -1,7 +1,7 @@
 """Tests for the ArraySource data source for MayaVi.
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/integrationtests/mayavi/test_close_scene.py
+++ b/integrationtests/mayavi/test_close_scene.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env mayavi2
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008,  Prabhu Ramachandran
+# Copyright (c) Prabhu Ramachandran
 # License: BSD Style.
 
 """This tests that closing a hidden TVTK scene window does not crash or

--- a/integrationtests/mayavi/test_contour.py
+++ b/integrationtests/mayavi/test_contour.py
@@ -1,7 +1,7 @@
 """Simple test for the contour related modules.
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/integrationtests/mayavi/test_generic_module.py
+++ b/integrationtests/mayavi/test_generic_module.py
@@ -1,7 +1,7 @@
 """Simple test for the GenericModule.
 """
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008,  Prabhu Ramachandran
+# Copyright (c) Prabhu Ramachandran
 # License: BSD Style.
 
 # Standard library imports.

--- a/integrationtests/mayavi/test_glyph.py
+++ b/integrationtests/mayavi/test_glyph.py
@@ -1,7 +1,7 @@
 """Tests for the Glyph module.
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/integrationtests/mayavi/test_grid_plane.py
+++ b/integrationtests/mayavi/test_grid_plane.py
@@ -1,7 +1,7 @@
 """Simple test for the grid plane and outline module.
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/integrationtests/mayavi/test_hide_show.py
+++ b/integrationtests/mayavi/test_hide_show.py
@@ -1,7 +1,7 @@
 """Test for the hide-show feature.
 """
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/integrationtests/mayavi/test_image_data_probe.py
+++ b/integrationtests/mayavi/test_image_data_probe.py
@@ -1,7 +1,7 @@
 """Simple test for the ImageDataProbe filter.
 """
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/integrationtests/mayavi/test_image_plane_widget.py
+++ b/integrationtests/mayavi/test_image_plane_widget.py
@@ -1,7 +1,7 @@
 """Tests for the ImagePlaneWidget module.
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/integrationtests/mayavi/test_ipw_multiple_scalars.py
+++ b/integrationtests/mayavi/test_ipw_multiple_scalars.py
@@ -1,6 +1,6 @@
 
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2009,  Prabhu Ramachandran
+# Copyright (c) Prabhu Ramachandran
 # License: BSD Style.
 
 # Local imports.

--- a/integrationtests/mayavi/test_labels.py
+++ b/integrationtests/mayavi/test_labels.py
@@ -1,7 +1,7 @@
 """Simple test for the ImageDataProbe filter.
 """
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/integrationtests/mayavi/test_mlab.py
+++ b/integrationtests/mayavi/test_mlab.py
@@ -1,7 +1,7 @@
 """Tests for the mlab interface to Mayavi
 """
 # Author: Gael Varoquaux
-# Copyright (c) 2008,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/integrationtests/mayavi/test_optional_collection.py
+++ b/integrationtests/mayavi/test_optional_collection.py
@@ -1,7 +1,7 @@
 """Simple test for the Optional and Collection filters.
 """
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008,  Prabhu Ramachandran
+# Copyright (c) Prabhu Ramachandran
 # License: BSD Style.
 
 # Standard library imports.

--- a/integrationtests/mayavi/test_plot3d_mb_reader.py
+++ b/integrationtests/mayavi/test_plot3d_mb_reader.py
@@ -3,7 +3,7 @@ also tests the SelectOutput filter.
 """
 
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008,  Prabhu Ramachandran
+# Copyright (c) Prabhu Ramachandran
 # License: BSD Style.
 
 # Standard library imports.

--- a/integrationtests/mayavi/test_restore_scene.py
+++ b/integrationtests/mayavi/test_restore_scene.py
@@ -1,7 +1,7 @@
 """Simple test for the Optional and Collection filters.
 """
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008,  Prabhu Ramachandran
+# Copyright (c) Prabhu Ramachandran
 # License: BSD Style.
 
 # Standard library imports.

--- a/integrationtests/mayavi/test_set_active_attribute.py
+++ b/integrationtests/mayavi/test_set_active_attribute.py
@@ -1,5 +1,5 @@
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/integrationtests/mayavi/test_streamline.py
+++ b/integrationtests/mayavi/test_streamline.py
@@ -6,7 +6,7 @@ tests.  However, we recommend that one does not use image based tests
 since they are not always reliable and a pain.
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/integrationtests/mayavi/test_user_defined.py
+++ b/integrationtests/mayavi/test_user_defined.py
@@ -1,7 +1,7 @@
 """Simple test for the UsedDefined filter.
 """
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/integrationtests/mayavi/test_vtk_data_source.py
+++ b/integrationtests/mayavi/test_vtk_data_source.py
@@ -2,7 +2,7 @@
 of test_contour.py with the data source alone modified.
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/integrationtests/mayavi/test_vtk_xml_reader.py
+++ b/integrationtests/mayavi/test_vtk_xml_reader.py
@@ -2,7 +2,7 @@
 of test_contour.py with just the reader changed.
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/__init__.py
+++ b/mayavi/__init__.py
@@ -1,5 +1,5 @@
 # Author: Prabhu Ramachandran, Gael Varoquaux
-# Copyright (c) 2004-2024, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 """ A tool for easy and interactive visualization of data.
     Part of the Mayavi project of the Enthought Tool Suite.

--- a/mayavi/__version__.py
+++ b/mayavi/__version__.py
@@ -1,7 +1,7 @@
 """Version information for MayaVi2.
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2006, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from mayavi.version import version as __version__

--- a/mayavi/action/__init__.py
+++ b/mayavi/action/__init__.py
@@ -1,3 +1,3 @@
 # Author: Prabhu Ramachandran
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.

--- a/mayavi/action/filters.py
+++ b/mayavi/action/filters.py
@@ -1,7 +1,7 @@
 """Actions to start various filters.
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from pyface.action.api import Action

--- a/mayavi/action/help.py
+++ b/mayavi/action/help.py
@@ -3,7 +3,7 @@
 """
 # Authors: Gael Varoquaux <gael.varoquaux[at]normalesup.org>
 #          Prabhu Ramachandran
-# Copyright (c) 2007-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/action/modules.py
+++ b/mayavi/action/modules.py
@@ -2,7 +2,7 @@
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Local imports.

--- a/mayavi/action/save_load.py
+++ b/mayavi/action/save_load.py
@@ -2,7 +2,7 @@
 
 """
 # Author: Prabhu Ramachandran <prabhu@enthought.com>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/action/sources.py
+++ b/mayavi/action/sources.py
@@ -2,7 +2,7 @@
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/components/__init__.py
+++ b/mayavi/components/__init__.py
@@ -1,3 +1,3 @@
 # Author: Prabhu Ramachandran
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.

--- a/mayavi/components/actor.py
+++ b/mayavi/components/actor.py
@@ -2,7 +2,7 @@
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import vtk

--- a/mayavi/components/actor2d.py
+++ b/mayavi/components/actor2d.py
@@ -2,7 +2,7 @@
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/components/common.py
+++ b/mayavi/components/common.py
@@ -1,7 +1,7 @@
 """Common code used by different components.
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/components/contour.py
+++ b/mayavi/components/contour.py
@@ -7,7 +7,7 @@ a convenient option to create "filled contours".
 
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/components/custom_grid_plane.py
+++ b/mayavi/components/custom_grid_plane.py
@@ -2,7 +2,7 @@
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/components/cutter.py
+++ b/mayavi/components/cutter.py
@@ -1,7 +1,7 @@
 """A simple wrapper for `tvtk.Cutter`.
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/mayavi/components/glyph.py
+++ b/mayavi/components/glyph.py
@@ -4,7 +4,7 @@ input point data.
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
 #         KK Rai (kk.rai [at] iitb.ac.in)
 #         R. Ambareesha (ambareesha [at] iitb.ac.in)
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/components/grid_plane.py
+++ b/mayavi/components/grid_plane.py
@@ -2,7 +2,7 @@
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/components/implicit_plane.py
+++ b/mayavi/components/implicit_plane.py
@@ -1,7 +1,7 @@
 """A component to manage an implicit plane widget.
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/components/implicit_widgets.py
+++ b/mayavi/components/implicit_widgets.py
@@ -3,7 +3,7 @@ to be used by various modules.
 """
 # Author: Suyog Dutt Jain <suyog.jain@aero.iitb.ac.in>
 #         Prabhu Ramachandran <prabhu at aero.iitb.ac.in>
-# Copyright (c) 2009-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import pickle

--- a/mayavi/components/optional.py
+++ b/mayavi/components/optional.py
@@ -5,7 +5,7 @@ add a trait in the module to enable/disable a particular component.
 
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/components/poly_data_normals.py
+++ b/mayavi/components/poly_data_normals.py
@@ -1,7 +1,7 @@
 """This component computes normals for input poly data.
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/components/source_widget.py
+++ b/mayavi/components/source_widget.py
@@ -3,7 +3,7 @@ to be used by various modules.
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/components/ui/__init__.py
+++ b/mayavi/components/ui/__init__.py
@@ -1,3 +1,3 @@
 # Author: Judah De Paula
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.

--- a/mayavi/components/ui/actor.py
+++ b/mayavi/components/ui/actor.py
@@ -9,7 +9,7 @@ importing.
 """
 # Authors: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
 #          Judah De Paula <judah@enthought.com>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from traitsui.api import (View, Group, Item, InstanceEditor,

--- a/mayavi/components/ui/contour.py
+++ b/mayavi/components/ui/contour.py
@@ -9,7 +9,7 @@ importing.
 """
 # Authors: Prabhu Ramachandran <prabhu_r@users.sf.net>
 #          Judah De Paula <judah@enthought.com>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from traitsui.api import Item, Group, View

--- a/mayavi/core/__init__.py
+++ b/mayavi/core/__init__.py
@@ -1,3 +1,3 @@
 # Author: Prabhu Ramachandran
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.

--- a/mayavi/core/adder_node.py
+++ b/mayavi/core/adder_node.py
@@ -4,7 +4,7 @@ to the tree.
 """
 # Authors: Judah De Paula <judah@enthought.com>
 #          Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/core/base.py
+++ b/mayavi/core/base.py
@@ -2,7 +2,7 @@
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/core/common.py
+++ b/mayavi/core/common.py
@@ -3,7 +3,7 @@ messages etc.
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/core/component.py
+++ b/mayavi/core/component.py
@@ -2,7 +2,7 @@
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/core/customize.py
+++ b/mayavi/core/customize.py
@@ -18,7 +18,7 @@ custom plugins.
 
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008-2020, Prabhu Ramachandran, Enthought, Inc.
+# Copyright (c) Prabhu Ramachandran, Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/core/dataset_manager.py
+++ b/mayavi/core/dataset_manager.py
@@ -3,7 +3,7 @@ Code to help with managing a TVTK data set in Pythonic ways.
 """
 
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from traits.api import (HasTraits, Instance, Array, Str,

--- a/mayavi/core/engine.py
+++ b/mayavi/core/engine.py
@@ -3,7 +3,7 @@ highest level.
 
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2005-2022, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/core/file_data_source.py
+++ b/mayavi/core/file_data_source.py
@@ -3,7 +3,7 @@ sources derive.
 
 """
 # Author: Prabhu Ramachandran
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/core/filter.py
+++ b/mayavi/core/filter.py
@@ -2,7 +2,7 @@
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/core/lut/__init__.py
+++ b/mayavi/core/lut/__init__.py
@@ -1,4 +1,4 @@
 # Author: Gael Varoquaux
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 

--- a/mayavi/core/lut_manager.py
+++ b/mayavi/core/lut_manager.py
@@ -2,7 +2,7 @@
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import os.path

--- a/mayavi/core/metadata.py
+++ b/mayavi/core/metadata.py
@@ -3,7 +3,7 @@ The definition of different kinds of metadata that is put into the
 mayavi registry
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/core/module.py
+++ b/mayavi/core/module.py
@@ -2,7 +2,7 @@
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/core/module_manager.py
+++ b/mayavi/core/module_manager.py
@@ -3,7 +3,7 @@ tables.
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import numpy

--- a/mayavi/core/null_engine.py
+++ b/mayavi/core/null_engine.py
@@ -9,7 +9,7 @@ not allow for rendering.
 
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from traits.api import HasTraits, Any, Event, Callable

--- a/mayavi/core/off_screen_engine.py
+++ b/mayavi/core/off_screen_engine.py
@@ -2,7 +2,7 @@
 An off-screen mayavi engine.
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from traits.api import Callable, Str

--- a/mayavi/core/pipeline_base.py
+++ b/mayavi/core/pipeline_base.py
@@ -3,7 +3,7 @@ basically abstracts out the common parts of the pipeline interface.
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/core/pipeline_info.py
+++ b/mayavi/core/pipeline_info.py
@@ -3,7 +3,7 @@
  outputs of an object in the pipeline.
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008-2020, Prabhu Ramachandran Enthought, Inc.
+# Copyright (c) Prabhu Ramachandran, Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/core/registry.py
+++ b/mayavi/core/registry.py
@@ -2,7 +2,7 @@
  A registry for engines, sources, filters and modules.
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/core/scene.py
+++ b/mayavi/core/scene.py
@@ -1,7 +1,7 @@
 """A scene object manages a TVTK scene and objects in it.
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/core/source.py
+++ b/mayavi/core/source.py
@@ -2,7 +2,7 @@
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/core/traits_menu.py
+++ b/mayavi/core/traits_menu.py
@@ -2,7 +2,7 @@
  Code related to traits UI menu items for the tree view of mayavi.
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008-2020, Prabhu Ramachandran Enthought, Inc.
+# Copyright (c) Prabhu Ramachandran, Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/core/ui/__init__.py
+++ b/mayavi/core/ui/__init__.py
@@ -1,3 +1,3 @@
 # Author: Judah De Paula
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.

--- a/mayavi/core/ui/engine_rich_view.py
+++ b/mayavi/core/ui/engine_rich_view.py
@@ -2,7 +2,7 @@
 
 """
 # Author: Gael Varoquaux <gael dot varoquaux at normalesup dot org>
-# Copyright (c) 2009, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/core/ui/engine_view.py
+++ b/mayavi/core/ui/engine_view.py
@@ -2,7 +2,7 @@
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/core/ui/lut_manager.py
+++ b/mayavi/core/ui/lut_manager.py
@@ -9,7 +9,7 @@ importing.
 """
 # Authors: Prabhu Ramachandran <prabhu_r@users.sf.net>
 #          Judah De Paula <judah@enthought.com>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from traits.etsconfig.api import ETSConfig

--- a/mayavi/core/ui/mayavi_scene.py
+++ b/mayavi/core/ui/mayavi_scene.py
@@ -2,7 +2,7 @@
 """
 
 # Author: Gael Varoquaux <gael dot varoquaux at normalesup dot org>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports

--- a/mayavi/core/ui/module_manager.py
+++ b/mayavi/core/ui/module_manager.py
@@ -9,7 +9,7 @@ importing.
 """
 # Authors: Prabhu Ramachandran <prabhu_r@users.sf.net>
 #          Judah De Paula <judah@enthought.com>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from traitsui.api import Item, Group, View, EnumEditor

--- a/mayavi/filters/__init__.py
+++ b/mayavi/filters/__init__.py
@@ -1,3 +1,3 @@
 # Author: Prabhu Ramachandran
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.

--- a/mayavi/filters/api.py
+++ b/mayavi/filters/api.py
@@ -2,7 +2,7 @@
 """
 
 # Authors: Frederic Petit, Prabhu Ramachandran and Gael Varoquaux
-# Copyright (c) 2007-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from .cell_derivatives import CellDerivatives

--- a/mayavi/filters/cell_derivatives.py
+++ b/mayavi/filters/cell_derivatives.py
@@ -1,5 +1,5 @@
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/filters/cell_to_point_data.py
+++ b/mayavi/filters/cell_to_point_data.py
@@ -1,5 +1,5 @@
 # Author: Prabhu Ramachandran <prabhu_r at users dot sf dot net>
-# Copyright (c) 2006, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/filters/collection.py
+++ b/mayavi/filters/collection.py
@@ -2,7 +2,7 @@
 filters/components bundled into one.
 """
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/filters/contour.py
+++ b/mayavi/filters/contour.py
@@ -1,5 +1,5 @@
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008,  Prabhu Ramachandran
+# Copyright (c) Prabhu Ramachandran
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/filters/cut_plane.py
+++ b/mayavi/filters/cut_plane.py
@@ -1,5 +1,5 @@
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008,  Prabhu Ramachandran
+# Copyright (c) Prabhu Ramachandran
 # License: BSD Style.
 
 # Local imports.

--- a/mayavi/filters/data_set_clipper.py
+++ b/mayavi/filters/data_set_clipper.py
@@ -3,7 +3,7 @@ using various Implicit Widgets.
 """
 # Author: Suyog Dutt Jain <suyog.jain@aero.iitb.ac.in>
 #         Prabhu Ramachandran <prabhu at aero.iitb.ac.in>
-# Copyright (c) 2009-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/filters/decimatepro.py
+++ b/mayavi/filters/decimatepro.py
@@ -1,5 +1,5 @@
 # Author: Gael Varoquaux <gael _dot_ varoquaux _at_ normalesup _dot_ org>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/filters/delaunay2d.py
+++ b/mayavi/filters/delaunay2d.py
@@ -1,5 +1,5 @@
 # Author: Prabhu Ramachandran <prabhu_r at users dot sf dot net>
-# Copyright (c) 2006, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/filters/delaunay3d.py
+++ b/mayavi/filters/delaunay3d.py
@@ -1,5 +1,5 @@
 # Author: Prabhu Ramachandran <prabhu_r at users dot sf dot net>
-# Copyright (c) 2006, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/filters/elevation_filter.py
+++ b/mayavi/filters/elevation_filter.py
@@ -1,5 +1,5 @@
 # Author: Gael Varoquaux <gael _dot_ varoquaux _at_ normalesup _dot_ org>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/filters/extract_edges.py
+++ b/mayavi/filters/extract_edges.py
@@ -1,5 +1,5 @@
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/filters/extract_grid.py
+++ b/mayavi/filters/extract_grid.py
@@ -4,7 +4,7 @@ Rectilinear.
 
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2007-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/filters/extract_tensor_components.py
+++ b/mayavi/filters/extract_tensor_components.py
@@ -1,5 +1,5 @@
 # Author: Prabhu Ramachandran <prabhu_r at users dot sf dot net>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/filters/extract_unstructured_grid.py
+++ b/mayavi/filters/extract_unstructured_grid.py
@@ -1,5 +1,5 @@
 # Author: Prabhu Ramachandran <prabhu_r at users dot sf dot net>
-# Copyright (c) 2006, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/filters/extract_vector_norm.py
+++ b/mayavi/filters/extract_vector_norm.py
@@ -1,5 +1,5 @@
 # Author: Prabhu Ramachandran <prabhu_r at users dot sf dot net>
-# Copyright (c) 2006, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/filters/filter_base.py
+++ b/mayavi/filters/filter_base.py
@@ -1,7 +1,7 @@
 """The base class for many filters.
 """
 # Author: Prabhu Ramachandran <prabhu_r at users dot sf dot net>
-# Copyright (c) 2006, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/mayavi/filters/gaussian_splatter.py
+++ b/mayavi/filters/gaussian_splatter.py
@@ -1,5 +1,5 @@
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/filters/greedy_terrain_decimation.py
+++ b/mayavi/filters/greedy_terrain_decimation.py
@@ -1,5 +1,5 @@
 # Author: Gael Varoquaux <gael _dot_ varoquaux _at_ normalesup _dot_ org>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/filters/image_change_information.py
+++ b/mayavi/filters/image_change_information.py
@@ -3,7 +3,7 @@ A filter that lets you change the spacing and origin of an input
 ImageData dataset.
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/filters/image_data_probe.py
+++ b/mayavi/filters/image_data_probe.py
@@ -1,5 +1,5 @@
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/filters/mask_points.py
+++ b/mayavi/filters/mask_points.py
@@ -1,5 +1,5 @@
 # Author: Prabhu Ramachandran <prabhu_r at users dot sf dot net>
-# Copyright (c) 2006, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/filters/metadata.py
+++ b/mayavi/filters/metadata.py
@@ -2,7 +2,7 @@
 Metadata for all filters.
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008, Prabhu Ramachandran Enthought, Inc.
+# Copyright (c) Prabhu Ramachandran, Enthought, Inc.
 # License: BSD Style.
 
 # Local imports.

--- a/mayavi/filters/optional.py
+++ b/mayavi/filters/optional.py
@@ -2,7 +2,7 @@
 around any mayavi filter or component.
 """
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008,  Prabhu Ramachandran
+# Copyright (c) Prabhu Ramachandran
 # License: BSD Style.
 
 from mayavi.filters.wrapper import Wrapper

--- a/mayavi/filters/point_to_cell_data.py
+++ b/mayavi/filters/point_to_cell_data.py
@@ -1,5 +1,5 @@
 # Author: Prabhu Ramachandran <prabhu_r at users dot sf dot net>
-# Copyright (c) 2006, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/filters/poly_data_filter_base.py
+++ b/mayavi/filters/poly_data_filter_base.py
@@ -1,5 +1,5 @@
 # Author: Gael Varoquaux <gael _dot_ varoquaux _at_ normalesup _dot_ org>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Local imports

--- a/mayavi/filters/poly_data_normals.py
+++ b/mayavi/filters/poly_data_normals.py
@@ -1,5 +1,5 @@
 # Author: Prabhu Ramachandran <prabhu_r at users dot sf dot net>
-# Copyright (c) 2006, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/filters/quadric_decimation.py
+++ b/mayavi/filters/quadric_decimation.py
@@ -1,5 +1,5 @@
 # Author: Gael Varoquaux <gael _dot_ varoquaux _at_ normalesup _dot_ org>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/filters/select_output.py
+++ b/mayavi/filters/select_output.py
@@ -3,7 +3,7 @@ of a given input.  This is typically very useful for a multi-block data
 source.  """
 
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008,  Prabhu Ramachandran
+# Copyright (c) Prabhu Ramachandran
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/filters/set_active_attribute.py
+++ b/mayavi/filters/set_active_attribute.py
@@ -1,5 +1,5 @@
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/filters/stripper.py
+++ b/mayavi/filters/stripper.py
@@ -1,5 +1,5 @@
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/filters/threshold.py
+++ b/mayavi/filters/threshold.py
@@ -2,9 +2,9 @@
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2010, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import numpy as np

--- a/mayavi/filters/transform_data.py
+++ b/mayavi/filters/transform_data.py
@@ -4,7 +4,7 @@ ImageData/StructuredPoints/RectilinearGrid.
 
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2006-2020,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/filters/triangle_filter.py
+++ b/mayavi/filters/triangle_filter.py
@@ -1,5 +1,5 @@
 # Author: Robert Kern <robert.kern@enthought.com>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/filters/tube.py
+++ b/mayavi/filters/tube.py
@@ -1,5 +1,5 @@
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/filters/user_defined.py
+++ b/mayavi/filters/user_defined.py
@@ -1,5 +1,5 @@
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/filters/vorticity.py
+++ b/mayavi/filters/vorticity.py
@@ -1,5 +1,5 @@
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/filters/warp_scalar.py
+++ b/mayavi/filters/warp_scalar.py
@@ -1,5 +1,5 @@
 # Author: Prabhu Ramachandran <prabhu_r at users dot sf dot net>
-# Copyright (c) 2006, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/filters/warp_vector.py
+++ b/mayavi/filters/warp_vector.py
@@ -1,5 +1,5 @@
 # Author: Prabhu Ramachandran <prabhu_r at users dot sf dot net>
-# Copyright (c) 2006, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/filters/wrapper.py
+++ b/mayavi/filters/wrapper.py
@@ -4,7 +4,7 @@ from the UI, for that see the `Optional` filter.
 """
 
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/mlab.py
+++ b/mayavi/mlab.py
@@ -7,7 +7,7 @@ application with a compatible UI (Qt or wxPython).
 
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
 #         Gael Varoquaux <gael dot varoquaux at normalesup dot org>
-# Copyright (c) 2007-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/mayavi/modules/__init__.py
+++ b/mayavi/modules/__init__.py
@@ -1,3 +1,3 @@
 # Author: Prabhu Ramachandran
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.

--- a/mayavi/modules/api.py
+++ b/mayavi/modules/api.py
@@ -2,7 +2,7 @@
 """
 
 # Author: Frederic Petit and Prabhu Ramachandran
-# Copyright (c) 2007-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/mayavi/modules/axes.py
+++ b/mayavi/modules/axes.py
@@ -1,7 +1,7 @@
 """Draws a simple axes using tvtk.CubeAxesActor2D.
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/modules/contour_grid_plane.py
+++ b/mayavi/modules/contour_grid_plane.py
@@ -4,7 +4,7 @@ for structured points, rectilinear grid and structured grid input.
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/modules/custom_grid_plane.py
+++ b/mayavi/modules/custom_grid_plane.py
@@ -4,7 +4,7 @@ datasets.
 
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2007,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/mayavi/modules/generic_module.py
+++ b/mayavi/modules/generic_module.py
@@ -5,7 +5,7 @@ create new modules.
 """
 
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/modules/glyph.py
+++ b/mayavi/modules/glyph.py
@@ -2,7 +2,7 @@
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/mayavi/modules/grid_plane.py
+++ b/mayavi/modules/grid_plane.py
@@ -2,7 +2,7 @@
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/modules/image_actor.py
+++ b/mayavi/modules/image_actor.py
@@ -1,7 +1,7 @@
 """Displays ImageData efficiently.
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/mayavi/modules/image_plane_widget.py
+++ b/mayavi/modules/image_plane_widget.py
@@ -2,7 +2,7 @@
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/modules/iso_surface.py
+++ b/mayavi/modules/iso_surface.py
@@ -2,7 +2,7 @@
 point data.
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/mayavi/modules/labels.py
+++ b/mayavi/modules/labels.py
@@ -1,5 +1,5 @@
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/modules/metadata.py
+++ b/mayavi/modules/metadata.py
@@ -2,7 +2,7 @@
 Metadata for all modules.
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008, Prabhu Ramachandran Enthought, Inc.
+# Copyright (c) Prabhu Ramachandran, Enthought, Inc.
 # License: BSD Style.
 
 # Local imports.

--- a/mayavi/modules/orientation_axes.py
+++ b/mayavi/modules/orientation_axes.py
@@ -3,7 +3,7 @@ co-ordinate axes and thereby marks the orientation of the scene.  It
 uses the OrientationMarkerWidget which requires VTK-4.5 and above.
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/mayavi/modules/outline.py
+++ b/mayavi/modules/outline.py
@@ -5,7 +5,7 @@
 # Authors: Prabhu Ramachandran <prabhu_r [at] users.sf.net>
 #          KK Rai (kk.rai [at] iitb.ac.in)
 #          R. Ambareesha (ambareesha [at] iitb.ac.in)
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/modules/scalar_cut_plane.py
+++ b/mayavi/modules/scalar_cut_plane.py
@@ -3,7 +3,7 @@ plots the data with optional contouring and scalar warping.
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/modules/streamline.py
+++ b/mayavi/modules/streamline.py
@@ -5,7 +5,7 @@ supports different types of interactive modes of calculating the
 streamlines.
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/modules/structured_grid_outline.py
+++ b/mayavi/modules/structured_grid_outline.py
@@ -1,7 +1,7 @@
 """Draws a grid-conforming outline for structured grids.
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2007,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/mayavi/modules/surface.py
+++ b/mayavi/modules/surface.py
@@ -1,7 +1,7 @@
 """Draws a surface for any input dataset with optional contouring.
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/mayavi/modules/text.py
+++ b/mayavi/modules/text.py
@@ -2,7 +2,7 @@
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/modules/text3d.py
+++ b/mayavi/modules/text3d.py
@@ -6,7 +6,7 @@ and in 2D on the screen. As a result the text resizes with the figure,
 and can be masked by objects in the foreground.
 """
 # Author: Gael Varoquaux <gael dot varoquaux at normalesup dot org>
-# Copyright (c) 2009, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/modules/ui/__init__.py
+++ b/mayavi/modules/ui/__init__.py
@@ -1,3 +1,3 @@
 # Author: Judah De Paula
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.

--- a/mayavi/modules/ui/iso_surface.py
+++ b/mayavi/modules/ui/iso_surface.py
@@ -9,7 +9,7 @@ importing.
 """
 # Authors: Prabhu Ramachandran <prabhu_r@users.sf.net>
 #          Judah De Paula <judah@enthought.com>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from traitsui.api import Item, Group, View, InstanceEditor

--- a/mayavi/modules/ui/surface.py
+++ b/mayavi/modules/ui/surface.py
@@ -9,7 +9,7 @@ importing.
 """
 # Authors: Prabhu Ramachandran <prabhu_r@users.sf.net>
 #          Judah De Paula <judah@enthought.com>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/mayavi/modules/vector_cut_plane.py
+++ b/mayavi/modules/vector_cut_plane.py
@@ -5,7 +5,7 @@ attributes.
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/mayavi/modules/vectors.py
+++ b/mayavi/modules/vectors.py
@@ -4,7 +4,7 @@ that is entirely based on the Glyph module.
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/mayavi/modules/volume.py
+++ b/mayavi/modules/volume.py
@@ -6,7 +6,7 @@ probably with the ImageData based renderers.
 
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2006-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard imports

--- a/mayavi/modules/warp_vector_cut_plane.py
+++ b/mayavi/modules/warp_vector_cut_plane.py
@@ -5,7 +5,7 @@ are displayed on the warped surface as colors.
 
 """
 # Authors: Fr�d�ric Petit and Prabhu Ramachandran
-# Copyright (c) 2006, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/mayavi/plugins/__init__.py
+++ b/mayavi/plugins/__init__.py
@@ -1,3 +1,3 @@
 # Author: Prabhu Ramachandran
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.

--- a/mayavi/plugins/app.py
+++ b/mayavi/plugins/app.py
@@ -1,7 +1,7 @@
 """The Mayavi Envisage application.
 """
 # Author: Prabhu Ramachandran <prabhu@enthought.com>
-# Copyright (c) 2008-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/plugins/envisage_engine.py
+++ b/mayavi/plugins/envisage_engine.py
@@ -1,7 +1,7 @@
 """The MayaVi Engine meant to be used with Envisage.
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/plugins/mayavi_plugin.py
+++ b/mayavi/plugins/mayavi_plugin.py
@@ -1,7 +1,7 @@
 """The Mayavi plugin.
 """
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from traits.api import List

--- a/mayavi/plugins/mayavi_ui_action_set.py
+++ b/mayavi/plugins/mayavi_ui_action_set.py
@@ -1,7 +1,7 @@
 """Mayavi action set for menus and actions etc.
 """
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/plugins/mayavi_ui_plugin.py
+++ b/mayavi/plugins/mayavi_ui_plugin.py
@@ -1,7 +1,7 @@
 """The Mayavi UI plugin
 """
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/plugins/mayavi_workbench_application.py
+++ b/mayavi/plugins/mayavi_workbench_application.py
@@ -1,7 +1,7 @@
 """Mayavi specific workbench application.
 """
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/plugins/script.py
+++ b/mayavi/plugins/script.py
@@ -6,7 +6,7 @@ safe to instantiate as many Script instances as desired.
 """
 
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought imports

--- a/mayavi/preferences/__init__.py
+++ b/mayavi/preferences/__init__.py
@@ -1,3 +1,3 @@
 # Author: Prabhu Ramachandran
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.

--- a/mayavi/preferences/bindings.py
+++ b/mayavi/preferences/bindings.py
@@ -2,7 +2,7 @@
 Code to setup the preferences for common objects.
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008-2020, Enthought Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import ast

--- a/mayavi/preferences/contrib_finder.py
+++ b/mayavi/preferences/contrib_finder.py
@@ -4,7 +4,7 @@ on startup.
 """
 
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008-2020, Prabhu Ramachandran
+# Copyright (c) Prabhu Ramachandran
 # License: BSD Style.
 
 import sys

--- a/mayavi/preferences/mayavi_preferences_page.py
+++ b/mayavi/preferences/mayavi_preferences_page.py
@@ -1,7 +1,7 @@
 """Preferences for Mayavi
 """
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/preferences/preference_manager.py
+++ b/mayavi/preferences/preference_manager.py
@@ -16,7 +16,7 @@ package).
 
 """
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports

--- a/mayavi/preferences/preference_manager_view.py
+++ b/mayavi/preferences/preference_manager_view.py
@@ -2,7 +2,7 @@
 A view for the Mayavi preferences outside of Envisage.
 """
 # Author: Gael Varoquaux <gael dot varoquaux at normalesup dot org>
-# Copyright (c) 2008,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports

--- a/mayavi/preferences/preferences_helpers.py
+++ b/mayavi/preferences/preferences_helpers.py
@@ -1,7 +1,7 @@
 """Various preference helpers for the mayavi preferences.
 """
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008-2020,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports

--- a/mayavi/scripts/__init__.py
+++ b/mayavi/scripts/__init__.py
@@ -1,3 +1,3 @@
 # Author: Prabhu Ramachandran
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.

--- a/mayavi/scripts/mayavi2.py
+++ b/mayavi/scripts/mayavi2.py
@@ -9,7 +9,7 @@ Mayavi2: https://mayavi.readthedocs.io/en/latest/overview.html
 
 """
 # Author: Prabhu Ramachandran <prabhu@enthought.com>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/scripts/util.py
+++ b/mayavi/scripts/util.py
@@ -3,7 +3,7 @@ significant envisage/mayavi code but is useful for scripts that use
 mayavi.
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import sys

--- a/mayavi/sources/__init__.py
+++ b/mayavi/sources/__init__.py
@@ -1,3 +1,3 @@
 # Author: Prabhu Ramachandran
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.

--- a/mayavi/sources/api.py
+++ b/mayavi/sources/api.py
@@ -2,7 +2,7 @@
 """
 
 # Author: Frederic Petit, Prabhu Ramachandran
-# Copyright (c) 2007-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/mayavi/sources/array_source.py
+++ b/mayavi/sources/array_source.py
@@ -2,7 +2,7 @@
 array as ImageData.  This supports both scalar and vector data.
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/sources/builtin_image.py
+++ b/mayavi/sources/builtin_image.py
@@ -3,7 +3,7 @@ A module that offers lots of VTK image data sources
 """
 #Author: Suyog Dutt Jain <suyog.jain@aero.iitb.ac.in>
 #        Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2008,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/sources/builtin_surface.py
+++ b/mayavi/sources/builtin_surface.py
@@ -4,7 +4,7 @@ poly data sources.
 
 #Author: Suyog Dutt Jain <suyog.jain@aero.iitb.ac.in>
 #        Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2008,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/sources/chaco_reader.py
+++ b/mayavi/sources/chaco_reader.py
@@ -1,7 +1,7 @@
 """A Chaco file reader.
 """
 # Author: Suyog Dutt Jain <suyog.jain@aero.iitb.ac.in>
-# Copyright (c) 2009, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/sources/image_reader.py
+++ b/mayavi/sources/image_reader.py
@@ -6,7 +6,7 @@
 #          Chandrashekhar Kaushik
 #          Suyog Dutt Jain <suyog.jain [at] aero.iitb.ac.in>
 #          Prabhu Ramachandran <prabhu [at] aero.iitb.ac.in>
-# Copyright (c) 2007-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from os.path import basename

--- a/mayavi/sources/metadata.py
+++ b/mayavi/sources/metadata.py
@@ -2,7 +2,7 @@
 Metadata for all sources.
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008, Prabhu Ramachandran Enthought, Inc.
+# Copyright (c) Prabhu Ramachandran, Enthought, Inc.
 # License: BSD Style.
 
 # Local imports.

--- a/mayavi/sources/plot3d_reader.py
+++ b/mayavi/sources/plot3d_reader.py
@@ -3,7 +3,7 @@ files.
 
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2007-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/mayavi/sources/poly_data_reader.py
+++ b/mayavi/sources/poly_data_reader.py
@@ -2,7 +2,7 @@
 """
 # Author:   R.Sreekanth <sreekanth [at] aero.iitb.ac.in>
 #               Suyog Dutt Jain <suyog.jain [at] aero.iitb.ac.in>
-# Copyright (c) 2009-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/sources/three_ds_importer.py
+++ b/mayavi/sources/three_ds_importer.py
@@ -2,7 +2,7 @@
 
 """
 # Author: Prabhu Ramachandran <prabhu at aero dot iitb dot ac dot in>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/sources/ui/__init__.py
+++ b/mayavi/sources/ui/__init__.py
@@ -1,3 +1,3 @@
 # Author: Judah De Paula
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.

--- a/mayavi/sources/ui/parametric_surface.py
+++ b/mayavi/sources/ui/parametric_surface.py
@@ -10,7 +10,7 @@ importing.
 # Authors: Prabhu Ramachandran <prabhu_r@users.sf.net>
 #          Vibha Srinivasan <vibha@enthought.com>
 #          Judah De Paula <judah@enthought.com>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 from traitsui.api import Item, Group, View
 

--- a/mayavi/sources/unstructured_grid_reader.py
+++ b/mayavi/sources/unstructured_grid_reader.py
@@ -2,7 +2,7 @@
 """
 # Author:   R.Sreekanth <sreekanth [at] aero.iitb.ac.in>
 #               Suyog Dutt Jain <suyog.jain [at] aero.iitb.ac.in>
-# Copyright (c) 2009-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from os.path import basename

--- a/mayavi/sources/volume_reader.py
+++ b/mayavi/sources/volume_reader.py
@@ -1,6 +1,6 @@
 """A Volume file reader"""
 # Author: Suyog Dutt Jain <suyog.jain@aero.iitb.ac.in>
-# Copyright (c) 2009, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/sources/vrml_importer.py
+++ b/mayavi/sources/vrml_importer.py
@@ -2,7 +2,7 @@
 
 """
 # Author: Prabhu Ramachandran <prabhu at aero dot iitb dot ac dot in>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/sources/vtk_data_source.py
+++ b/mayavi/sources/vtk_data_source.py
@@ -3,7 +3,7 @@ pickled or persisted, it saves the data given to it in the form of a
 gzipped string.
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import sys

--- a/mayavi/sources/vtk_file_reader.py
+++ b/mayavi/sources/vtk_file_reader.py
@@ -2,7 +2,7 @@
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/sources/vtk_xml_file_reader.py
+++ b/mayavi/sources/vtk_xml_file_reader.py
@@ -1,7 +1,7 @@
 """A VTK XML file reader object.
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/tests/common.py
+++ b/mayavi/tests/common.py
@@ -3,7 +3,7 @@ Common code for mayavi tests.
 
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 import os.path
 

--- a/mayavi/tests/data_reader_test_base.py
+++ b/mayavi/tests/data_reader_test_base.py
@@ -1,5 +1,5 @@
 # Author: Suyog Dutt Jain <suyog.jain@aero.iitb.ac.in>
-# Copyright (c) 2009,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/tests/datasets.py
+++ b/mayavi/tests/datasets.py
@@ -1,6 +1,6 @@
 # Author: Suyog Dutt Jain <suyog.jain@aero.iitb.ac.in>
 #         Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2008,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/tests/runtests.py
+++ b/mayavi/tests/runtests.py
@@ -7,7 +7,7 @@ thing.
 """
 
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2009-2020,  Enthought Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import sys

--- a/mayavi/tests/test_array_source.py
+++ b/mayavi/tests/test_array_source.py
@@ -2,7 +2,7 @@
 Tests for the ArraySource class.
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008, Prabhu Ramachandran Enthought, Inc.
+# Copyright (c) Prabhu Ramachandran, Enthought, Inc.
 # License: BSD Style.
 
 import unittest

--- a/mayavi/tests/test_builtin_image.py
+++ b/mayavi/tests/test_builtin_image.py
@@ -1,6 +1,6 @@
 # Author: Suyog Dutt Jain <suyog.jain@aero.iitb.ac.in>
 #         Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2008-2020,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/tests/test_builtin_surface.py
+++ b/mayavi/tests/test_builtin_surface.py
@@ -1,6 +1,6 @@
 # Author: Suyog Dutt Jain <suyog.jain@aero.iitb.ac.in>
 #         Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2008-2020,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/tests/test_contour.py
+++ b/mayavi/tests/test_contour.py
@@ -1,6 +1,6 @@
 # Author: Suyog Dutt Jain <suyog.jain@aero.iitb.ac.in>
 #         Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2008-2020,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/tests/test_core_common.py
+++ b/mayavi/tests/test_core_common.py
@@ -2,7 +2,7 @@
 Tests for the mayavi.core.common module.
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import os

--- a/mayavi/tests/test_csv_sniff.py
+++ b/mayavi/tests/test_csv_sniff.py
@@ -2,7 +2,7 @@
 Tests for the CSV file sniffer
 """
 # Author: Ilan Schnell <ischnell@enthought.com>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 import glob
 import os

--- a/mayavi/tests/test_cut_plane.py
+++ b/mayavi/tests/test_cut_plane.py
@@ -1,5 +1,5 @@
 # Author: Deepak Surti <dsurti@enthought.com>
-# Copyright (c) 2015,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/tests/test_dataset_manager.py
+++ b/mayavi/tests/test_dataset_manager.py
@@ -2,7 +2,7 @@
 Test for the dataset_manager.py module.
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import unittest

--- a/mayavi/tests/test_extract_grid_filter.py
+++ b/mayavi/tests/test_extract_grid_filter.py
@@ -1,6 +1,6 @@
 # Author: Suyog Dutt Jain <suyog.jain@aero.iitb.ac.in>
 #         Prabhu Ramachandran
-# Copyright (c) 2009,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/tests/test_garbage_collection.py
+++ b/mayavi/tests/test_garbage_collection.py
@@ -1,7 +1,7 @@
 """ Tests for the garbage collection of objects in mayavi package.
 """
 # Authors: Deepak Surti, Ioannis Tziakos
-# Copyright (c) 2015, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import unittest

--- a/mayavi/tests/test_glyph.py
+++ b/mayavi/tests/test_glyph.py
@@ -1,6 +1,6 @@
 # Author: Suyog Dutt Jain <suyog.jain@aero.iitb.ac.in>
 #         Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2008-2020,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/tests/test_grid_plane.py
+++ b/mayavi/tests/test_grid_plane.py
@@ -1,6 +1,6 @@
 # Author: Suyog Dutt Jain <suyog.jain@aero.iitb.ac.in>
 #         Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2008-2020,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/tests/test_image_data_probe.py
+++ b/mayavi/tests/test_image_data_probe.py
@@ -1,6 +1,6 @@
 # Author: Suyog Dutt Jain <suyog.jain@aero.iitb.ac.in>
 #         Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2008,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/tests/test_image_data_reader.py
+++ b/mayavi/tests/test_image_data_reader.py
@@ -1,5 +1,5 @@
 # Author: Suyog Dutt Jain <suyog.jain@aero.iitb.ac.in>
-# Copyright (c) 2009,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/tests/test_image_plane_widget.py
+++ b/mayavi/tests/test_image_plane_widget.py
@@ -1,6 +1,6 @@
 # Author: Suyog Dutt Jain <suyog.jain@aero.iitb.ac.in>
 #         Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2008-2020,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/tests/test_mayavi_traits.py
+++ b/mayavi/tests/test_mayavi_traits.py
@@ -2,7 +2,7 @@
 Tests for traits defined in mayavi.core.traits
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008, Prabhu Ramachandran Enthought, Inc.
+# Copyright (c) Prabhu Ramachandran, Enthought, Inc.
 # License: BSD Style.
 
 import unittest

--- a/mayavi/tests/test_mlab_source.py
+++ b/mayavi/tests/test_mlab_source.py
@@ -2,7 +2,7 @@
 Test for MlabSource and its subclasses.
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import unittest

--- a/mayavi/tests/test_mlab_source_integration.py
+++ b/mayavi/tests/test_mlab_source_integration.py
@@ -6,7 +6,7 @@ MlabSource subclasses. They are meant to capture errors in the formatting
 of the input arguments.
 """
 # Author: Gael Varoquaux <gael dot varoquaux at normalesup dot org>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import unittest

--- a/mayavi/tests/test_no_ui_toolkit.py
+++ b/mayavi/tests/test_no_ui_toolkit.py
@@ -2,7 +2,7 @@
 Tests to try and ensure that important mayavi imports work with no UI.
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2009, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import sys

--- a/mayavi/tests/test_optional_collection.py
+++ b/mayavi/tests/test_optional_collection.py
@@ -1,6 +1,6 @@
 # Author: Suyog Dutt Jain <suyog.jain@aero.iitb.ac.in>
 #         Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2008-2020,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/tests/test_pipeline_info.py
+++ b/mayavi/tests/test_pipeline_info.py
@@ -2,7 +2,7 @@
 Tests for the pipeline_info.py module
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008, Prabhu Ramachandran Enthought, Inc.
+# Copyright (c) Prabhu Ramachandran, Enthought, Inc.
 # License: BSD Style.
 
 import unittest

--- a/mayavi/tests/test_plot3d_mb_reader.py
+++ b/mayavi/tests/test_plot3d_mb_reader.py
@@ -1,6 +1,6 @@
 # Author: Suyog Dutt Jain <suyog.jain@aero.iitb.ac.in>
 #         Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2008-2020,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/tests/test_poly_data_reader.py
+++ b/mayavi/tests/test_poly_data_reader.py
@@ -1,5 +1,5 @@
 # Author: Suyog Dutt Jain <suyog.jain@aero.iitb.ac.in>
-# Copyright (c) 2009-2020,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/tests/test_preferences_mirror.py
+++ b/mayavi/tests/test_preferences_mirror.py
@@ -1,5 +1,5 @@
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008, Enthought Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import unittest

--- a/mayavi/tests/test_recorder.py
+++ b/mayavi/tests/test_recorder.py
@@ -4,7 +4,7 @@ refactored to move to AppTools however we repeat the tests here with a
 TVTK object to ensure that the test works with TVTK objects.
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import sys

--- a/mayavi/tests/test_registry.py
+++ b/mayavi/tests/test_registry.py
@@ -1,5 +1,5 @@
 # Author: Suyog Dutt Jain <suyog.jain@aero.iitb.ac.in>
-# Copyright (c) 2009-2020,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/tests/test_script_recording.py
+++ b/mayavi/tests/test_script_recording.py
@@ -2,7 +2,7 @@
 A simple test for script recording in Mayavi.
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import unittest

--- a/mayavi/tests/test_set_active_attribute.py
+++ b/mayavi/tests/test_set_active_attribute.py
@@ -1,6 +1,6 @@
 # Author: Suyog Dutt Jain <suyog.jain@aero.iitb.ac.in>
 #         Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2008-2020,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/tests/test_sources.py
+++ b/mayavi/tests/test_sources.py
@@ -1,5 +1,5 @@
 # Author: Stefano Borini <stefano borini at enthought dot com>
-# Copyright (c) 2009-2020,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/tests/test_streamline.py
+++ b/mayavi/tests/test_streamline.py
@@ -1,6 +1,6 @@
 # Author: Suyog Dutt Jain <suyog.jain@aero.iitb.ac.in>
 #         Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2008-2020,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/tests/test_text3d.py
+++ b/mayavi/tests/test_text3d.py
@@ -1,5 +1,5 @@
 # Author: Gael Varoquaux <gael dot varoquaux at enthought dot com>
-# Copyright (c) 2009-2020,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/tests/test_threshold_filter.py
+++ b/mayavi/tests/test_threshold_filter.py
@@ -1,5 +1,5 @@
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2010,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/tests/test_unstructured_data_reader.py
+++ b/mayavi/tests/test_unstructured_data_reader.py
@@ -1,5 +1,5 @@
 # Author: Suyog Dutt Jain <suyog.jain@aero.iitb.ac.in>
-# Copyright (c) 2009,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/tests/test_user_defined.py
+++ b/mayavi/tests/test_user_defined.py
@@ -1,6 +1,6 @@
 # Author: Suyog Dutt Jain <suyog.jain@aero.iitb.ac.in>
 #         Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2008-2020,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/tests/test_vtk_data_source.py
+++ b/mayavi/tests/test_vtk_data_source.py
@@ -1,6 +1,6 @@
 # Author: Suyog Dutt Jain <suyog.jain@aero.iitb.ac.in>
 #         Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2008-2020,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/tests/test_vtk_file_reader.py
+++ b/mayavi/tests/test_vtk_file_reader.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/tests/test_vtk_xml_reader.py
+++ b/mayavi/tests/test_vtk_xml_reader.py
@@ -1,6 +1,6 @@
 # Author: Suyog Dutt Jain <suyog.jain@aero.iitb.ac.in>
 #         Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2008-2020,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/tools/__init__.py
+++ b/mayavi/tools/__init__.py
@@ -1,3 +1,3 @@
 # Author: Prabhu Ramachandran
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.

--- a/mayavi/tools/animator.py
+++ b/mayavi/tools/animator.py
@@ -2,7 +2,7 @@
 Simple utility code for animations.
 """
 # Author: Prabhu Ramachandran <prabhu at aerodotiitbdotacdotin>
-# Copyright (c) 2009, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import types

--- a/mayavi/tools/auto_doc.py
+++ b/mayavi/tools/auto_doc.py
@@ -3,7 +3,7 @@ Automatic documentation from traited objects.
 """
 
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2007-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from textwrap import wrap, dedent

--- a/mayavi/tools/camera.py
+++ b/mayavi/tools/camera.py
@@ -3,7 +3,7 @@ Controlling the camera.
 """
 
 # Author: Gael Varoquaux and Prabhu Ramachandran
-# Copyright (c) 2007-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/tools/data_wizards/csv_loader.py
+++ b/mayavi/tools/data_wizards/csv_loader.py
@@ -1,5 +1,5 @@
 # Author: Ilan Schnell <ischnell@enthought.com>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/mayavi/tools/data_wizards/csv_sniff.py
+++ b/mayavi/tools/data_wizards/csv_sniff.py
@@ -1,5 +1,5 @@
 # Author: Ilan Schnell <ischnell@enthought.com>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # TODO: should derive from HasTraits

--- a/mayavi/tools/data_wizards/csv_source_factory.py
+++ b/mayavi/tools/data_wizards/csv_source_factory.py
@@ -3,7 +3,7 @@ Factory used by mayavi to import csv-like files into datasets.
 """
 
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from traits.api import HasTraits, Callable

--- a/mayavi/tools/decorations.py
+++ b/mayavi/tools/decorations.py
@@ -4,7 +4,7 @@ pipeline in a procedural way.
 """
 
 # Author: Gael Varoquaux
-# Copyright (c) 2007-2020 Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import numbers

--- a/mayavi/tools/figure.py
+++ b/mayavi/tools/figure.py
@@ -4,7 +4,7 @@ Functions related to creating the engine or the figures.
 """
 
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mayavi/tools/filters.py
+++ b/mayavi/tools/filters.py
@@ -8,7 +8,7 @@ helper functions.
 
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
 #         Prabhu Ramachandran
-# Copyright (c) 2007-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from traits.api import Instance, CFloat, CInt, CArray, Trait, \

--- a/mayavi/tools/helper_functions.py
+++ b/mayavi/tools/helper_functions.py
@@ -10,7 +10,7 @@ both for testing and to ilustrate its use.
 """
 
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from .modules import VectorsFactory, StreamlineFactory, GlyphFactory, \

--- a/mayavi/tools/mlab.py
+++ b/mayavi/tools/mlab.py
@@ -1,5 +1,5 @@
 # Author: Gael Varoquaux <gael.varoquaux at normalesup.org>
-# Copyright (c) 2007-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 print("!! mayavi.tools.mlab is obsolete and has been replaced by !!")

--- a/mayavi/tools/mlab_scene_model.py
+++ b/mayavi/tools/mlab_scene_model.py
@@ -1,7 +1,7 @@
 """`MlabSceneModel` makes it easy to plug `mayavi.mlab` in traits UI views.
 """
 # Authors: Prabhu Ramachandran <prabhu [at] aero.iitb.ac.in>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from traits.api import Instance, Property

--- a/mayavi/tools/modules.py
+++ b/mayavi/tools/modules.py
@@ -8,7 +8,7 @@ helper functions.
 
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
 #         Prabhu Ramachandran
-# Copyright (c) 2007-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import numpy

--- a/mayavi/tools/pipe_base.py
+++ b/mayavi/tools/pipe_base.py
@@ -4,7 +4,7 @@ Base class for factories for adding objects to the pipeline.
 """
 
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2007-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import warnings

--- a/mayavi/tools/pipeline.py
+++ b/mayavi/tools/pipeline.py
@@ -5,7 +5,7 @@ pipeline.
 """
 
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2007-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from .modules import *

--- a/mayavi/tools/preferences_mirror.py
+++ b/mayavi/tools/preferences_mirror.py
@@ -1,5 +1,5 @@
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008,  Prabhu Ramachandran
+# Copyright (c) Prabhu Ramachandran
 # License: BSD Style.
 
 # Enthought library imports.

--- a/mayavi/tools/server.py
+++ b/mayavi/tools/server.py
@@ -41,7 +41,7 @@ hole** since the remote user can do pretty much anything they want.
 """
 
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2009-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import sys

--- a/mayavi/tools/show.py
+++ b/mayavi/tools/show.py
@@ -1,5 +1,5 @@
 # Author: Prabhu Ramachandran <prabhu[at]aero[dot]iitb[dot]ac[dot]in>
-# Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from traits.etsconfig.api import ETSConfig

--- a/mayavi/tools/sources.py
+++ b/mayavi/tools/sources.py
@@ -4,7 +4,7 @@ Data sources classes and their associated functions for mlab.
 
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
 #         Prabhu Ramachandran
-# Copyright (c) 2007-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import numpy as np

--- a/mayavi/tools/tools.py
+++ b/mayavi/tools/tools.py
@@ -4,7 +4,7 @@ The general purpose tools to manipulate the pipeline with the mlab interface.
 
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>,
 #         Gael Varoquaux      <gael dot varoquaux at normalesup dot org>
-# Copyright (c) 2007-2020 Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/mlab_reference.py
+++ b/mlab_reference.py
@@ -3,7 +3,7 @@ Script to generate the function reference for mlab.
 
 """
 # Author: Gael Varoquaux <gael dot varoquaux at normalesup dot org>
-# Copyright (c) 2007-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import os

--- a/scripts/cm2lut.py
+++ b/scripts/cm2lut.py
@@ -6,7 +6,7 @@ user, but only once in a while to synchronize with MPL development.
 """
 # Authors: Frederic Petit <fredmfp@gmail.com>,
 #          Gael Varoquaux <gael.varoquaux@normalesup.org>
-# Copyright (c) 2007-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import os

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) 2008-2022 by Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # All rights reserved.
 
 from setuptools import Command, Distribution, setup

--- a/tvtk/__init__.py
+++ b/tvtk/__init__.py
@@ -1,6 +1,6 @@
 # Author: Prabhu Ramachandran
 # License: BSD style
-# Copyright (c) 2004, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 """ A Traits-based wrapper for the Visualization Toolkit.
     Part of the Mayavi project of the Enthought Tool Suite.
 """

--- a/tvtk/array_handler.py
+++ b/tvtk/array_handler.py
@@ -10,7 +10,7 @@ seems no unique one-to-one VTK data array type to map it to.
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2004-2020,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import sys

--- a/tvtk/class_tree.py
+++ b/tvtk/class_tree.py
@@ -1,5 +1,5 @@
 # Author: Prabhu Ramachandran
-# Copyright (c) 2004-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 """This module generates the class hierarchy for any given Python

--- a/tvtk/code_gen.py
+++ b/tvtk/code_gen.py
@@ -15,7 +15,7 @@ Exceptions to behaviors based on VTK versions and bugs etc. live in ``wrapper_ge
 and ``vtk_parser.py``.
 """
 # Author: Prabhu Ramachandran
-# Copyright (c) 2004-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import os

--- a/tvtk/common.py
+++ b/tvtk/common.py
@@ -1,7 +1,7 @@
 """Common functions and classes.
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from contextlib import contextmanager

--- a/tvtk/custom/__init__.py
+++ b/tvtk/custom/__init__.py
@@ -1,3 +1,3 @@
 # Author: Prabhu Ramachandran
-# Copyright (c) 2004-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.

--- a/tvtk/indenter.py
+++ b/tvtk/indenter.py
@@ -5,7 +5,7 @@ miscellaneous classes useful for the tvtk code generation.
 """
 
 # Author: Prabhu Ramachandran
-# Copyright (c) 2004-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import re

--- a/tvtk/messenger.py
+++ b/tvtk/messenger.py
@@ -47,7 +47,7 @@ shows how disconnection works.
 
 """
 # Author: Prabhu Ramachandran
-# Copyright (c) 2004-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 __all__ = ['Messenger', 'MessengerError',

--- a/tvtk/misc.py
+++ b/tvtk/misc.py
@@ -1,7 +1,7 @@
 """Some miscellaneous convenience functionality.
 """
 # Author: Prabhu Ramachandran <prabhu_r [at] users.sf.net>
-# Copyright (c) 2007,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from os.path import splitext

--- a/tvtk/pipeline/__init__.py
+++ b/tvtk/pipeline/__init__.py
@@ -1,3 +1,3 @@
 # Author: Prabhu Ramachandran
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.

--- a/tvtk/pipeline/browser.py
+++ b/tvtk/pipeline/browser.py
@@ -27,7 +27,7 @@ TODO:
 
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/tvtk/plugins/__init__.py
+++ b/tvtk/plugins/__init__.py
@@ -1,3 +1,3 @@
 # Author: Prabhu Ramachandran
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.

--- a/tvtk/plugins/browser/__init__.py
+++ b/tvtk/plugins/browser/__init__.py
@@ -1,3 +1,3 @@
 # Author: Prabhu Ramachandran
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.

--- a/tvtk/plugins/browser/browser_view.py
+++ b/tvtk/plugins/browser/browser_view.py
@@ -2,7 +2,7 @@
 
 
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/tvtk/plugins/scene/__init__.py
+++ b/tvtk/plugins/scene/__init__.py
@@ -1,3 +1,3 @@
 # Author: Prabhu Ramachandran
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.

--- a/tvtk/plugins/scene/scene_editor.py
+++ b/tvtk/plugins/scene/scene_editor.py
@@ -1,7 +1,7 @@
 """ A TVTK scene editor. """
 
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import ast

--- a/tvtk/plugins/scene/ui/__init__.py
+++ b/tvtk/plugins/scene/ui/__init__.py
@@ -1,3 +1,3 @@
 # Author: Prabhu Ramachandran
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.

--- a/tvtk/plugins/scene/ui/actions.py
+++ b/tvtk/plugins/scene/ui/actions.py
@@ -2,7 +2,7 @@
 
 
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/tvtk/plugins/scene/ui/scene_preferences_page.py
+++ b/tvtk/plugins/scene/ui/scene_preferences_page.py
@@ -1,7 +1,7 @@
 """ Preferences page for a TVTK scene. """
 
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/tvtk/plugins/scene/ui/scene_ui_action_set.py
+++ b/tvtk/plugins/scene/ui/scene_ui_action_set.py
@@ -2,7 +2,7 @@
 
 
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2006, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/tvtk/pyface/__init__.py
+++ b/tvtk/pyface/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/tvtk/pyface/actor_editor.py
+++ b/tvtk/pyface/actor_editor.py
@@ -3,7 +3,7 @@
 
 # Authors: Robert Kern <robert.kern [at] gmail.com>
 #          Prabhu Ramachandran <prabhu [at] aero.iitb.ac.in>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Import the toolkit specific version.

--- a/tvtk/pyface/actor_model.py
+++ b/tvtk/pyface/actor_model.py
@@ -3,7 +3,7 @@
 
 # Authors: Robert Kern <robert.kern [at] gmail.com>
 #          Prabhu Ramachandran <prabhu [at] aero.iitb.ac.in>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/tvtk/pyface/actors.py
+++ b/tvtk/pyface/actors.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -17,7 +17,7 @@ when writing demo/example code.
 """
 
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from tvtk.api import tvtk

--- a/tvtk/pyface/decorated_scene.py
+++ b/tvtk/pyface/decorated_scene.py
@@ -4,7 +4,7 @@ etc.
 """
 # Authors: Prabhu Ramachandran <prabhu_r@users.sf.net>,
 #          Dave Peterson <dpeterson@enthought.com>
-# Copyright (c) 2006, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/tvtk/pyface/light_manager.py
+++ b/tvtk/pyface/light_manager.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -19,7 +19,7 @@ implementation is considerably different.
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from math import sin, cos, atan2, pi, sqrt

--- a/tvtk/pyface/picker.py
+++ b/tvtk/pyface/picker.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -18,7 +18,7 @@ probe for the data at that point.
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2004-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from traits.api import HasTraits, Trait, Int, Array, Any, Float, \

--- a/tvtk/pyface/scene.py
+++ b/tvtk/pyface/scene.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -16,7 +16,7 @@ the class docs for more details.
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2004-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/tvtk/pyface/scene_editor.py
+++ b/tvtk/pyface/scene_editor.py
@@ -4,7 +4,7 @@
 # Authors: Prabhu Ramachandran <prabhu [at] aero.iitb.ac.in>
 #          Robert Kern <robert.kern [at] gmail.com>
 #
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Import the toolkit specific version.

--- a/tvtk/pyface/scene_model.py
+++ b/tvtk/pyface/scene_model.py
@@ -10,7 +10,7 @@ Caveats:
 
 """
 # Author: Prabhu Ramachandran <prabhu [at] aero.iitb.ac.in>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/tvtk/pyface/tvtk_scene.py
+++ b/tvtk/pyface/tvtk_scene.py
@@ -7,7 +7,7 @@ functionality. See the class docs for more details.
 
 """
 # Author: Prabhu Ramachandran <prabhu@enthought.com>
-# Copyright (c) 2007-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import os

--- a/tvtk/pyface/ui/__init__.py
+++ b/tvtk/pyface/ui/__init__.py
@@ -1,6 +1,6 @@
 #------------------------------------------------------------------------------
 #
-#  Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 #  All rights reserved.
 #
 #  This software is provided without warranty under the terms of the BSD

--- a/tvtk/pyface/ui/null/__init__.py
+++ b/tvtk/pyface/ui/null/__init__.py
@@ -1,6 +1,6 @@
 #------------------------------------------------------------------------------
 #
-#  Copyright (c) 2008, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 #  All rights reserved.
 #
 #  This software is provided without warranty under the terms of the BSD

--- a/tvtk/pyface/ui/null/init.py
+++ b/tvtk/pyface/ui/null/init.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2007, Riverbank Computing Limited
+# Copyright (c) Riverbank Computing Limited
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/tvtk/pyface/ui/qt4/__init__.py
+++ b/tvtk/pyface/ui/qt4/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/tvtk/pyface/ui/qt4/actor_editor.py
+++ b/tvtk/pyface/ui/qt4/actor_editor.py
@@ -3,7 +3,7 @@
 
 # Authors: Robert Kern <robert.kern [at] gmail.com>
 #          Prabhu Ramachandran <prabhu [at] aero.iitb.ac.in>
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Major library imports.

--- a/tvtk/pyface/ui/qt4/decorated_scene.py
+++ b/tvtk/pyface/ui/qt4/decorated_scene.py
@@ -4,7 +4,7 @@ etc.
 """
 # Authors: Prabhu Ramachandran <prabhu_r@users.sf.net>,
 #          Dave Peterson <dpeterson@enthought.com>
-# Copyright (c) 2006-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # System imports.

--- a/tvtk/pyface/ui/qt4/scene.py
+++ b/tvtk/pyface/ui/qt4/scene.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -17,7 +17,7 @@ docs for more details.
 """
 
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2004-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/tvtk/pyface/ui/qt4/scene_editor.py
+++ b/tvtk/pyface/ui/qt4/scene_editor.py
@@ -5,7 +5,7 @@
 # Authors: Prabhu Ramachandran <prabhu [at] aero.iitb.ac.in>
 #          Robert Kern <robert.kern [at] gmail.com>
 #
-# Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import os

--- a/tvtk/pyface/ui/wx/__init__.py
+++ b/tvtk/pyface/ui/wx/__init__.py
@@ -1,6 +1,6 @@
 #------------------------------------------------------------------------------
 #
-#  Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 #  All rights reserved.
 #
 #  This software is provided without warranty under the terms of the BSD

--- a/tvtk/pyface/ui/wx/actor_editor.py
+++ b/tvtk/pyface/ui/wx/actor_editor.py
@@ -1,6 +1,6 @@
 #------------------------------------------------------------------------------
 #
-#  Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 #  All rights reserved.
 #
 #  This software is provided without warranty under the terms of the BSD

--- a/tvtk/pyface/ui/wx/decorated_scene.py
+++ b/tvtk/pyface/ui/wx/decorated_scene.py
@@ -1,6 +1,6 @@
 #------------------------------------------------------------------------------
 #
-#  Copyright (c) 2006, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 #  All rights reserved.
 #
 #  This software is provided without warranty under the terms of the BSD

--- a/tvtk/pyface/ui/wx/scene.py
+++ b/tvtk/pyface/ui/wx/scene.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -16,7 +16,7 @@ the class docs for more details.
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2004-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 

--- a/tvtk/pyface/ui/wx/scene_editor.py
+++ b/tvtk/pyface/ui/wx/scene_editor.py
@@ -1,6 +1,6 @@
 #------------------------------------------------------------------------------
 #
-#  Copyright (c) 2007, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 #  All rights reserved.
 #
 #  This software is provided without warranty under the terms of the BSD

--- a/tvtk/special_gen.py
+++ b/tvtk/special_gen.py
@@ -6,7 +6,7 @@ some of the VTK classes.  `HelperGenerator` helps generate the
 
 """
 # Author: Prabhu Ramachandran
-# Copyright (c) 2004-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import vtk

--- a/tvtk/tests/common.py
+++ b/tvtk/tests/common.py
@@ -1,7 +1,7 @@
 """ Test utilities
 """
 # Authors: Deepak Surti, Ioannis Tziakos
-# Copyright (c) 2015, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import contextlib

--- a/tvtk/tests/test_array_ext.py
+++ b/tvtk/tests/test_array_ext.py
@@ -2,7 +2,7 @@
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import unittest

--- a/tvtk/tests/test_array_handler.py
+++ b/tvtk/tests/test_array_handler.py
@@ -2,7 +2,7 @@
 Tests for array_handler.py.
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import unittest

--- a/tvtk/tests/test_class_tree.py
+++ b/tvtk/tests/test_class_tree.py
@@ -1,6 +1,6 @@
 # Author: Prabhu Ramachandran
 # License: BSD style
-# Copyright (c) 2004, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 
 """Tests class_tree.py.  Uses the vtk module to test the code.  Also
 tests if the tree generation works for the builtins module.

--- a/tvtk/tests/test_garbage_collection.py
+++ b/tvtk/tests/test_garbage_collection.py
@@ -1,7 +1,7 @@
 """ Tests for the garbage collection of objects in tvtk package.
 """
 # Authors: Deepak Surti, Ioannis Tziakos
-# Copyright (c) 2015-2021, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import sys

--- a/tvtk/tests/test_indenter.py
+++ b/tvtk/tests/test_indenter.py
@@ -2,7 +2,7 @@
 
 # Author: Prabhu Ramachandran
 # License: BSD style
-# Copyright (c) 2004-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 
 import unittest
 try:

--- a/tvtk/tests/test_messenger.py
+++ b/tvtk/tests/test_messenger.py
@@ -2,7 +2,7 @@
 
 """
 # Author: Prabhu Ramachandran
-# Copyright (c) 2004-2020,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from importlib import reload

--- a/tvtk/tests/test_misc.py
+++ b/tvtk/tests/test_misc.py
@@ -2,7 +2,7 @@
 Tests for enthought/tvtk/misc.py
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2008-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import unittest

--- a/tvtk/tests/test_tvtk.py
+++ b/tvtk/tests/test_tvtk.py
@@ -5,7 +5,7 @@ make sure that the generated code works well.
 
 """
 # Author: Prabhu Ramachandran
-# Copyright (c) 2004-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import os

--- a/tvtk/tests/test_tvtk_base.py
+++ b/tvtk/tests/test_tvtk_base.py
@@ -4,7 +4,7 @@ test_tvtk.py.
 
 """
 # Author: Prabhu Ramachandran
-# Copyright (c) 2004-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 from importlib import reload
 import unittest

--- a/tvtk/tests/test_tvtk_scene.py
+++ b/tvtk/tests/test_tvtk_scene.py
@@ -2,7 +2,7 @@
 
 """
 # Authors: Deepak Surti, Ioannis Tziakos
-# Copyright (c) 2015, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import sys

--- a/tvtk/tests/test_vtk_parser.py
+++ b/tvtk/tests/test_vtk_parser.py
@@ -1,6 +1,6 @@
 # Author: Prabhu Ramachandran
 # License: BSD style
-# Copyright (c) 2004, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 
 """Tests for vtk_parser.py.
 

--- a/tvtk/tests/test_wrapper_gen.py
+++ b/tvtk/tests/test_wrapper_gen.py
@@ -5,7 +5,7 @@ wrapper_gen directly.
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2004, Prabhu Ramachandran,  Enthought, Inc.
+# Copyright (c) Prabhu Ramachandran, Enthought, Inc.
 # License: BSD Style.
 
 import unittest

--- a/tvtk/tools/__init__.py
+++ b/tvtk/tools/__init__.py
@@ -1,3 +1,3 @@
 # Author: Prabhu Ramachandran
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.

--- a/tvtk/tools/ivtk.py
+++ b/tvtk/tools/ivtk.py
@@ -22,7 +22,7 @@ Here is example usage of the viewer along with tvtk under IPython:
 """
 
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/tvtk/tools/mlab.py
+++ b/tvtk/tools/mlab.py
@@ -89,7 +89,7 @@ functions::
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2005-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import numpy

--- a/tvtk/tools/tvtk_doc.py
+++ b/tvtk/tools/tvtk_doc.py
@@ -13,7 +13,7 @@ docs are shown.
 
 """
 # Author: Prabhu Ramachandran <prabhu [at] aero . iitb . ac . in>
-# Copyright (c) 2008-2020,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Standard library imports.

--- a/tvtk/tvtk_access.py
+++ b/tvtk/tvtk_access.py
@@ -4,7 +4,7 @@ and this instance serves as the `tvtk` 'module'.  For more details on
 this see the devel.txt in the TVTK documentation directory.
 """
 # Author: Prabhu Ramachandran <prabhu [at] aero.iitb.ac.in>
-# Copyright (c) 2007-2020,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from os.path import exists, join, dirname, isdir

--- a/tvtk/tvtk_base.py
+++ b/tvtk/tvtk_base.py
@@ -2,7 +2,7 @@
 
 """
 # Author: Prabhu Ramachandran <prabhu_r@users.sf.net>
-# Copyright (c) 2004-2020,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import sys

--- a/tvtk/tvtk_base_handler.py
+++ b/tvtk/tvtk_base_handler.py
@@ -1,7 +1,7 @@
 """ Handler and UI elements for tvtk objects.
 """
 # Author: Vibha Srinivasan <vibha@enthought.com>
-# Copyright (c) 2008-2020,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from traits.api import HasTraits, Str, Instance, Property, Button, List, Enum

--- a/tvtk/util/__init__.py
+++ b/tvtk/util/__init__.py
@@ -1,3 +1,3 @@
 # Author: Prabhu Ramachandran
-# Copyright (c) 2006, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.

--- a/tvtk/util/ctf.py
+++ b/tvtk/util/ctf.py
@@ -2,7 +2,7 @@
 
 """
 # Author: Prabhu Ramachandran <prabhu@aero.iitb.ac.in>
-# Copyright (c) 2006-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 # Enthought library imports.

--- a/tvtk/vtk_module.py
+++ b/tvtk/vtk_module.py
@@ -9,7 +9,7 @@ need to be wrapped.
 """
 
 # Author: Prabhu Ramachandran <prabhu [at] aero.iitb.ac.in>
-# Copyright (c) 2007-2021,  Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 from vtk import *

--- a/tvtk/vtk_parser.py
+++ b/tvtk/vtk_parser.py
@@ -3,7 +3,7 @@ type information, and organizes them.
 
 """
 # Author: Prabhu Ramachandran
-# Copyright (c) 2004-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import collections.abc

--- a/tvtk/wrapper_gen.py
+++ b/tvtk/wrapper_gen.py
@@ -3,7 +3,7 @@ VTK classes.
 
 """
 # Author: Prabhu Ramachandran
-# Copyright (c) 2004-2020, Enthought, Inc.
+# Copyright (c) Enthought, Inc.
 # License: BSD Style.
 
 import faulthandler


### PR DESCRIPTION
The years were manual and had drifted into 55 distinct spellings across 449 files -- "2005-2020, Enthought, Inc.", "2008,  Enthought, Inc.", "2006-2020, Enthought Inc." and so on -- so every touched file invited a "should this be 2026?" question that nothing enforced.  A copyright notice does not need a current year to be valid, and LICENSE.txt carries the authoritative one.

Only the year is removed; each holder is reproduced as it stood, so the third-party claims (Riverbank Computing, S. Chris Colbert, Prabhu Ramachandran) are untouched apart from punctuation.  What is left is:

    413  # Copyright (c) Enthought, Inc.
     17  # Copyright (c) Prabhu Ramachandran
     10  # Copyright (c) Prabhu Ramachandran, Enthought, Inc.
      2  # Copyright (c) S. Chris Colbert
      1  # Copyright (c) Riverbank Computing Limited

The two Sphinx `copyright` values, which render in the page footer and read 2018 and 2016, lose their years the same way.

Closes #1381