### PR TITLE
MAINT: Give git archives a usable version

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,3 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,8 @@
 *.jpg binary
 *.pdf binary
 *.pkl binary
+
+# setuptools_scm derives the version from git, which a GitHub zipball does not
+# carry; export-subst fills these in as the archive is written so that building
+# from one still gets a version instead of failing outright
+.git_archival.txt export-subst

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,7 @@
 include *.rst *.txt *.py *.toml
+# only a git archive can expand it; an sdist carries the version in PKG-INFO,
+# and shipping the unexpanded file just makes setuptools_scm warn twice
+exclude .git_archival.txt
 recursive-include artwork *.*
 recursive-include docs *.* Makefile*
 recursive-include examples *.py *.txt *.jpg *.ipynb


### PR DESCRIPTION
setuptools_scm derives the version from git metadata, which a GitHub zipball/tarball does not carry, so building from one fails outright with "no version found" rather than falling back to anything.  That bites any downstream that packages from the archive URL rather than the PyPI sdist (conda-forge, distro packagers).

Add the standard .git_archival.txt plus the export-subst attribute that fills it in as the archive is written, so setuptools_scm can read the version back out.  Verified against this tree:

  archive of tag 4.9.0        -> 4.9.0
  archive of a later commit   -> 4.8.4.dev20+g5328f6ac
  before this change          -> ERROR: no version found

The file is excluded from the sdist: only a git archive can expand it, the sdist already carries the version in PKG-INFO, and shipping it unexpanded makes setuptools_scm emit two UserWarnings on every build.