### PR TITLE
MAINT: Treat warnings as errors in the test suites

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,14 +86,19 @@ jobs:
         # --no-build-isolation, so it must be present in the environment
         python -m pip install --upgrade pip setuptools setuptools_scm wheel
         if [[ "${{ matrix.vtk }}" == "vtk-dev" ]]; then
-          # Dev wheels get their own pip call so that --pre only applies to VTK
+          # Dev wheels get their own pip calls so that --pre and the nightly
+          # indexes apply only to the package they belong to
           python -m pip install --upgrade --pre --only-binary ":all:" --extra-index-url "https://wheels.vtk.org" vtk
+          python -m pip install --upgrade --pre --only-binary ":all:" --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" numpy
           vtk_spec=""
+          numpy_spec=""
         else
           vtk_spec="${{ matrix.vtk || 'vtk' }}"
+          numpy_spec="${{ matrix.numpy || 'numpy' }}"
         fi
-        python -m pip install --upgrade ${{ matrix.qt-api || ''}} "${{ matrix.numpy || 'numpy' }}" $vtk_spec pillow pytest pytest-timeout traits traitsui --only-binary="numpy,vtk"
+        python -m pip install --upgrade ${{ matrix.qt-api || ''}} $numpy_spec $vtk_spec pillow pytest pytest-timeout traits traitsui --only-binary="numpy,vtk"
         python -c "import vtk; print(f'VTK {vtk.VTK_VERSION}')"
+        python -c "import numpy; print(f'NumPy {numpy.__version__}')"
         if [[ "${{ matrix.headless }}" != "true" ]]; then
           echo "extra=[app]" | tee -a $GITHUB_OUTPUT
         fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,9 @@ one package.
 
 - Supported VTK floor: `MIN_VTK` in `setup.py` (SPEC 0-style ~2-year
   window).  When bumping it, cull workarounds per `tvtk/WORKAROUNDS.md`.
+- Supported VTK ceiling: `MAX_VTK` in `setup.py`, exclusive.  It runs ahead
+  of the newest release, since the `vtk-dev` CI row tests the next version's
+  prereleases; raise it once that row has been green on them.
 - Wheels are pure Python but **platform-tagged** (`py3-none-manylinux…/
   macosx…/win_amd64`) because the generated classes differ per OS
   (X11/Cocoa/Win32).  `MyBdistWheel` in `setup.py` handles the tags.
@@ -34,8 +37,7 @@ one package.
   runtime tolerances.  The generation VTK is recorded in
   `tvtk_classes/vtk_version.py` inside the zip.
 - Dependencies are PEP 643 dynamic (`setup.py`): the wheel gets
-  `vtk>=MIN_VTK,<{next minor of the build VTK}`; the sdist stays uncapped
-  above the floor.
+  `vtk>=MIN_VTK,<MAX_VTK`; the sdist stays uncapped above the floor.
 
 ## Building and testing locally
 
@@ -49,8 +51,23 @@ pytest -v --timeout=10 mayavi
 pytest -sv --timeout=60 tvtk
 ```
 
+- `integrationtests/` is not a pytest tree — each file is an `optparse` script
+  subclassing `TestCase(Mayavi)`, run by `run.py` shelling out per file, and
+  collecting one launches the Mayavi2 application and waits for the window to
+  be closed.  `integrationtests/conftest.py` sets `collect_ignore_glob` so a
+  bare `pytest` cannot wander into it.  21 of the 26 pass as of 2026-07;
+  porting them to pytest and wiring up a Linux-only CI job is a follow-up.
 - Regeneration is skipped if `tvtk/tvtk_classes.zip` is < 120 s old
   (`_tvtk_built_recently` in `setup.py`).
+- Warnings are errors.  The filters live in `mayavi/tests/conftest.py` and
+  `tvtk/tests/conftest.py` rather than `pyproject.toml`, so that they ship in
+  the wheel and so reach the `pytest --pyargs` runs below and in `wheel.yml`.
+  Each conftest adds its own `error::` but skips any line the other already
+  added: pluggy calls the two `pytest_configure` hooks in reverse load order,
+  and a second `error::` would outrank the ignores the first one just added.
+- `mayavi/tests/conftest.py` also turns `mayavi.core.common.exception()` from
+  swallow-and-show-a-modal-dialog into a re-raise.  Otherwise a headed run
+  blocks on a pyface box that has to be clicked away, and passes regardless.
 - To test against an older VTK: `uv venv -p 3.11 && uv pip install
   "vtk==9.x.*" <wheel>`, then `pytest --pyargs tvtk mayavi` from *outside*
   the repo (so the source tree does not shadow the installed wheel — the
@@ -172,9 +189,12 @@ commit**:
 - `tests.yml` — same-version matrix: build + test with the *same* VTK
   (latest on all OSes; older VTK/Python/Qt rows on Linux; one headless row
   with `ETS_TOOLKIT=null`), plus a `vtk-dev` row against prerelease wheels
-  from https://wheels.vtk.org.  Also runs weekly on a schedule, which is how
-  VTK-dev breakage gets noticed; a scheduled failure opens an issue (the
-  `issue-on-failure` job) since there is no PR to show it on.
+  from https://wheels.vtk.org and NumPy nightlies from
+  https://pypi.anaconda.org/scientific-python-nightly-wheels — that row is
+  what `MAX_VTK` is raised on the strength of.  Also runs weekly on a
+  schedule, which is how VTK-dev breakage gets noticed; a scheduled failure
+  opens an issue (the `issue-on-failure` job) since there is no PR to show it
+  on.
 - `.github/actions/open-issue` — composite action behind both
   `issue-on-failure` jobs: files an issue unless one with the same title is
   already open, appending the run URL.  Callers need an `actions/checkout`

--- a/integrationtests/conftest.py
+++ b/integrationtests/conftest.py
@@ -1,0 +1,9 @@
+"""Keep pytest away from the integration tests."""
+# Copyright (c) Enthought, Inc.
+# License: BSD Style.
+
+# These are not pytest tests: each is a script subclassing TestCase(Mayavi),
+# driven by run.py.  Collecting them launches the Mayavi2 application and waits
+# for someone to close the window, so a bare `pytest` at the repo root has to
+# skip the whole tree.  See integrationtests/mayavi/README.txt.
+collect_ignore_glob = ['*']

--- a/mayavi/components/contour.py
+++ b/mayavi/components/contour.py
@@ -215,6 +215,9 @@ class Contour(Component):
         if name is None:
             error('Cannot contour: No scalars in input data!')
             rng = (0.0, 1.0)
+        # get_range hands back a list, which never compares equal to the Tuple
+        # trait (so the update always fired) and warns when assigned to it
+        rng = tuple(rng)
         if rng != self._current_range:
             self.trait_set(_data_min=rng[0], _data_max=rng[1],
                            trait_change_notify=False)

--- a/mayavi/core/common.py
+++ b/mayavi/core/common.py
@@ -23,6 +23,10 @@ else:
 # Setup a logger for this module.
 logger = logging.getLogger(__name__)
 
+# Flipped by the test suite (see conftest.py): the callers of exception() below
+# are bare ``except:`` blocks, so a swallowed failure is invisible to a test.
+reraise_exceptions = False
+
 ######################################################################
 # Utility functions.
 ######################################################################
@@ -56,6 +60,8 @@ def exception(msg='Exception', parent=None):
     along to the dialog box.  The optional `msg` is printed and sent
     to the logger.  So you could send extra information here.
     """
+    if reraise_exceptions:
+        raise
     try:
         type, value, tb = sys.exc_info()
         info = traceback.extract_tb(tb)

--- a/mayavi/core/utils.py
+++ b/mayavi/core/utils.py
@@ -5,6 +5,12 @@ from vtk.numpy_interface import algorithms as algs
 
 from tvtk.api import tvtk
 
+# VTK 9.6 deprecated algs.min/max/mean/sum in favour of the numpy equivalents,
+# which only dispatch on composite arrays (registered by the import above) from
+# that version on -- see tvtk/WORKAROUNDS.md
+if hasattr(dsa, 'COMPOSITE_OVERRIDE'):
+    algs = np
+
 
 def get_new_output(input, update=True):
     if update and hasattr(input, 'update'):

--- a/mayavi/modules/volume.py
+++ b/mayavi/modules/volume.py
@@ -467,6 +467,9 @@ class Volume(Module):
         else:
             rng = cell_rng
 
+        # get_range hands back a list, which never compares equal to the Tuple
+        # trait (so the update always fired) and warns when assigned to it
+        rng = tuple(rng)
         if self.current_range != rng:
             self.current_range = rng
 

--- a/mayavi/tests/conftest.py
+++ b/mayavi/tests/conftest.py
@@ -14,13 +14,25 @@ ignore: module 'sre_.+' is deprecated:DeprecationWarning
 """
 
 
+# VTK's own numpy_support.vtk_to_numpy assigns to .shape, which NumPy 2.5
+# deprecated; fixed in 9.7, so keep it an error there -- see
+# tvtk/WORKAROUNDS.md
+OLD_VTK_WARNING_LINES = r"""
+ignore:Setting the shape on a NumPy array has been deprecated:DeprecationWarning
+"""
+
+
 def pytest_configure(config):
     """Add the warning filters this suite needs."""
+    from tvtk.common import vtk_major_version, vtk_minor_version
+    lines = WARNING_LINES
+    if (vtk_major_version, vtk_minor_version) < (9, 7):
+        lines += OLD_VTK_WARNING_LINES
     # Later entries win, so skip any the other suite's conftest already added:
     # a second "error::" would outrank the ignores it put there (`pytest mayavi
     # tvtk` runs both, and pluggy calls the two hooks in reverse load order).
     existing = config.getini('filterwarnings')
-    for line in WARNING_LINES.split('\n'):
+    for line in lines.split('\n'):
         line = line.strip()
         if line and not line.startswith('#') and line not in existing:
             config.addinivalue_line('filterwarnings', line)

--- a/mayavi/tests/conftest.py
+++ b/mayavi/tests/conftest.py
@@ -1,0 +1,46 @@
+"""Pytest configuration for the mayavi test suite."""
+# Copyright (c) Enthought, Inc.
+# License: BSD Style.
+
+import pytest
+
+# One filter per line, "#" comments allowed.
+WARNING_LINES = r"""
+error::
+# unsatisfiable until pyface.workbench moves
+ignore:Workbench will be moved from pyface:PendingDeprecationWarning
+# should be fixed in traits
+ignore: module 'sre_.+' is deprecated:DeprecationWarning
+"""
+
+
+def pytest_configure(config):
+    """Add the warning filters this suite needs."""
+    # Later entries win, so skip any the other suite's conftest already added:
+    # a second "error::" would outrank the ignores it put there (`pytest mayavi
+    # tvtk` runs both, and pluggy calls the two hooks in reverse load order).
+    existing = config.getini('filterwarnings')
+    for line in WARNING_LINES.split('\n'):
+        line = line.strip()
+        if line and not line.startswith('#') and line not in existing:
+            config.addinivalue_line('filterwarnings', line)
+
+
+@pytest.fixture(autouse=True)
+def no_modal_dialogs(monkeypatch):
+    """Keep mayavi's error reporting from blocking (or hiding) a test run.
+
+    A failure inside a pipeline update -- including a warning raised as an
+    error -- is swallowed by a bare ``except:`` and shown in a modal pyface
+    box, so on a headed toolkit the run stops until someone clicks OK and the
+    test then passes regardless.  Re-raise instead, and route the genuinely
+    user-facing messages to the log only.
+    """
+    from mayavi.core import common
+    monkeypatch.setattr(common, 'reraise_exceptions', True)
+    if common.pyface is not None:
+        for name in ('error', 'warning', 'information'):
+            monkeypatch.setattr(
+                common.pyface, name,
+                lambda parent, msg, *args, _name=name, **kwargs:
+                    common.logger.info('pyface.%s: %s', _name, msg))

--- a/mayavi/tests/test_extract_grid_filter.py
+++ b/mayavi/tests/test_extract_grid_filter.py
@@ -16,6 +16,7 @@ from mayavi.modules.grid_plane import GridPlane
 from mayavi.modules.axes import Axes
 from mayavi.filters.extract_grid import ExtractGrid
 from tvtk.api import tvtk
+from tvtk.common import reshape_view
 
 class TestExtractGridFilter(unittest.TestCase):
 
@@ -23,7 +24,7 @@ class TestExtractGridFilter(unittest.TestCase):
         pd = tvtk.PolyData()
         pd.points = 100 + 100*random.random((1000, 3))
         verts = arange(0, 1000, 1)
-        verts.shape = (1000, 1)
+        verts = reshape_view(verts, (1000, 1))
         pd.verts = verts
         pd.point_data.scalars = random.random(1000)
         pd.point_data.scalars.name = 'scalars'

--- a/mayavi/tools/figure.py
+++ b/mayavi/tools/figure.py
@@ -19,6 +19,7 @@ from pyface.timer.api import do_later
 
 #  imports
 from tvtk.api import tvtk
+from tvtk.common import reshape_view
 from mayavi.core.scene import Scene
 from mayavi.core.registry import registry
 from .camera import view
@@ -344,7 +345,6 @@ def screenshot(figure=None, mode='rgb', antialiased=False):
         pixel_getter(*pg_args)
 
     # Return the array in a way that pylab.imshow plots it right:
-    out = out.to_array()
-    out.shape = shape
+    out = reshape_view(out.to_array(), shape)
     out = np.flipud(out)
     return out

--- a/mayavi/tools/sources.py
+++ b/mayavi/tools/sources.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from traits.api import Bool, HasTraits, Instance, on_trait_change
 from tvtk.api import tvtk
-from tvtk.common import camel2enthought
+from tvtk.common import camel2enthought, reshape_view
 
 from mayavi.sources.array_source import ArraySource
 from mayavi.core.registry import registry
@@ -172,7 +172,7 @@ class MGlyphSource(MlabSource):
 
         else:
             points = np.c_[x.ravel(), y.ravel(), z.ravel()].ravel()
-            points.shape = (-1, 3)
+            points = reshape_view(points, (-1, 3))
             self.trait_set(points=points, trait_change_notify=False)
 
         u, v, w = self.u, self.v, self.w
@@ -183,7 +183,7 @@ class MGlyphSource(MlabSource):
             if len(u) > 0:
                 vectors = np.c_[u.ravel(), v.ravel(),
                                 w.ravel()].ravel()
-                vectors.shape = (-1, 3)
+                vectors = reshape_view(vectors, (-1, 3))
                 self.trait_set(vectors=vectors, trait_change_notify=False)
 
         if 'vectors' in traits:
@@ -196,7 +196,7 @@ class MGlyphSource(MlabSource):
             if u is not None and len(u) > 0:
                 vectors = np.c_[u.ravel(), v.ravel(),
                                 w.ravel()].ravel()
-                vectors.shape = (-1, 3)
+                vectors = reshape_view(vectors, (-1, 3))
                 self.trait_set(vectors=vectors, trait_change_notify=False)
 
         if vectors is not None and len(vectors) > 0:
@@ -368,7 +368,8 @@ class MArraySource(MlabSource):
                 #                axis=3)
                 vectors = np.c_[u.ravel(), v.ravel(),
                                    w.ravel()].ravel()
-                vectors.shape = (u.shape[0], u.shape[1], w.shape[2], 3)
+                vectors = reshape_view(
+                    vectors, (u.shape[0], u.shape[1], w.shape[2], 3))
                 self.trait_set(vectors=vectors, trait_change_notify=False)
 
         if vectors is not None and len(vectors) > 0 and scalars is not None:
@@ -480,7 +481,7 @@ class MLineSource(MlabSource):
 
         else:
             points = np.c_[x.ravel(), y.ravel(), z.ravel()].ravel()
-            points.shape = (len(x), 3)
+            points = reshape_view(points, (len(x), 3))
             self.trait_set(points=points, trait_change_notify=False)
 
         # Create the dataset.
@@ -703,7 +704,7 @@ class MGridSource(MlabSource):
 
         nx, ny = x.shape
         points = np.c_[x.ravel(), y.ravel(), z.ravel()].ravel()
-        points.shape = (nx * ny, 3)
+        points = reshape_view(points, (nx * ny, 3))
         self.trait_set(points=points, trait_change_notify=False)
 
         i, j = np.mgrid[0:nx - 1, 0:ny - 1]
@@ -806,7 +807,7 @@ class MTriangularMeshSource(MlabSource):
 
         x, y, z = self.x, self.y, self.z
         points = np.c_[x.ravel(), y.ravel(), z.ravel()].ravel()
-        points.shape = (-1, 3)
+        points = reshape_view(points, (-1, 3))
         self.trait_set(points=points, trait_change_notify=False)
 
         triangles = self.triangles

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,11 +103,5 @@ namespaces = true
 
 [tool.pytest.ini_options]
 addopts = "--durations=20 -ra --tb=short"
-filterwarnings = [
-    # Currently unsatisfiable
-    'ignore:Workbench will be moved from pyface:PendingDeprecationWarning',
-    # Should be fixed in traits
-    "ignore: module 'sre_.+' is deprecated:DeprecationWarning",
-    # We call deprecated methods and classes in our tests, and there are many variants for how the parentheticals are formatted
-    'ignore:Call to deprecated .*. \((This|Use|Please|Deprecated|Deprecating|Removed|Part|no|renamed) .*\) -- Deprecated since version.*:DeprecationWarning',
-]
+# Warning filters live in mayavi/tests/conftest.py and tvtk/tests/conftest.py,
+# which unlike this file also reach a `pytest --pyargs` run against the wheel

--- a/setup.py
+++ b/setup.py
@@ -302,21 +302,16 @@ DEPENDENCIES = [
 # Oldest supported VTK, per SPEC 0-style two-year support window.  When
 # raising this, cull the workarounds it makes dead -- see tvtk/WORKAROUNDS.md.
 MIN_VTK = '9.4'
+# First VTK the generated wrappers are *not* known to work with.  Raise it
+# once the vtk-dev CI row has been green against that version's prereleases.
+MAX_VTK = '9.8'
 
 
 def vtk_requirement():
     """The VTK requirement, with an upper bound when building a wheel."""
     if 'sdist' in sys.argv[1:]:
         return 'vtk>=%s' % MIN_VTK
-    try:
-        import vtk
-    except ImportError:
-        # no VTK at metadata time: leave uncapped rather than error (class
-        # generation will fail later anyway unless reusing a fresh ZIP)
-        return 'vtk>=%s' % MIN_VTK
-    version = vtk.vtkVersion()
-    return 'vtk>=%s,<%d.%d' % (MIN_VTK, version.GetVTKMajorVersion(),
-                               version.GetVTKMinorVersion() + 1)
+    return 'vtk>=%s,<%s' % (MIN_VTK, MAX_VTK)
 
 
 # Static metadata lives in pyproject.toml; setup.py carries only the dynamic

--- a/tvtk/WORKAROUNDS.md
+++ b/tvtk/WORKAROUNDS.md
@@ -198,6 +198,11 @@ plain runtime API drift rather than wrapping workarounds.  They obey the same
 cull rule: once `MIN_VTK` is past the version the old branch is unreachable
 and should go.  Current case:
 
+- `mayavi/tests/conftest.py` ignores NumPy 2.5's "Setting the shape on a
+  NumPy array has been deprecated" on VTK < 9.7, where VTK's own
+  `numpy_support.vtk_to_numpy` still assigns to `.shape`.  9.7 fixed it, so
+  the filter is version-keyed rather than blanket — mayavi's own assignments
+  all went through `tvtk.common.reshape_view` instead, and must stay errors.
 - `mayavi/core/utils.py` reduces composite arrays with `numpy` rather than
   `numpy_interface.algorithms` when the runtime VTK dispatches numpy functions
   on them (detected by `dsa.COMPOSITE_OVERRIDE`, added in 9.6 along with the

--- a/tvtk/WORKAROUNDS.md
+++ b/tvtk/WORKAROUNDS.md
@@ -71,6 +71,10 @@ from crashing or producing garbage:
   default-probed on VTK >= 9.5 (realizing + destroying a window segfaults).
   The same bug makes `tvtk/tools/tvtk_doc.py` drop those classes from its
   browsable class list (`skip_windowed`).
+- `parse(no_warn=True)` silences `DeprecationWarning` for the duration:
+  probing every getter necessarily calls the deprecated ones, and a VTK
+  deprecation raised as an error surfaces as an uninformative `SystemError`
+  from the C wrapper.  `tvtk_doc.py`'s class sweep does the same.
 
 Debugging a generation crash: set `VTK_PARSER_VERBOSE=1` (prints each
 `Get*` call before making it; the last line printed is the culprit) and
@@ -107,7 +111,9 @@ class for objects of removed classes.
 ## Layer 4: `tvtk_base.py` — runtime tolerances
 
 `update_traits()` (syncing trait values from the wrapped VTK object at
-instantiation) tolerates, in order:
+instantiation) silences `DeprecationWarning` while it reads the getters —
+traits are generated for methods VTK later deprecates — and then tolerates,
+in order:
 
 - `AttributeError`/`TypeError` from the getter (method missing on an older
   runtime VTK, or needs arguments);
@@ -188,10 +194,16 @@ Those obey the same marker and cull rules; they are keyed on `qVersion()` and
 ## Outside the layers: `mayavi/`
 
 Mayavi is a consumer of the wrapped API, so its version conditionals are
-plain runtime API drift rather than wrapping workarounds — none are live
-right now (`mayavi/filters/threshold.py`'s pre-9.1 `threshold_between()`
-fallback went with the 9.4 floor).  They obey the same cull rule: once
-`MIN_VTK` is past the version the old branch is unreachable and should go.
+plain runtime API drift rather than wrapping workarounds.  They obey the same
+cull rule: once `MIN_VTK` is past the version the old branch is unreachable
+and should go.  Current case:
+
+- `mayavi/core/utils.py` reduces composite arrays with `numpy` rather than
+  `numpy_interface.algorithms` when the runtime VTK dispatches numpy functions
+  on them (detected by `dsa.COMPOSITE_OVERRIDE`, added in 9.6 along with the
+  deprecation of `algs.min`/`max`/`mean`/`sum`).  At a 9.6 floor the `algs`
+  fallback goes, but the `algorithms` import must stay: importing it is what
+  registers the dispatch.
 
 ## Auditing
 

--- a/tvtk/array_handler.py
+++ b/tvtk/array_handler.py
@@ -24,6 +24,8 @@ except ImportError:
 
 import numpy
 
+from tvtk.common import reshape_view
+
 # Useful constants for VTK arrays.
 VTK_ID_TYPE_SIZE = vtk.vtkIdTypeArray().GetDataTypeSize()
 if VTK_ID_TYPE_SIZE == 4:
@@ -69,12 +71,10 @@ def set_id_type_array_py(id_array, out_array):
     assert sz == e_sz, \
         "out_array size is incorrect, expected: %s, given: %s" % (e_sz, sz)
 
-    # we are guaranteed contiguous, so these just change the view (no copy)
-    out_shp = out_array.shape
-    out_array.shape = (shp[0], shp[1] + 1)
-    out_array[:, 0] = shp[1]
-    out_array[:, 1:] = id_array
-    out_array.shape = out_shp
+    # we are guaranteed contiguous, so this just changes the view (no copy)
+    view = reshape_view(out_array, (shp[0], shp[1] + 1))
+    view[:, 0] = shp[1]
+    view[:, 1:] = id_array
 
 
 # Historically this came from a small Cython extension (``tvtk.array_ext``) for
@@ -411,8 +411,7 @@ def vtk2array(vtk_array):
         result = numpy.frombuffer(vtk_array, dtype=dtype)
         if shape[1] == 1:
             shape = (shape[0], )
-        result.shape = shape
-        return result
+        return reshape_view(result, shape)
 
     # Setup an imaging pipeline to export the array.
     img_data = vtk.vtkImageData()

--- a/tvtk/common.py
+++ b/tvtk/common.py
@@ -6,12 +6,19 @@
 
 from contextlib import contextmanager
 import re
+
+import numpy
+from packaging.version import Version
 import vtk
 
 # The runtime VTK version every version-keyed workaround is gated on --
 # see tvtk/WORKAROUNDS.md for the full map and the cull policy.
 vtk_major_version = vtk.vtkVersion.GetVTKMajorVersion()
 vtk_minor_version = vtk.vtkVersion.GetVTKMinorVersion()
+
+# NumPy 2.5 deprecated assigning to .shape, but the reshape(copy=False) that
+# replaces it only exists from 2.1 -- drop the branch at a numpy>=2.1 floor.
+_NUMPY_HAS_RESHAPE_COPY = Version(numpy.__version__).release >= (2, 1)
 
 
 ######################################################################
@@ -35,6 +42,19 @@ def suppress_vtk_warnings():
         yield
     finally:
         obj.GlobalWarningDisplayOn()
+
+
+def reshape_view(arr, shape):
+    """Reshape `arr` as a view, raising if a copy would be needed.
+
+    The `arr.shape = shape` this replaces is deprecated as of NumPy 2.5.
+    Both spellings refuse to copy, which matters for the arrays here that
+    alias VTK-owned memory.
+    """
+    if _NUMPY_HAS_RESHAPE_COPY:
+        return arr.reshape(shape, copy=False)
+    arr.shape = shape
+    return arr
 
 
 def get_tvtk_name(vtk_name):

--- a/tvtk/special_gen.py
+++ b/tvtk/special_gen.py
@@ -113,7 +113,7 @@ class SpecialGenerator:
             obj = self._vtk_obj
             e = [obj.GetElement(i, j) for i in range(4) for j in range(4)]
             arr = array_handler.numpy.array(e, dtype=float)
-            arr.shape = (4,4)
+            arr = array_handler.reshape_view(arr, (4, 4))
             return arr
 
         """

--- a/tvtk/tests/conftest.py
+++ b/tvtk/tests/conftest.py
@@ -1,0 +1,25 @@
+"""Pytest configuration for the tvtk test suite."""
+# Copyright (c) Enthought, Inc.
+# License: BSD Style.
+
+# One filter per line, "#" comments allowed.
+WARNING_LINES = r"""
+error::
+# these tests instantiate every VTK class and read every getter, deprecated
+# ones included; the parenthetical wording varies far too much to match on
+ignore:Call to deprecated .*Deprecated since version.*:DeprecationWarning
+# should be fixed in traits
+ignore: module 'sre_.+' is deprecated:DeprecationWarning
+"""
+
+
+def pytest_configure(config):
+    """Add the warning filters this suite needs."""
+    # Later entries win, so skip any the other suite's conftest already added:
+    # a second "error::" would outrank the ignores it put there (`pytest mayavi
+    # tvtk` runs both, and pluggy calls the two hooks in reverse load order).
+    existing = config.getini('filterwarnings')
+    for line in WARNING_LINES.split('\n'):
+        line = line.strip()
+        if line and not line.startswith('#') and line not in existing:
+            config.addinivalue_line('filterwarnings', line)

--- a/tvtk/tests/test_tvtk.py
+++ b/tvtk/tests/test_tvtk.py
@@ -22,7 +22,7 @@ import numpy
 from textwrap import indent
 
 from tvtk import tvtk_base
-from tvtk.common import (get_tvtk_name, configure_input_data,
+from tvtk.common import (get_tvtk_name, configure_input_data, reshape_view,
                          vtk_major_version, vtk_minor_version)
 from tvtk import vtk_module as vtk
 from numpy.testing import assert_array_equal
@@ -291,7 +291,7 @@ class TestTVTK(unittest.TestCase):
                 self.assertEqual(m.get_element(i, j), i*4 + j)
         # Test the from/to_array functions.
         a = numpy.array(list(range(16)), dtype=float)
-        a.shape = 4, 4
+        a = reshape_view(a, (4, 4))
         m = tvtk.Matrix4x4()
         m.from_array(a)
         b = m.to_array()

--- a/tvtk/tools/tvtk_doc.py
+++ b/tvtk/tools/tvtk_doc.py
@@ -20,6 +20,7 @@ docs are shown.
 import inspect
 import os
 import sys
+import warnings
 
 # Enthought library imports.
 from traits.api import HasTraits, Property, List, Str, \
@@ -88,7 +89,11 @@ def get_tvtk_class_names():
             if verbose:
                 print(f'Trying {name}', file=sys.__stdout__, flush=True)
             try:
-                c = klass()
+                with warnings.catch_warnings():
+                    # sweeping up every class inevitably hits VTK's deprecated
+                    # ones, where the warning comes back out as a SystemError
+                    warnings.simplefilter('ignore', DeprecationWarning)
+                    c = klass()
                 # Some classes hijack sys.stdout/sys.stderr.
                 # Restore it when that happens.
                 if sys.stdout != old_stdout or sys.stderr != old_stderr:

--- a/tvtk/tvtk_base.py
+++ b/tvtk/tvtk_base.py
@@ -6,6 +6,7 @@
 # License: BSD Style.
 
 import sys
+import warnings
 import weakref
 import os
 import logging
@@ -597,37 +598,41 @@ class TVTKBase(traits.HasStrictTraits):
         warn = vtk.vtkObject.GetGlobalWarningDisplay()
         vtk.vtkObject.GlobalWarningDisplayOff()
 
-        for name, getter in self._updateable_traits_:
-            if name == 'global_warning_display':
-                setattr(self, name, warn)
-                continue
+        with warnings.catch_warnings():
+            # A getter VTK has since deprecated still has a trait generated
+            # for it, so reading it here must not blow up under -W error.
+            warnings.simplefilter('ignore', DeprecationWarning)
+            for name, getter in self._updateable_traits_:
+                if name == 'global_warning_display':
+                    setattr(self, name, warn)
+                    continue
 
-            try:
-                val = getattr(vtk_obj, getter)()
-            except (AttributeError, TypeError):
-                # Some vtk GetMethod accepts more than 1 arguments, or is
-                # missing entirely on an older runtime VTK than the classes
-                # were generated against (see tvtk/WORKAROUNDS.md).
-                # FIXME: If we really want to try harder, we could
-                # pass an empty array to the Get method, some Get
-                # method will populate the array as the return
-                # value (e.g. vtkImageConvolve.GetKernel3x3 and alike)
-                pass
-            else:
                 try:
-                    setattr(self, name, val)
-                except traits.TraitError:
-                    if name in self._allow_update_failure_:
-                        pass
-                    elif vtk_version_mismatch():
-                        # The trait definitions were generated against a
-                        # different VTK, so values read from the runtime
-                        # object may no longer validate (type/range drift
-                        # across VTK versions); keep the generated default.
-                        # See tvtk/WORKAROUNDS.md.
-                        pass
-                    else:
-                        raise
+                    val = getattr(vtk_obj, getter)()
+                except (AttributeError, TypeError):
+                    # Some vtk GetMethod accepts more than 1 arguments, or is
+                    # missing entirely on an older runtime VTK than the classes
+                    # were generated against (see tvtk/WORKAROUNDS.md).
+                    # FIXME: If we really want to try harder, we could
+                    # pass an empty array to the Get method, some Get
+                    # method will populate the array as the return
+                    # value (e.g. vtkImageConvolve.GetKernel3x3 and alike)
+                    pass
+                else:
+                    try:
+                        setattr(self, name, val)
+                    except traits.TraitError:
+                        if name in self._allow_update_failure_:
+                            pass
+                        elif vtk_version_mismatch():
+                            # The trait definitions were generated against a
+                            # different VTK, so values read from the runtime
+                            # object may no longer validate (type/range drift
+                            # across VTK versions); keep the generated default.
+                            # See tvtk/WORKAROUNDS.md.
+                            pass
+                        else:
+                            raise
 
         # Reset the warning state.
         vtk.vtkObject.SetGlobalWarningDisplay(warn)

--- a/tvtk/vtk_parser.py
+++ b/tvtk/vtk_parser.py
@@ -10,6 +10,7 @@ import collections.abc
 import gc
 import re
 import os
+import warnings
 
 # Local imports (these are relative imports for a good reason).
 from . import class_tree
@@ -169,7 +170,11 @@ class VTKMethodParser:
             if klass.__name__ != 'vtkObject':
                 vtk.vtkObject.GlobalWarningDisplayOff()
 
-        self._organize_methods(klass, methods)
+        with warnings.catch_warnings():
+            if no_warn:
+                # probing every getter necessarily calls the deprecated ones
+                warnings.simplefilter('ignore', DeprecationWarning)
+            self._organize_methods(klass, methods)
 
         if no_warn:
             # Reset warning status.


### PR DESCRIPTION
Allow VTK 9.7 by replacing the derived wheel cap (next minor of the build VTK) with an explicit MAX_VTK, and test NumPy nightlies alongside the VTK dev wheels so the same row covers both.

Then turn warnings into errors and deal with what that turns up:

- mayavi.core.common.exception() swallowed the failure and put up a modal pyface box, so a headed run blocked on a dialog and passed anyway; mayavi/tests/conftest.py re-raises instead.
- Contour and Volume assigned get_range's list to a Tuple trait, which warned and never compared equal, so the range update always fired.
- algs.min/max/mean/sum are deprecated as of VTK 9.6, which is also where numpy functions start dispatching on composite arrays.
- Introspecting every VTK getter (vtk_parser, tvtk_base.update_traits, tvtk_doc) inevitably calls deprecated ones, where the warning comes back out of the C wrapper as a SystemError.

The filters are per-suite, in each tests/conftest.py rather than pyproject.toml, so that they ship in the wheel and so also apply to the pytest --pyargs runs in wheel.yml.

integrationtests/ is not a pytest tree -- collecting it launches the Mayavi2 application and blocks on the window -- so it gets a conftest.py that hides it from a bare pytest.  Porting it is a follow-up.