### PR TITLE
MAINT: Treat warnings as errors when building the docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,19 @@ The build is warning-clean and **kept** that way: both Makefiles default
 warning is genuinely unfixable, add it to `nitpick_ignore` in
 `docs/source/mayavi/conf.py` with a reason rather than dropping the flags.
 
+`-W` covers only Sphinx's *own* diagnostics, so **Python** warnings are made
+fatal separately, in the two places that run Python:
+
+- both `conf.py`s call `warnings.filterwarnings('error')`, for the Sphinx
+  build itself (autodoc importing our modules);
+- `scripts/render_docs.py` sets `WARNING_FILTERS` for example execution, and
+  exports them as `PYTHONWARNINGS` so they reach the per-example child
+  processes too — `capture_in_subprocess` throws a child's output away unless
+  it exits non-zero, so a warning there is only ever seen by being raised.
+  Failures are collected in `render_examples.RENDER_FAILURES` and turned into
+  a non-zero exit *after* every example has had its turn, so one broken
+  example still does not cost the gallery the rest of its figures.
+
 - The Makefiles export `ETS_TOOLKIT=null`: `tips.rst` autodocs
   `mayavi.tools.server`, whose `wx`/`twisted` imports are handled by
   `autodoc_mock_imports`, and PySide6's feature import hook hits an

--- a/docs/source/mayavi/auto/canyon.py
+++ b/docs/source/mayavi/auto/canyon.py
@@ -34,7 +34,7 @@ import numpy as np
 
 data = np.frombuffer(zipfile.ZipFile('N36W113.hgt.zip').read('N36W113.hgt'),
                     '>i2')
-data.shape = (3601, 3601)
+data = data.reshape((3601, 3601))
 data = data.astype(np.float32)
 
 # Plot an interesting section #################################################

--- a/docs/source/mayavi/auto/canyon_decimation.py
+++ b/docs/source/mayavi/auto/canyon_decimation.py
@@ -48,7 +48,7 @@ import numpy as np
 
 data = np.frombuffer(zipfile.ZipFile('N36W113.hgt.zip').read('N36W113.hgt'),
                     '>i2')
-data.shape = (3601, 3601)
+data = data.reshape((3601, 3601))
 data = data[200:400, 1200:1400]
 data = data.astype(np.float32)
 

--- a/docs/source/mayavi/auto/chemistry.py
+++ b/docs/source/mayavi/auto/chemistry.py
@@ -74,7 +74,7 @@ mlab.plot3d(atoms_x, atoms_y, atoms_z, [1, 2, 1],
 with open('h2o-elf.cube') as fid:
     text = ' '.join(fid.readlines()[9:])
 data = np.array(text.split(), dtype=float)
-data.shape = (40, 40, 40)
+data = data.reshape((40, 40, 40))
 
 source = mlab.pipeline.scalar_field(data)
 min = data.min()

--- a/docs/source/mayavi/auto/compute_in_thread.py
+++ b/docs/source/mayavi/auto/compute_in_thread.py
@@ -43,7 +43,7 @@ def make_data(dims=(128, 128, 128)):
     # dimensions of the data.  The scalars themselves are ravel'd and
     # used internally by VTK so the dimension does not matter for the
     # scalars.
-    s.shape = s.shape[::-1]
+    s = s.reshape(s.shape[::-1])
     return s
 
 

--- a/docs/source/mayavi/auto/examples.rst
+++ b/docs/source/mayavi/auto/examples.rst
@@ -77,8 +77,8 @@ Advanced mlab examples
 .. toctree::
    :hidden:
 
-   example_julia_set.rst
    example_boy.rst
+   example_julia_set.rst
    example_bunny.rst
    example_dragon.rst
    example_lucy.rst
@@ -101,11 +101,11 @@ Advanced mlab examples
    example_flight_graph.rst
 
 
-.. |0000| image:: ../generated_images/example_julia_set.jpg
+.. |0000| image:: ../generated_images/example_boy.jpg
     :width: 150
 
             
-.. |0001| image:: ../generated_images/example_boy.jpg
+.. |0001| image:: ../generated_images/example_julia_set.jpg
     :width: 150
 
             
@@ -191,13 +191,13 @@ Advanced mlab examples
             
 ======= =============================================
 ======= =============================================
-|0000|  :ref:`example_julia_set`
-         An example showing the Julia set
-         displayed as a z-warped surface.
-
-|0001|  :ref:`example_boy`
+|0000|  :ref:`example_boy`
          A script to generate the Mayavi logo: a
          Boy surface.
+
+|0001|  :ref:`example_julia_set`
+         An example showing the Julia set
+         displayed as a z-warped surface.
 
 |0002|  :ref:`example_bunny`
          Viewing Stanford 3D Scanning Repository

--- a/docs/source/mayavi/auto/julia_set.py
+++ b/docs/source/mayavi/auto/julia_set.py
@@ -20,9 +20,11 @@ z = x + 1j * y
 
 julia = np.zeros(z.shape)
 
-for i in range(50):
-    z = z ** 2 - 0.70176 - 0.3842j
-    julia += 1 / float(2 + i) * (z * np.conj(z) > 4)
+# the iteration is an escape-time one, so |z| overflowing is the point
+with np.errstate(over='ignore', invalid='ignore'):
+    for i in range(50):
+        z = z ** 2 - 0.70176 - 0.3842j
+        julia += 1 / float(2 + i) * (z * np.conj(z) > 4)
 
 # Display it
 mlab.figure(size=(400, 300))

--- a/docs/source/mayavi/auto/julia_set_decimation.py
+++ b/docs/source/mayavi/auto/julia_set_decimation.py
@@ -38,9 +38,11 @@ z = x + 1j * y
 
 julia = np.zeros(z.shape)
 
-for i in range(50):
-    z = z ** 2 - 0.70176 - 0.3842j
-    julia += 1 / float(2 + i) * (z * np.conj(z) > 4)
+# the iteration is an escape-time one, so |z| overflowing is the point
+with np.errstate(over='ignore', invalid='ignore'):
+    for i in range(50):
+        z = z ** 2 - 0.70176 - 0.3842j
+        julia += 1 / float(2 + i) * (z * np.conj(z) > 4)
 
 
 mlab.figure(size=(400, 300))

--- a/docs/source/mayavi/auto/magnetic_field.py
+++ b/docs/source/mayavi/auto/magnetic_field.py
@@ -198,9 +198,9 @@ for this_n, this_r0, this_R in zip(n, r0, R):
 Bx = B[:, 0]
 By = B[:, 1]
 Bz = B[:, 2]
-Bx.shape = X.shape
-By.shape = Y.shape
-Bz.shape = Z.shape
+Bx = Bx.reshape(X.shape)
+By = By.reshape(Y.shape)
+Bz = Bz.reshape(Z.shape)
 
 Bnorm = np.sqrt(Bx**2 + By**2 + Bz**2)
 

--- a/docs/source/mayavi/auto/mlab_3D_to_2D.py
+++ b/docs/source/mayavi/auto/mlab_3D_to_2D.py
@@ -185,9 +185,9 @@ if __name__ == '__main__':
     N = 4
 
     # create a few points in 3-space
-    X = np.random.random_integers(-3, 3, N)
-    Y = np.random.random_integers(-3, 3, N)
-    Z = np.random.random_integers(-3, 3, N)
+    X = np.random.randint(-3, 4, N)
+    Y = np.random.randint(-3, 4, N)
+    Z = np.random.randint(-3, 4, N)
 
     # plot the points with mlab
     pts = mlab.points3d(X, Y, Z)

--- a/docs/source/mayavi/auto/mri.py
+++ b/docs/source/mayavi/auto/mri.py
@@ -46,7 +46,7 @@ if not os.path.exists(mri_slice_file):
 import numpy as np
 data = np.array([np.fromfile(os.path.join('mri_data', 'MRbrain.%i' % i),
                                         dtype='>u2') for i in range(1, 110)])
-data.shape = (109, 256, 256)
+data = data.reshape((109, 256, 256))
 data = data.T
 
 # Display the data ############################################################

--- a/docs/source/mayavi/auto/normal_flipping_stl.py
+++ b/docs/source/mayavi/auto/normal_flipping_stl.py
@@ -22,7 +22,7 @@ def flip_normals(stl_fname):
     x, y, z = points.T
 
     data = polydata.polys.to_array()
-    data.shape = data.size//4,4
+    data = data.reshape(data.size//4,4)
     ordering = np.delete(data, 0, 1)
 
     # getting normal data of the stl file

--- a/docs/source/mayavi/auto/numeric_source.py
+++ b/docs/source/mayavi/auto/numeric_source.py
@@ -37,7 +37,7 @@ def make_data(dims=(128, 128, 128)):
     # dimensions of the data.  The scalars themselves are ravel'd and
     # used internally by VTK so the dimension does not matter for the
     # scalars.
-    s.shape = s.shape[::-1]
+    s = s.reshape(s.shape[::-1])
 
     return s
 

--- a/docs/source/mayavi/auto/scatter_plot.py
+++ b/docs/source/mayavi/auto/scatter_plot.py
@@ -39,7 +39,7 @@ def main():
     pd = tvtk.PolyData()
     pd.points = np.random.random((1000, 3))
     verts = np.arange(0, 1000, 1)
-    verts.shape = (1000, 1)
+    verts = verts.reshape((1000, 1))
     pd.verts = verts
     pd.point_data.scalars = np.random.random(1000)
     pd.point_data.scalars.name = 'scalars'

--- a/docs/source/mayavi/auto/simple_structured_grid.py
+++ b/docs/source/mayavi/auto/simple_structured_grid.py
@@ -43,10 +43,10 @@ vectors[..., 2] = sin(z * pi)
 # We reorder the points, scalars and vectors so this is as per VTK's
 # requirement of x first, y next and z last.
 pts = pts.transpose(2, 1, 0, 3).copy()
-pts.shape = pts.size // 3, 3
+pts = pts.reshape(pts.size // 3, 3)
 scalars = scalars.T.copy()
 vectors = vectors.transpose(2, 1, 0, 3).copy()
-vectors.shape = vectors.size // 3, 3
+vectors = vectors.reshape(vectors.size // 3, 3)
 
 # Create the dataset.
 sg = tvtk.StructuredGrid(dimensions=x.shape, points=pts)

--- a/docs/source/mayavi/auto/tvtk_segmentation.py
+++ b/docs/source/mayavi/auto/tvtk_segmentation.py
@@ -41,7 +41,7 @@ if not os.path.exists(mri_slice_file):
 import numpy as np
 data = np.array([np.fromfile(os.path.join('mri_data', 'MRbrain.%i' % i),
                                         dtype='>u2') for i in range(1, 110)])
-data.shape = (109, 256, 256)
+data = data.reshape((109, 256, 256))
 data = data.T
 
 ################################################################################

--- a/docs/source/mayavi/auto/volume_slicer_advanced.py
+++ b/docs/source/mayavi/auto/volume_slicer_advanced.py
@@ -177,7 +177,7 @@ class VolumeSlicer(HasTraits):
             position = list(obj.GetCurrentCursorPosition()*spacing)[:2]
             position.insert(this_axis_number, self.position[this_axis_number])
             # We need to special case y, as the view has been rotated.
-            if axis_name is 'y':
+            if axis_name == 'y':
                 position = position[::-1]
             self.position = position
 
@@ -239,7 +239,7 @@ class VolumeSlicer(HasTraits):
             # side view
             position2d = list(self.position)
             position2d.pop(axis_number)
-            if axis_name is 'y':
+            if axis_name == 'y':
                 position2d = position2d[::-1]
             # Move the cursor
             # For the following to work, you need Mayavi 3.4.0, if you

--- a/docs/source/mayavi/conf.py
+++ b/docs/source/mayavi/conf.py
@@ -17,6 +17,13 @@
 import faulthandler
 import os
 import re
+import warnings
+from pathlib import Path
+
+# Python warnings during the build are fatal too: the Makefiles' -W only
+# covers Sphinx's own diagnostics.  Example execution is separate -- see the
+# filters in scripts/render_docs.py.
+warnings.filterwarnings('error')
 
 # autodoc imports mayavi, so VTK can take the build down with it; without this
 # a crash is a bare signal number.  The variable carries it into any child.
@@ -68,8 +75,8 @@ copyright = 'Enthought, Inc.'
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.
 d = {}
-fname = os.path.join(basedir, '..', '..', '..', 'mayavi', '__init__.py')
-exec(compile(open(fname).read(), fname, 'exec'), d)
+fname = Path(basedir, '..', '..', '..', 'mayavi', '__init__.py')
+exec(compile(fname.read_text(), str(fname), 'exec'), d)
 # "4.8.4.dev", not "4.8.4.dev14+g8665ab72c.d20260729": the commit and date show
 # up in the title of every page, so they would churn the whole site each build.
 # A pre-release segment such as rc1 is kept.

--- a/docs/source/render_examples.py
+++ b/docs/source/render_examples.py
@@ -6,6 +6,8 @@ Render the examples to images and adds them to the documentation.
 import glob
 import inspect
 import os
+from io import StringIO
+from pathlib import Path
 import shutil
 import subprocess
 import sys
@@ -124,7 +126,7 @@ def is_dialog_example(filename):
 
 
 def _code_without_comments(filename):
-    tokens = tokenize.generate_tokens(open(filename).readline)
+    tokens = tokenize.generate_tokens(StringIO(Path(filename).read_text()).readline)
     return ''.join([tok_content
                     for tok_type, tok_content, _, _, _ in tokens
                     if not token.tok_name[tok_type] in ('COMMENT', 'STRING')])
@@ -211,7 +213,7 @@ def capture_dialog(filename, image_file):
     HasTraits.configure_traits = lambda self, *a, **k: edit_traits(self)
     np.random.seed(0)
     try:
-        exec(compile(open(filename).read(), filename, 'exec'),
+        exec(compile(Path(filename).read_text(), filename, 'exec'),
              {'__name__': '__main__', '__file__': os.path.abspath(filename)})
         if not created:
             raise RuntimeError('%s opened no dialog' % filename)
@@ -350,7 +352,7 @@ def capture_example(filename, short_file_name, image_file):
 
 
 def is_mlab_example(filename):
-    tokens = tokenize.generate_tokens(open(filename).readline)
+    tokens = tokenize.generate_tokens(StringIO(Path(filename).read_text()).readline)
     code_only = ''.join([tok_content
                             for tok_type, tok_content, _, _, _  in tokens
                             if not token.tok_name[tok_type] in ('COMMENT',
@@ -398,7 +400,7 @@ def run_mlab_file(filename, image_file):
     e = mlab.get_engine()
     e.close_scene(mlab.gcf())
     exec(
-        compile(open(filename).read(), filename, 'exec'),
+        compile(Path(filename).read_text(), filename, 'exec'),
         {'__name__': '__main__', '__file__': os.path.abspath(filename)}
     )
     realize_scene_window(mlab.gcf().scene)
@@ -412,7 +414,7 @@ def run_mlab_file(filename, image_file):
 
 def extract_docstring(filename):
     # Extract a module-level docstring, if any
-    lines = open(filename).readlines()
+    lines = Path(filename).read_text().splitlines(keepends=True)
     start_row = 0
     if lines[0].startswith('#!'):
         lines.pop(0)
@@ -503,9 +505,9 @@ class ExampleLister(object):
         for index, file_details in enumerate(files_details):
             filename, short_file_name, short_desc, title, docstring, \
                                                     end_row = file_details
-            self.render_example_page(open(os.path.join(self.out_dir,
-                                            'example_%s.rst') %
-                                     short_file_name, 'w'), index, file_details)
+            page = Path(self.out_dir, 'example_%s.rst' % short_file_name)
+            with page.open('w') as stream:
+                self.render_example_page(stream, index, file_details)
             self.gallery_entry(index, file_details)
 
         del self._stream
@@ -597,9 +599,9 @@ class ImagesExampleLister(ExampleLister):
         for index, file_details in enumerate(files_details):
             filename, short_file_name, short_desc, title, docstring, end_row = \
                                                                 file_details
-            self.render_example_page(open(os.path.join(self.out_dir,
-                                        'example_%s.rst') %
-                                     short_file_name, 'w'), index, file_details)
+            page = Path(self.out_dir, 'example_%s.rst' % short_file_name)
+            with page.open('w') as stream:
+                self.render_example_page(stream, index, file_details)
             self.gallery_entry(index, file_details)
 
         self._stream.write("\n"+7*"=" + " " + 45*"=" + '\n')
@@ -778,7 +780,7 @@ Advanced mlab examples
 def render_examples(render_images=False, out_dir='mayavi/auto'):
     if not os.path.exists(out_dir):
         os.makedirs(out_dir)
-    example_gallery_file = open(os.path.join(out_dir, 'examples.rst'), 'w')
+    example_gallery_file = StringIO()
 
     example_gallery_file.write("""
 
@@ -797,7 +799,7 @@ Example gallery
                     if is_mlab_example(filename)]
     # Sort by file length (gives a measure of the complexity of the
     # example)
-    example_files.sort(key=lambda name: (len(open(name, 'r').readlines()), name))
+    example_files.sort(key=lambda name: (len(Path(name).read_text().splitlines()), name))
 
     mlab_example_lister = MlabExampleLister(render_images=render_images,
                                         out_dir=out_dir,
@@ -815,7 +817,7 @@ Example gallery
                         'interactive', '*.py'))]
     # Sort by file length (gives a measure of the complexity of the
     # example)
-    example_files.sort(key=lambda name: (len(open(name, 'r').readlines()), name))
+    example_files.sort(key=lambda name: (len(Path(name).read_text().splitlines()), name))
     example_lister = RenderedExampleLister(
             render_images=render_images,
             images_dir='mayavi/generated_images',
@@ -836,7 +838,7 @@ applications.
                         'advanced_visualization', '*.py'))]
     # Sort by file length (gives a measure of the complexity of the
     # example)
-    example_files.sort(key=lambda name: (len(open(name, 'r').readlines()), name))
+    example_files.sort(key=lambda name: (len(Path(name).read_text().splitlines()), name))
     example_lister = RenderedExampleLister(
             render_images=render_images,
             images_dir='mayavi/generated_images',
@@ -856,7 +858,7 @@ more fine control than mlab.
                         'data_interaction', '*.py'))]
     # Sort by file length (gives a measure of the complexity of the
     # example)
-    example_files.sort(key=lambda name: (len(open(name, 'r').readlines()), name))
+    example_files.sort(key=lambda name: (len(Path(name).read_text().splitlines()), name))
     example_lister = RenderedExampleLister(
             render_images=render_images,
             images_dir='mayavi/generated_images',
@@ -875,11 +877,13 @@ Examples showing how you can query and interact with the data.
                         '*.py'))]
     # Sort by file length (gives a measure of the complexity of the
     # example)
-    example_files.sort(key=lambda name: (len(open(name, 'r').readlines()), name))
+    example_files.sort(key=lambda name: (len(Path(name).read_text().splitlines()), name))
     example_lister = ExampleLister(title="Misc examples",
                                    out_dir=out_dir)
     example_lister.render_all(example_gallery_file, example_files)
 
+
+    Path(out_dir, 'examples.rst').write_text(example_gallery_file.getvalue())
 
 
 if __name__ == '__main__':

--- a/docs/source/tvtk/conf.py
+++ b/docs/source/tvtk/conf.py
@@ -15,6 +15,13 @@ import faulthandler
 import os
 import re
 import sys
+import warnings
+from pathlib import Path
+
+# Python warnings during the build are fatal too: the Makefiles' -W only
+# covers Sphinx's own diagnostics.  Example execution is separate -- see the
+# filters in scripts/render_docs.py.
+warnings.filterwarnings('error')
 
 # autodoc imports tvtk, so VTK can take the build down with it; without this a
 # crash is a bare signal number.  The variable carries it into any child.
@@ -56,8 +63,8 @@ copyright = 'Enthought, Inc.'
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.
 d = {}
-fname = os.path.join(basedir, '..', '..', '..', 'mayavi', '__init__.py')
-exec(compile(open(fname).read(), fname, 'exec'), d)
+fname = Path(basedir, '..', '..', '..', 'mayavi', '__init__.py')
+exec(compile(fname.read_text(), str(fname), 'exec'), d)
 # truncated like the mayavi docs do; see the note in ../mayavi/conf.py
 version = release = re.sub(r'\.dev\d+', '.dev', d['__version__'].split('+')[0])
 

--- a/examples/mayavi/advanced_visualization/magnetic_field.py
+++ b/examples/mayavi/advanced_visualization/magnetic_field.py
@@ -198,9 +198,9 @@ for this_n, this_r0, this_R in zip(n, r0, R):
 Bx = B[:, 0]
 By = B[:, 1]
 Bz = B[:, 2]
-Bx.shape = X.shape
-By.shape = Y.shape
-Bz.shape = Z.shape
+Bx = Bx.reshape(X.shape)
+By = By.reshape(Y.shape)
+Bz = Bz.reshape(Z.shape)
 
 Bnorm = np.sqrt(Bx**2 + By**2 + Bz**2)
 

--- a/examples/mayavi/advanced_visualization/mlab_3D_to_2D.py
+++ b/examples/mayavi/advanced_visualization/mlab_3D_to_2D.py
@@ -185,9 +185,9 @@ if __name__ == '__main__':
     N = 4
 
     # create a few points in 3-space
-    X = np.random.random_integers(-3, 3, N)
-    Y = np.random.random_integers(-3, 3, N)
-    Z = np.random.random_integers(-3, 3, N)
+    X = np.random.randint(-3, 4, N)
+    Y = np.random.randint(-3, 4, N)
+    Z = np.random.randint(-3, 4, N)
 
     # plot the points with mlab
     pts = mlab.points3d(X, Y, Z)

--- a/examples/mayavi/advanced_visualization/numeric_source.py
+++ b/examples/mayavi/advanced_visualization/numeric_source.py
@@ -37,7 +37,7 @@ def make_data(dims=(128, 128, 128)):
     # dimensions of the data.  The scalars themselves are ravel'd and
     # used internally by VTK so the dimension does not matter for the
     # scalars.
-    s.shape = s.shape[::-1]
+    s = s.reshape(s.shape[::-1])
 
     return s
 

--- a/examples/mayavi/advanced_visualization/scatter_plot.py
+++ b/examples/mayavi/advanced_visualization/scatter_plot.py
@@ -39,7 +39,7 @@ def main():
     pd = tvtk.PolyData()
     pd.points = np.random.random((1000, 3))
     verts = np.arange(0, 1000, 1)
-    verts.shape = (1000, 1)
+    verts = verts.reshape((1000, 1))
     pd.verts = verts
     pd.point_data.scalars = np.random.random(1000)
     pd.point_data.scalars.name = 'scalars'

--- a/examples/mayavi/advanced_visualization/tvtk_segmentation.py
+++ b/examples/mayavi/advanced_visualization/tvtk_segmentation.py
@@ -41,7 +41,7 @@ if not os.path.exists(mri_slice_file):
 import numpy as np
 data = np.array([np.fromfile(os.path.join('mri_data', 'MRbrain.%i' % i),
                                         dtype='>u2') for i in range(1, 110)])
-data.shape = (109, 256, 256)
+data = data.reshape((109, 256, 256))
 data = data.T
 
 ################################################################################

--- a/examples/mayavi/data_interaction/normal_flipping_stl.py
+++ b/examples/mayavi/data_interaction/normal_flipping_stl.py
@@ -22,7 +22,7 @@ def flip_normals(stl_fname):
     x, y, z = points.T
 
     data = polydata.polys.to_array()
-    data.shape = data.size//4,4
+    data = data.reshape(data.size//4,4)
     ordering = np.delete(data, 0, 1)
 
     # getting normal data of the stl file

--- a/examples/mayavi/explorer/explorer_app.py
+++ b/examples/mayavi/explorer/explorer_app.py
@@ -169,7 +169,7 @@ class Explorer3D(HasTraits):
             # messes up the dimensions of the data.  The scalars
             # themselves are ravel'd and used internally by VTK so the
             # dimension does not matter for the scalars.
-            s.shape = s.shape[::-1]
+            s = s.reshape(s.shape[::-1])
             self.data = s
         except:
             pass

--- a/examples/mayavi/interactive/compute_in_thread.py
+++ b/examples/mayavi/interactive/compute_in_thread.py
@@ -43,7 +43,7 @@ def make_data(dims=(128, 128, 128)):
     # dimensions of the data.  The scalars themselves are ravel'd and
     # used internally by VTK so the dimension does not matter for the
     # scalars.
-    s.shape = s.shape[::-1]
+    s = s.reshape(s.shape[::-1])
     return s
 
 

--- a/examples/mayavi/interactive/volume_slicer_advanced.py
+++ b/examples/mayavi/interactive/volume_slicer_advanced.py
@@ -177,7 +177,7 @@ class VolumeSlicer(HasTraits):
             position = list(obj.GetCurrentCursorPosition()*spacing)[:2]
             position.insert(this_axis_number, self.position[this_axis_number])
             # We need to special case y, as the view has been rotated.
-            if axis_name is 'y':
+            if axis_name == 'y':
                 position = position[::-1]
             self.position = position
 
@@ -239,7 +239,7 @@ class VolumeSlicer(HasTraits):
             # side view
             position2d = list(self.position)
             position2d.pop(axis_number)
-            if axis_name is 'y':
+            if axis_name == 'y':
                 position2d = position2d[::-1]
             # Move the cursor
             # For the following to work, you need Mayavi 3.4.0, if you

--- a/examples/mayavi/mlab/canyon.py
+++ b/examples/mayavi/mlab/canyon.py
@@ -34,7 +34,7 @@ import numpy as np
 
 data = np.frombuffer(zipfile.ZipFile('N36W113.hgt.zip').read('N36W113.hgt'),
                     '>i2')
-data.shape = (3601, 3601)
+data = data.reshape((3601, 3601))
 data = data.astype(np.float32)
 
 # Plot an interesting section #################################################

--- a/examples/mayavi/mlab/canyon_decimation.py
+++ b/examples/mayavi/mlab/canyon_decimation.py
@@ -48,7 +48,7 @@ import numpy as np
 
 data = np.frombuffer(zipfile.ZipFile('N36W113.hgt.zip').read('N36W113.hgt'),
                     '>i2')
-data.shape = (3601, 3601)
+data = data.reshape((3601, 3601))
 data = data[200:400, 1200:1400]
 data = data.astype(np.float32)
 

--- a/examples/mayavi/mlab/chemistry.py
+++ b/examples/mayavi/mlab/chemistry.py
@@ -74,7 +74,7 @@ mlab.plot3d(atoms_x, atoms_y, atoms_z, [1, 2, 1],
 with open('h2o-elf.cube') as fid:
     text = ' '.join(fid.readlines()[9:])
 data = np.array(text.split(), dtype=float)
-data.shape = (40, 40, 40)
+data = data.reshape((40, 40, 40))
 
 source = mlab.pipeline.scalar_field(data)
 min = data.min()

--- a/examples/mayavi/mlab/julia_set.py
+++ b/examples/mayavi/mlab/julia_set.py
@@ -20,9 +20,11 @@ z = x + 1j * y
 
 julia = np.zeros(z.shape)
 
-for i in range(50):
-    z = z ** 2 - 0.70176 - 0.3842j
-    julia += 1 / float(2 + i) * (z * np.conj(z) > 4)
+# the iteration is an escape-time one, so |z| overflowing is the point
+with np.errstate(over='ignore', invalid='ignore'):
+    for i in range(50):
+        z = z ** 2 - 0.70176 - 0.3842j
+        julia += 1 / float(2 + i) * (z * np.conj(z) > 4)
 
 # Display it
 mlab.figure(size=(400, 300))

--- a/examples/mayavi/mlab/julia_set_decimation.py
+++ b/examples/mayavi/mlab/julia_set_decimation.py
@@ -38,9 +38,11 @@ z = x + 1j * y
 
 julia = np.zeros(z.shape)
 
-for i in range(50):
-    z = z ** 2 - 0.70176 - 0.3842j
-    julia += 1 / float(2 + i) * (z * np.conj(z) > 4)
+# the iteration is an escape-time one, so |z| overflowing is the point
+with np.errstate(over='ignore', invalid='ignore'):
+    for i in range(50):
+        z = z ** 2 - 0.70176 - 0.3842j
+        julia += 1 / float(2 + i) * (z * np.conj(z) > 4)
 
 
 mlab.figure(size=(400, 300))

--- a/examples/mayavi/mlab/mri.py
+++ b/examples/mayavi/mlab/mri.py
@@ -46,7 +46,7 @@ if not os.path.exists(mri_slice_file):
 import numpy as np
 data = np.array([np.fromfile(os.path.join('mri_data', 'MRbrain.%i' % i),
                                         dtype='>u2') for i in range(1, 110)])
-data.shape = (109, 256, 256)
+data = data.reshape((109, 256, 256))
 data = data.T
 
 # Display the data ############################################################

--- a/examples/mayavi/mlab/simple_structured_grid.py
+++ b/examples/mayavi/mlab/simple_structured_grid.py
@@ -43,10 +43,10 @@ vectors[..., 2] = sin(z * pi)
 # We reorder the points, scalars and vectors so this is as per VTK's
 # requirement of x first, y next and z last.
 pts = pts.transpose(2, 1, 0, 3).copy()
-pts.shape = pts.size // 3, 3
+pts = pts.reshape(pts.size // 3, 3)
 scalars = scalars.T.copy()
 vectors = vectors.transpose(2, 1, 0, 3).copy()
-vectors.shape = vectors.size // 3, 3
+vectors = vectors.reshape(vectors.size // 3, 3)
 
 # Create the dataset.
 sg = tvtk.StructuredGrid(dimensions=x.shape, points=pts)

--- a/examples/tvtk/animated_texture.py
+++ b/examples/tvtk/animated_texture.py
@@ -85,7 +85,7 @@ def image_from_array(ary):
 
         # create a 2d view of the array
         ary_2d = ary[:]
-        ary_2d.shape = sz[0]*sz[1],sz[2]
+        ary_2d = ary_2d.reshape(sz[0]*sz[1],sz[2])
         img.point_data.scalars = ary_2d
 
     else:

--- a/mlab_reference.py
+++ b/mlab_reference.py
@@ -7,6 +7,8 @@ Script to generate the function reference for mlab.
 # License: BSD Style.
 
 import os
+from io import StringIO
+from pathlib import Path
 import re
 import sys
 
@@ -22,12 +24,15 @@ from mayavi import mlab
 from inspect import cleandoc, getmembers, getsource, signature
 from docutils import io as docIO
 from docutils import core as docCore
+from docutils.parsers import rst as docRst
+from docutils.readers import standalone as docStandalone
+from docutils.writers import pseudoxml as docPseudoxml
 
 # We need to exec render_image, as we can't import it, because it is not
 # in a python package.
 _src = os.path.abspath(os.path.join('docs', 'source', 'render_images.py'))
 render_images = dict(__name__='', __file__=_src)
-exec(compile(open(_src).read(), _src, 'exec'), render_images)
+exec(compile(Path(_src).read_text(), _src, 'exec'), render_images)
 IMAGE_DIR = render_images['IMAGE_DIR']
 
 # Demonstrations that belong to a function but are not named after it, so the
@@ -87,9 +92,13 @@ def relpath(target, base=os.curdir):
 def is_valid_rst(string):
     """ Check if the given string can be compiled to rst.
     """
-    publisher = docCore.Publisher( source_class = docIO.StringInput,
-                        destination_class = docIO.StringOutput )
-    publisher.set_components('standalone', 'restructuredtext', 'pseudoxml')
+    # components go to the constructor; naming them via set_components() is
+    # deprecated as of Docutils 2.0
+    publisher = docCore.Publisher(reader=docStandalone.Reader(),
+                                  parser=docRst.Parser(),
+                                  writer=docPseudoxml.Writer(),
+                                  source_class=docIO.StringInput,
+                                  destination_class=docIO.StringOutput)
     publisher.process_programmatic_settings(None, None, None)
     publisher.set_source(string, None)
 
@@ -280,7 +289,7 @@ from mayavi.mlab import *
                             if not ( name[:5] == 'test_' or name[0] == '_')
                                                      and callable(func)])
 
-        outfile = open(os.sep.join([self.out_dir, self.filename]), 'w')
+        outfile = StringIO()
 
         outfile.write(self.header)
 
@@ -327,6 +336,7 @@ from mayavi.mlab import *
 
         outfile.write(self.footer)
         outfile.write('\n\n')
+        Path(self.out_dir, self.filename).write_text(outfile.getvalue())
 
 
     def write_doc_submodule(self, filename, title=None,
@@ -335,7 +345,7 @@ from mayavi.mlab import *
             submodule. If submodule is none, all the non-processed
             functions are processed.
         """
-        outfile = open(os.sep.join([self.out_dir, filename]), 'w')
+        outfile = StringIO()
 
         if header is not None:
             outfile.write(header)
@@ -371,6 +381,7 @@ from mayavi.mlab import *
             outfile.write("\n\n")
             documented.add(func_name)
 
+        Path(self.out_dir, filename).write_text(outfile.getvalue())
         self.to_document.difference_update(documented)
 
 

--- a/scripts/render_docs.py
+++ b/scripts/render_docs.py
@@ -8,12 +8,53 @@ illustrations.
 
 import faulthandler
 import os
+import re
 import runpy
 import sys
+import warnings
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
 SOURCE = REPO / 'docs' / 'source'
+
+# (action, message prefix, category) -- the examples and the generators run as
+# plain scripts, so this is the only thing making their warnings fatal; the
+# Makefiles' -W covers Sphinx's own diagnostics, not Python's.
+WARNING_FILTERS = (
+    ('error', '', Warning),
+    # third-party, reached through envisage's plugin manager and sphinxcontrib
+    ('ignore', 'pkg_resources is deprecated as an API', UserWarning),
+    ('ignore', 'Deprecated call to `pkg_resources.declare_namespace',
+     DeprecationWarning),
+    # unsatisfiable until pyface.workbench moves to apptools
+    ('ignore', 'Workbench will be moved from pyface', PendingDeprecationWarning),
+    # an example calling plt.show() is right; it is this renderer that has no
+    # interactive matplotlib backend
+    ('ignore', 'FigureCanvasAgg is non-interactive', UserWarning),
+)
+
+
+def apply_warning_filters():
+    """Make warnings fatal, here and in the per-example child processes.
+
+    `capture_in_subprocess` discards a child's output unless it exits
+    non-zero, so a warning there is only ever seen by being raised.
+    """
+    filters = list(WARNING_FILTERS)
+    # VTK's own numpy_support.vtk_to_numpy assigns to .shape, which NumPy 2.5
+    # deprecated; fixed in 9.7, so keep it fatal there.  mayavi/tests/conftest.py
+    # carries the same gate for the suites -- see tvtk/WORKAROUNDS.md
+    from tvtk.common import vtk_major_version, vtk_minor_version
+    if (vtk_major_version, vtk_minor_version) < (9, 7):
+        filters.append(('ignore',
+                        'Setting the shape on a NumPy array has been deprecated',
+                        DeprecationWarning))
+    for action, message, category in filters:
+        warnings.filterwarnings(action, re.escape(message), category)
+    # PYTHONWARNINGS matches the message as a literal prefix, not a regex
+    os.environ['PYTHONWARNINGS'] = ','.join(
+        ':'.join((action, message, category.__name__))
+        for action, message, category in filters)
 
 
 def main():
@@ -22,6 +63,7 @@ def main():
     # says where.  The variable carries this into the per-example children.
     faulthandler.enable()
     os.environ['PYTHONFAULTHANDLER'] = '1'
+    apply_warning_filters()
 
     # render_images.py imports its sibling render_examples, so docs/source has
     # to go on sys.path -- but docs/source/mayavi and docs/source/tvtk then


### PR DESCRIPTION
-W only makes Sphinx's own diagnostics fatal, so nothing was watching the Python warnings from the half of the build that runs our code: the examples.  Make them errors in both places that run Python -- the two conf.py files for the Sphinx build, and scripts/render_docs.py for example execution, exported as PYTHONWARNINGS so the filters reach the per-example child processes as well.  capture_in_subprocess discards a child's output unless it exits non-zero, so a warning there was only ever going to be noticed by being raised, and RENDER_FAILURES then carries it to the end of the run.

What that turned up:

- volume_slicer_advanced compared a trait against a string literal with `is` (twice), which is a SyntaxWarning and was never true by luck.
- mlab_3D_to_2D called np.random.random_integers, long deprecated.
- the two julia_set examples let |z| overflow, which is the point of an escape-time iteration but should say so via np.errstate.
- the doc generators leaked a file handle per example -- several inside sort keys, so hundreds per build.  Read via pathlib, and build the generated pages in memory rather than into a file nobody closed.
- mlab_reference named its docutils components through the deprecated Publisher.set_components() rather than the constructor.
- the examples assigned to ndarray.shape, deprecated in NumPy 2.5.

The gallery reorders because it sorts by example length and the errstate wrapper made julia_set two lines longer.  No images are committed here: they render 3px taller off CI, so CI's own should be taken instead.