### PR TITLE
FIX: Let font_family take VTK_FONT_FILE

### DIFF
--- a/docs/source/mayavi/auto/pick_on_surface.py
+++ b/docs/source/mayavi/auto/pick_on_surface.py
@@ -27,6 +27,7 @@ z = sin(phi)*sin(theta)
 ################################################################################
 # Plot the data
 from mayavi import mlab
+from tvtk.api import tvtk
 
 # A first plot in 3D
 fig = mlab.figure(1)
@@ -51,7 +52,7 @@ mlab.view(90, 0)
 
 def picker_callback(picker_obj):
     picked = picker_obj.actors
-    if mesh.actor.actor._vtk_obj in [o._vtk_obj for o in picked]:
+    if tvtk.to_vtk(mesh.actor.actor) in [tvtk.to_vtk(o) for o in picked]:
         # m.mlab_source.points is the points array underlying the vtk
         # dataset. GetPointId return the index in this array.
         x_, y_ = np.lib.index_tricks.unravel_index(picker_obj.point_id,

--- a/examples/mayavi/data_interaction/pick_on_surface.py
+++ b/examples/mayavi/data_interaction/pick_on_surface.py
@@ -27,6 +27,7 @@ z = sin(phi)*sin(theta)
 ################################################################################
 # Plot the data
 from mayavi import mlab
+from tvtk.api import tvtk
 
 # A first plot in 3D
 fig = mlab.figure(1)
@@ -51,7 +52,7 @@ mlab.view(90, 0)
 
 def picker_callback(picker_obj):
     picked = picker_obj.actors
-    if mesh.actor.actor._vtk_obj in [o._vtk_obj for o in picked]:
+    if tvtk.to_vtk(mesh.actor.actor) in [tvtk.to_vtk(o) for o in picked]:
         # m.mlab_source.points is the points array underlying the vtk
         # dataset. GetPointId return the index in this array.
         x_, y_ = np.lib.index_tricks.unravel_index(picker_obj.point_id,

--- a/tvtk/WORKAROUNDS.md
+++ b/tvtk/WORKAROUNDS.md
@@ -100,6 +100,55 @@ values), some of them keyed on `sys.platform` rather than a VTK version
 (`vtkPoints.DataType` on Windows, `vtkRenderWindow.StereoType` on macOS).
 Prefer `special_traits` for new cases.
 
+One of those inline entries is **not** a VTK bug and never expires:
+`_gen_state_methods()` infers a state trait's whole set of valid values from
+the `SetXToY` methods, so any value `SetX()` accepts without a matching
+`SetXToY` is missing from the map — the trait then rejects a value the C++
+object legitimately holds, and `update_traits()` raises inside a notification
+handler on every resync.  `vtkTextProperty.FontFamily` is the live case
+(`VTK_FONT_FILE`, which is how a custom `FontFile` is selected, and
+`VTK_UNKNOWN_FONT`, which everything out of range clamps to, have no `To`
+methods); it is patched by adding the two names to the map.  Raising
+`MIN_VTK` does not retire this — only VTK growing the missing `SetXToY`
+methods would.
+
+That one stays inline rather than moving to `special_traits`, against the
+preference above, because the registry is scoped to the get/set path and does
+not survive being pointed at the state path: `_gen_state_methods()` returns no
+`allow_update_failure` set, so half the `(updateable, allow_update_failure,
+writer)` contract would be silently dropped; a writer method would have to
+rebuild `d`/`default` from the parser by hand, since the registry replaces a
+whole trait definition and has no hook for amending an inferred one; and the
+existing regexes already match state attributes they have never been applied
+to — `[a-zA-Z0-9]+\.ScalarType$` catches `vtkImageCanvasSource2D`,
+`vtkVoxelModeller` and the `vtk*ExtractHistogram2D` family, whose writer
+`_write_any_scalar_type` is a deliberate no-op, so wiring the dispatch in
+would delete their `scalar_type` trait outright.
+
+Consolidating the ~10 inline per-class conditionals in `_gen_state_methods()`
+is still worth doing, but it wants a **second registry of its own**, keyed the
+same `vtkClass.Attribute` way and consulted only on the state path.  It cannot
+be a one-field mapping, because those conditionals poke three different knobs:
+
+- `vtk_val` — do not emit a mapped trait at all, fall back to plain methods
+  (`vtkRenderView.InteractionMode`, `vtkMatrixMathFilter.Operation`,
+  `vtkResliceImageViewer.ResliceMode`, `vtkThreshold.PointsDataType`).
+- `extra_val` — keep the map as inferred, but tolerate an extra value by
+  coercing it to the default.  For *junk* values only: uninitialized defaults
+  that fall outside the choices (`vtkGenericEnSightReader.ByteOrder`,
+  `vtkImagePlaneWidget.PlaneOrientation`, `vtkThreshold.AttributeMode`,
+  `vtkRenderWindow.StereoType` on macOS).
+- the map itself — add a name/value pair the `SetXToY` sweep could not
+  discover (`vtkPoints.DataType` on Windows, `vtkTextProperty.FontFamily`).
+  This is the amend-the-map hook `special_traits` has no equivalent of.
+
+Keep the last two apart: they look interchangeable and are not.  `extra_val`
+routes the value to `default_value` in `RevPrefixMap._rmap`, so using it for a
+*meaningful* value silently discards it — `font_family = 4` would read back as
+`'arial'` and the next resync would push `SetFontFamily(0)`, dropping the
+user's font file.  Reach for `extra_val` only when the value means nothing and
+the point is merely not to raise.
+
 ## Layer 3: `vtk_module.py` — runtime class removal
 
 For classes that crash or hang *whenever used* on a specific runtime VTK,

--- a/tvtk/tests/test_tvtk.py
+++ b/tvtk/tests/test_tvtk.py
@@ -195,6 +195,14 @@ class TestTVTK(unittest.TestCase):
         obj.SetSpecularColor(val)
         self.assertEqual(p.specular_color, val)
 
+        # A state value with no SetXToY method to discover it from must
+        # still resync, else this raises (see tvtk/WORKAROUNDS.md).  #1391
+        tp = tvtk.TextProperty()
+        tp._vtk_obj.SetFontFamily(4)  # vtk.VTK_FONT_FILE
+        self.assertEqual(tp.font_family, 'file')
+        tp.font_family = 0  # vtk.VTK_ARIAL
+        self.assertEqual(tp._vtk_obj.GetFontFamily(), vtk.VTK_ARIAL)
+
     def test_obj_del(self):
         """Test object deletion and reference cycles."""
         p = tvtk.Property()

--- a/tvtk/tests/test_tvtk.py
+++ b/tvtk/tests/test_tvtk.py
@@ -182,7 +182,7 @@ class TestTVTK(unittest.TestCase):
     def test_auto_update(self):
         """Test if traits are updated when the VTK object changes."""
         p = tvtk.Property()
-        obj = p._vtk_obj
+        obj = tvtk.to_vtk(p)
         obj.SetEdgeVisibility(1)
         self.assertEqual(p.edge_visibility, 1)
 
@@ -203,10 +203,11 @@ class TestTVTK(unittest.TestCase):
         # A state value with no SetXToY method to discover it from must
         # still resync, else this raises (see tvtk/WORKAROUNDS.md).  #1391
         tp = tvtk.TextProperty()
-        tp._vtk_obj.SetFontFamily(4)  # vtk.VTK_FONT_FILE
+        tp_obj = tvtk.to_vtk(tp)
+        tp_obj.SetFontFamily(4)  # vtk.VTK_FONT_FILE
         self.assertEqual(tp.font_family, 'file')
         tp.font_family = 0  # vtk.VTK_ARIAL
-        self.assertEqual(tp._vtk_obj.GetFontFamily(), vtk.VTK_ARIAL)
+        self.assertEqual(tp_obj.GetFontFamily(), vtk.VTK_ARIAL)
 
     def test_obj_del(self):
         """Test object deletion and reference cycles."""

--- a/tvtk/tests/test_tvtk.py
+++ b/tvtk/tests/test_tvtk.py
@@ -167,7 +167,7 @@ class TestTVTK(unittest.TestCase):
         for t, g in p._updateable_traits_:
             if g == "GetEdgeOpacity":
                 continue  # broken for some reason? (see tvtk/WORKAROUNDS.md)
-            vtk_get = getattr(p._vtk_obj, g, None)
+            vtk_get = getattr(tvtk.to_vtk(p), g, None)
             if vtk_get is None:
                 # getter from a newer VTK than the runtime one (TVTK
                 # classes may be generated against a newer VTK)
@@ -378,20 +378,20 @@ class TestTVTK(unittest.TestCase):
 
         # Test iterator nature.
         for i, j in zip(ac, a_list):
-            self.assertEqual(i._vtk_obj, j._vtk_obj)
+            self.assertEqual(tvtk.to_vtk(i), tvtk.to_vtk(j))
         for i, j in enumerate(ac):
-            self.assertEqual(a_list[i]._vtk_obj, j._vtk_obj)
+            self.assertEqual(tvtk.to_vtk(a_list[i]), tvtk.to_vtk(j))
 
         # Test __setitem__.
         ac[0] = a_list[1]
         ac[1] = a_list[0]
-        self.assertEqual(ac[0]._vtk_obj, a_list[1]._vtk_obj)
-        self.assertEqual(ac[1]._vtk_obj, a_list[0]._vtk_obj)
+        self.assertEqual(tvtk.to_vtk(ac[0]), tvtk.to_vtk(a_list[1]))
+        self.assertEqual(tvtk.to_vtk(ac[1]), tvtk.to_vtk(a_list[0]))
         self.assertRaises(TypeError, ac.__setitem__, 's', a_list[1])
 
         # Test __delitem__.
         del ac[-2]
-        self.assertEqual(ac[0]._vtk_obj, a_list[0]._vtk_obj)
+        self.assertEqual(tvtk.to_vtk(ac[0]), tvtk.to_vtk(a_list[0]))
         self.assertEqual(len(ac), 1)
         self.assertRaises(TypeError, ac.__delitem__, 1.414)
         del ac[0]
@@ -404,7 +404,7 @@ class TestTVTK(unittest.TestCase):
         ac.extend(a_list)
         self.assertEqual(len(ac), 2)
         for i, j in enumerate(ac):
-            self.assertEqual(a_list[i]._vtk_obj, j._vtk_obj)
+            self.assertEqual(tvtk.to_vtk(a_list[i]), tvtk.to_vtk(j))
 
         # Test the prop collection.
         pc = tvtk.PropCollection()
@@ -640,7 +640,7 @@ class TestTVTK(unittest.TestCase):
 
         # Get it back
         result = numpy.empty(9)
-        tvtk_filter._vtk_obj.GetKernel3x3(result)
+        tvtk.to_vtk(tvtk_filter).GetKernel3x3(result)
 
         self.assertTrue(numpy.allclose(result, expected), True)
 
@@ -667,7 +667,7 @@ class TestTVTK(unittest.TestCase):
 
         # Get it back
         result = numpy.empty(3)
-        tvtk_filter._vtk_obj.GetPoint1WorldPosition(result)
+        tvtk.to_vtk(tvtk_filter).GetPoint1WorldPosition(result)
 
         self.assertTrue(numpy.allclose(result, expected), True)
 
@@ -776,6 +776,9 @@ class TestTVTK(unittest.TestCase):
             # Should be able to instantiate this wrapped class.
             getattr(tvtk, name)()
 
+    # The three tests below are the ones that establish what tvtk.to_vtk and
+    # tvtk.to_tvtk return, so they have to compare against `_vtk_obj` itself.
+    # Rewriting them in terms of to_vtk would make them tautological.
     def test_to_vtk_returns_vtk_object(self):
         # Given
         x = tvtk.ContourFilter()

--- a/tvtk/tests/test_tvtk_base.py
+++ b/tvtk/tests/test_tvtk_base.py
@@ -19,7 +19,9 @@ from tvtk.common import get_tvtk_name, camel2enthought
 
 
 # An elementary class based on vtkProperty that is used only for
-# testing.
+# testing.  It stands in for a generated wrapper, so its bodies use
+# `self._vtk_obj` the way wrapper_gen.py emits it rather than the public
+# deref_vtk() the tests below use from the outside.
 class Prop(tvtk_base.TVTKBase):
     def __init__(self, obj=None, update=1, **traits):
         tvtk_base.TVTKBase.__init__(
@@ -114,7 +116,7 @@ class TestTVTKBase(unittest.TestCase):
         p.diffuse_color = (1, 1, 1)
         p.specular_color = (1, 1, 0)
         for t, g in p._updateable_traits_:
-            val = getattr(p._vtk_obj, g)()
+            val = getattr(tvtk_base.deref_vtk(p), g)()
             if t == 'representation':
                 self.assertEqual(val, getattr(p, t + '_'))
             else:
@@ -127,7 +129,7 @@ class TestTVTKBase(unittest.TestCase):
         # When
         try:
             # Make a mistake
-            p._wrap_call(p._vtk_obj.SetLineWidth, 'a')
+            p._wrap_call(tvtk_base.deref_vtk(p).SetLineWidth, 'a')
         except TypeError:
             pass
 
@@ -138,7 +140,7 @@ class TestTVTKBase(unittest.TestCase):
     def test_auto_update(self):
         """Test trait updation when the VTK object changes."""
         p = Prop()
-        obj = p._vtk_obj
+        obj = tvtk_base.deref_vtk(p)
         obj.SetEdgeVisibility(1)
         self.assertEqual(p.edge_visibility, 1)
 
@@ -165,7 +167,7 @@ class TestTVTKBase(unittest.TestCase):
         p = Prop()
         # Turn off the observers.
         p.teardown_observers()
-        obj = p._vtk_obj
+        obj = tvtk_base.deref_vtk(p)
         obj.SetEdgeVisibility(1)
         self.assertEqual(p.edge_visibility, 0)
 
@@ -221,10 +223,10 @@ class TestTVTKBase(unittest.TestCase):
         d = p.__getstate__()
         del p
         p = Prop()
-        addr = p._vtk_obj.__this__
+        addr = tvtk_base.deref_vtk(p).__this__
         p.__setstate__(d)
         # Make sure its the same object.
-        self.assertEqual(addr, p._vtk_obj.__this__)
+        self.assertEqual(addr, tvtk_base.deref_vtk(p).__this__)
 
         self.assertEqual(p.edge_visibility, 1)
         self.assertEqual(p.opacity, 0.5)
@@ -343,7 +345,7 @@ class TestTVTKBase(unittest.TestCase):
 
         l1 = len(tvtk_base._object_cache)
         p = Prop()
-        addr = p._vtk_obj.__this__
+        addr = tvtk_base.deref_vtk(p).__this__
         self.assertEqual(l1 + 1, len(tvtk_base._object_cache))
         self.assertEqual(p, tvtk_base._object_cache.get(addr))
 

--- a/tvtk/wrapper_gen.py
+++ b/tvtk/wrapper_gen.py
@@ -617,6 +617,17 @@ class WrapperGenerator:
                 # an option and creates problems (see tvtk/WORKAROUNDS.md)
                 if klass.__name__ == "vtkPoints" and m == "DataType" and sys.platform == "win32":
                     d["int32"] = vtk.VTK_ID_TYPE
+                # VTK only offers SetFontFamilyTo{Arial,Courier,Times}, but
+                # SetFontFamily() accepts VTK_UNKNOWN_FONT and VTK_FONT_FILE
+                # too -- the latter is how a custom font_file is selected, and
+                # anything out of range clamps to the former.  Inferring the
+                # map from the SetXToY methods alone therefore rejects values
+                # the C++ object legitimately holds, so update_traits() raises
+                # on every resync.  https://github.com/enthought/mayavi/issues/1391
+                # (see tvtk/WORKAROUNDS.md)
+                if klass.__name__ == "vtkTextProperty" and m == "FontFamily":
+                    d["unknown"] = vtk.VTK_UNKNOWN_FONT
+                    d["file"] = vtk.VTK_FONT_FILE
                 if extra_val is None:
                     t_def = """tvtk_base.RevPrefixMap(%(d)s, default_value='%(default)s')""" % locals()
                 elif hasattr(extra_val, '__iter__'):


### PR DESCRIPTION
`_gen_state_methods()` builds a state trait's set of valid values from the `SetXToY` methods alone, so any value `SetX()` accepts without a matching `SetXToY` is missing from the map.  `vtkTextProperty` is the live case: it has no `SetFontFamilyToFile()`, yet `VTK_FONT_FILE` (4) is how a custom `FontFile` is selected, and out-of-range values clamp to `VTK_UNKNOWN_FONT` (3).  Both were rejected by the trait, so `update_traits()` raised inside a traits notification handler on every resync of a text property that really was set to a font file -- and setting it through tvtk at all was impossible.

Add the two names to the map, as `vtkPoints.DataType` already does for `VTK_ID_TYPE` on Windows.

Closes #1391