### PR TITLE
Fix offscreen rendering

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,6 +76,13 @@ jobs:
       with:
         qt: true
       if: matrix.headless != true
+    # The row above gets libegl1 and libosmesa6 from that action, so the
+    # off screen tests can force each of VTK's backends in turn.  The headless
+    # row skips it and would have no way to make a GL context at all -- which
+    # is the one configuration where EGL/OSMesa is not a fallback but the only
+    # option, so it is the row that most needs them.
+    - run: sudo apt-get update && sudo apt-get install -y libegl1 libosmesa6
+      if: matrix.headless == true
     - uses: actions/setup-python@v7.0.0
       with:
         python-version: ${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@
 .claude/
 _configtest.*
 .hypothesis
+# .coverage.* is the per-process data the off screen tests' subprocesses
+# write, before the parent run combines them
+.coverage
+.coverage.*
 
 # ignore the build directories
 *.egg-info/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,3 +272,27 @@ commit**:
   snake_case aliases only exist on >= 9.4.
 - `mayavi/__init__.py` reads the version from installed package metadata;
   the version itself comes from git tags via setuptools_scm.
+- Never name a concrete render window class (`EGLRenderWindow`,
+  `OSOpenGLRenderWindow`, …).  Construct `tvtk.RenderWindow()` and let
+  `vtkOpenGLRenderWindow::New()` choose: it honours
+  `VTK_DEFAULT_OPENGL_WINDOW`, else tries X11 → EGL → OSMesa and keeps the
+  first that initializes.  `hasattr(tvtk, 'EGLRenderWindow')` used to mean
+  "this is an EGL build of VTK"; the wheels have shipped all three backends
+  for years, so the same test now means "always", and picking EGL where no
+  driver backs it segfaults in `SetDeviceAsDisplay` (gh-1332).  The offscreen
+  paths that had this bug are covered by
+  `mayavi/tests/test_offscreen_rendering.py`, which renders through
+  `mlab.options.offscreen` under each of the three backends in turn (forced
+  with `VTK_DEFAULT_OPENGL_WINDOW`, and asserted in the child's output so a
+  variable VTK ignored cannot pass as coverage), and fakes a driverless EGL
+  with `__EGL_VENDOR_LIBRARY_FILENAMES`.  Those cases are subprocesses: the
+  option is process-global, and a render window that cannot initialize takes
+  its interpreter down with it.  They pass the parent's live coverage config
+  down in `COVERAGE_PROCESS_CONFIG`, which the `.pth` coverage installs turns
+  into a suffixed data file for the parent run to combine — otherwise a
+  `--cov` run reports everything they exercise as never imported.  (The
+  parent still *warns* "was never imported", since it genuinely does not
+  import it; the combined report is what to read.)  That is also what put the first OSMesa render
+  in CI, which is what made it safe to drop `remote_scene.py`'s
+  `ctypes.CDLL("libOSMesa.so", RTLD_GLOBAL)` preload -- a 2017 vtkglew
+  workaround VTK has not needed since well before `MIN_VTK`.

--- a/docs/source/mayavi/tips.rst
+++ b/docs/source/mayavi/tips.rst
@@ -131,10 +131,9 @@ like so::
 
     $ mayavi2 -x script.py -o
 
-This will run the script in an offscreen, standalone window.  On Linux,
-this works best with VTK-5.2 and above.  For more details on the command
-line arguments supported by the ``mayavi2`` application, see the
-:ref:`command-line-arguments` section.
+This will run the script in an offscreen, standalone window.  For more
+details on the command line arguments supported by the ``mayavi2``
+application, see the :ref:`command-line-arguments` section.
 
 When using ``mlab`` you will want to do this::
 
@@ -154,27 +153,24 @@ Please see below on the situation on different platforms.
 Platform Summary
 ~~~~~~~~~~~~~~~~~
 
-* **Windows**: If you are using win32 then off screen rendering should work
-  well out of the box.  All you will need to do is what is given above.
+On all supported platforms off screen rendering should work out of the box,
+provided the machine can create an OpenGL context at all.  A quick check::
 
-* **Linux and the Mac**: there are several options to get this working
-  correctly and some major issues to consider:
+    from mayavi import mlab
+    mlab.options.offscreen = True
+    mlab.test_contour3d()
+    mlab.savefig('example.png')
 
-  If you have VTK-5.2 the offscreen rendering option should let you
-  generate the pictures without worrying about occluding the window.
-  However, you will need VTK-5.2 to get this working properly.  There
-  are also situations when this does not always work -- try it and if
-  you get blank windows, you have a problem.  For example::
+If this produces a clean image -- even if you switch desktops or cover any
+windows produced -- you are all set.
 
-      from mayavi import mlab
-      mlab.options.offscreen = True
-      mlab.test_contour3d()
-      mlab.savefig('example.png')
-
-  If this produces a clean image (even if you switch desktops or cover
-  any windows produced), you should be golden.  If not you should
-  consider either using a virtual framebuffer or building VTK with Mesa
-  + OSMesa to give you a pure software rendering approach.
+On Linux this needs *some* way to get a context: either an X server (a real
+one or a virtual framebuffer, see below), or one of the headless OpenGL
+backends VTK ships with, EGL and OSMesa.  Mayavi does not choose between
+them; it creates a plain render window and lets VTK's own factory pick, which
+means the display is used when there is one and EGL or OSMesa is used when
+there is not.  See :ref:`choosing_the_opengl_backend` if you need to override
+that.
 
 
 
@@ -242,104 +238,35 @@ in a hidden window.
         mlab.options.offscreen = True
 
 
-Using VTK with Mesa for pure software rendering
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. _choosing_the_opengl_backend:
 
-Sometimes you might want to run Mayavi/VTK completely headless on a
-machine with no X server at all and are interested in pure offscreen
-rendering (for example for usage on the Sage_ notebook interface).  In
-these cases one could use Mesa's OSMesa library to render offscreen.
-The downside is that you will not get any hardware acceleration in this
-case.  Here are brief instructions on how to build VTK to do this.
+Choosing the OpenGL backend
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
- * Build a recent version of mesa.  7.0.4 (as of this time) should work
-   as would 7.2.  We assume you download MesaLib-7.0.4.tar.bz2.
+Sometimes you want to run Mayavi/VTK completely headless on a machine with no
+X server at all.  The VTK wheels on PyPI are built with EGL and OSMesa support
+alongside the usual X11 one, so nothing has to be rebuilt for this: set
+``ETS_TOOLKIT='null'`` and ``mlab.options.offscreen = True`` and it will work
+with no display.
 
- * Untar, and change directory to the new directory created. We call
-   this directory ``$MESA`` henceforth.
+VTK decides which of its backends to use, in this order: the one named by the
+``VTK_DEFAULT_OPENGL_WINDOW`` environment variable if it is set, otherwise the
+platform's native window (X11 on Linux), then EGL, then OSMesa, keeping the
+first one that manages to initialize.  Mayavi deliberately does not
+second-guess that, so the same rules apply to off screen scenes as to on
+screen ones.
 
- * Run ``make configs/linux-x86``,  change file as per your
-   configuration. Run ``make`` to see list of options.  Note: 7.2 has a
-   ``./configure`` script that you can run.
+To force a particular backend, set the variable before importing Mayavi::
 
- * Get VTK-5.2 or later (CVS will also work)..
+    $ export VTK_DEFAULT_OPENGL_WINDOW=vtkEGLRenderWindow   # GPU, no X needed
+    $ export VTK_DEFAULT_OPENGL_WINDOW=vtkOSOpenGLRenderWindow  # OSMesa, software
+    $ export VTK_DEFAULT_OPENGL_WINDOW=vtkXOpenGLRenderWindow   # X11
 
- * Run ``ccmake path/to/VTK``.
+EGL is the one to pick for headless rendering on a machine with a GPU; it
+needs a working EGL driver installed, which slim container images often lack
+even when they do have ``libgl1``.  OSMesa renders purely in software, so it
+needs no driver and no display at all, at the cost of speed.
 
-   * Now select advanced options 't'.
-
-   * Set ``VTK_OPENGL_HAS_OSMESA ON``
-
-   * Configure: press 'c'
-
-   * Set the ``OSMESA_INCLUDE_DIR`` to the ``$MESA/include dir``
-
-   * Set ``OSMESA_LIBRARY`` to ``$MESA/lib/libOSMesa.so``
-
-   * Similarly set the ``OPENGL_INCLUDE_DIR``,
-     ``OPENGL_gl_LIBRARY=$MESA/lib/libGL.so``,
-     ``OPENGL_glu_LIBRARY``, and ``OPENGL_xmesa_INCLUDE_DIR``.
-
-   * Set ``VTK_USE_OFFSCREEN`` to ``ON`` if you want offscreen all the
-     time, this will never produce an actual mapped VTK window since the
-     default value of the render window's offscreen rendering ivar will
-     be set to True in this case.
-
-   * Any other settings like ``VTK_USE_GL2PS, USE_RPATH`` etc.
-
-   * Configure again (press 'c') and then generate 'g'.
-
-
-   * Note that if you do not want to use ``ccmake`` and would like to do
-     this from the command line you may also do (for example)::
-
-        cmake \
-        -DVTK_OPENGL_HAS_OSMESA=ON \
-        -DVTK_USE_OFFSCREEN=ON \
-        -DCMAKE_INSTALL_PREFIX=/path/to/vtk-offscreen \
-        -DVTK_WRAP_PYTHON=ON \
-        -DPYTHON_EXECUTABLE=/usr/bin/python2.5 \
-        -DPYTHON_LIBRARY=/usr/lib/libpython2.5.so \
-        -DBUILD_SHARED_LIBS=ON \
-        -DVTK_USE_GL2PS=ON \
-        -DOSMESA_INCLUDE_DIR=/path/to/Mesa-7.2/include/ \
-        -DOSMESA_LIBRARY=/home/path/to/Mesa-7.2/lib64/libOSMesa.so \
-        -DOPENGL_INCLUDE_DIR=/path/to/Mesa-7.2/include \
-        -DOPENGL_gl_LIBRARY=/path/to/Mesa-7.2/lib64/libGL.so \
-        -DOPENGL_glu_LIBRARY=/path/to/Mesa-7.2/lib64/libGLU.so \
-        path/to/VTK/
-
- * Run ``make`` and wait till VTK has built.  Let us say the build is in
-   ``$VTK_BUILD``.
-
- * Now install VTK or set the ``PYTHONPATH`` and ``LD_LIBRARY_PATH``
-   suitably.  Also ensure that ``LD_LIBRARY_PATH`` points to
-   ``$MESA/lib`` (if the mesa libs are not installed on the system) this
-   ensures that VTK links to the right GL libs.  For example::
-
-        $ export PYTHONPATH=$VTK_BUILD/bin:$VTK_BUILD/Wrapping/Python``
-        $ export LD_LIBRARY_PATH=$VTK_BUILD/bin:$MESA/lib
-
-   Now, you should be all set.
-
-Once this is done you should be able to run mlab examples offscreen.
-This will work without an X display even.
-
-With such a VTK built and running, one could simply build and install
-mayavi2.  To use it in a Sage notebook for example you'd want to set
-``ETS_TOOLKIT='null'`` and set ``mlab.options.offscreen = True``.  Thats
-it.  Everything should now work offscreen.
-
-Note that if you set ``VTK_USE_OFFSCREEN`` to ``ON`` then you'll by
-default only get offscreen contexts.  If you do want a UI you will want
-to explicitly set the render window's ``off_screen_rendering`` ivar to
-``False`` to force a mapped window.  For this reason if you might need
-to popup a full UI, it might be better to *not set*
-``VTK_USE_OFFSCREEN=ON``.
-
-
-
-.. _Sage: http://www.sagemath.org
 
 
 

--- a/mayavi/tests/test_offscreen_rendering.py
+++ b/mayavi/tests/test_offscreen_rendering.py
@@ -1,0 +1,196 @@
+"""End to end tests for off screen rendering.
+
+Nothing else in the suite renders through ``mlab.options.offscreen``, which is
+how the off screen branch of ``tvtk_scene._create_control`` came to pick a
+render window that segfaults on arrival without CI ever noticing --
+https://github.com/enthought/mayavi/issues/1332.
+
+Each case gets its own interpreter.  The option is process-global and the
+engine it installs leaks into whatever runs next, and a render window that
+cannot initialize takes the process down with it, which this way costs one
+test rather than the whole run.
+
+"""
+# Copyright (c) Enthought, Inc.
+# License: BSD Style.
+
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+# The backends vtkOpenGLRenderWindow::New() can hand back on Linux, each
+# forced in turn so that none of them is left to whatever the machine running
+# the tests happens to prefer.  OSMesa has no other coverage anywhere, and
+# mayavi carried an OSMesa-specific workaround for years that nothing ever
+# exercised.  Elsewhere there is only the one native window to pick from.
+BACKENDS = [None]
+if sys.platform.startswith('linux'):
+    BACKENDS += ['vtkXOpenGLRenderWindow', 'vtkEGLRenderWindow',
+                 'vtkOSOpenGLRenderWindow']
+
+# What can VTK, on its own, render off screen with here?  If it cannot render
+# at all then neither can mayavi, and that is not a mayavi bug to fail on.
+PROBE = """
+import vtk
+
+renwin = vtk.vtkRenderWindow()
+renwin.SetOffScreenRendering(1)
+renwin.SetSize(50, 50)
+renwin.AddRenderer(vtk.vtkRenderer())
+renwin.Render()
+print(renwin.GetClassName())
+"""
+
+RENDER = """
+import sys
+
+import numpy as np
+from mayavi import mlab
+
+mlab.options.offscreen = True
+figure = mlab.figure(size=(200, 150))
+renwin = figure.scene.render_window
+assert renwin.off_screen_rendering, 'window is on screen'
+print('render_window=%s' % renwin.class_name)
+mlab.test_contour3d()
+image = mlab.screenshot()
+mlab.savefig(sys.argv[1])
+mlab.close(all=True)
+
+colors = np.unique(image.reshape(-1, image.shape[-1]), axis=0)
+assert len(colors) > 1, 'nothing was drawn, the image is a flat %s' % colors
+"""
+
+# Importing this is all it takes to be worth testing: it sets
+# options.offscreen itself, and used to preload OSMesa at import time.
+IMPORT_REMOTE = """
+import mayavi.tools.remote.remote_scene as remote_scene
+
+from mayavi.tools.engine_manager import options
+assert options.offscreen, 'importing remote_scene no longer forces offscreen'
+print('imported=%s' % remote_scene.__name__)
+"""
+
+
+def _backend_env(backend):
+    return None if backend is None else {'VTK_DEFAULT_OPENGL_WINDOW': backend}
+
+
+def _coverage_env():
+    """Have the child record coverage too, when we are running under it.
+
+    coverage ships a ``.pth`` that calls ``process_startup()`` whenever
+    COVERAGE_PROCESS_CONFIG or COVERAGE_PROCESS_START is set, so the child
+    needs nothing from us but the environment.  It writes its own suffixed
+    data file, which the parent run combines.  Without this every module
+    these tests exercise is reported as never imported, since coverage does
+    not follow subprocesses on its own.
+
+    """
+    try:
+        import coverage
+    except ImportError:
+        return {}
+    current = coverage.Coverage.current()
+    if current is None:
+        return {}
+    try:
+        # Hand the child our live config, so it lands in the same data file
+        # under the same source filter.  Preferred over pointing it at
+        # .coveragerc, which does not have whatever ``--cov=`` narrowed the
+        # run to (and which pytest-cov names whether or not it exists).
+        return {'COVERAGE_PROCESS_CONFIG': current.config.serialize()}
+    except AttributeError:  # coverage too old to serialize a config
+        config_file = current.config.config_file
+        if config_file and os.path.exists(config_file):
+            return {'COVERAGE_PROCESS_START': config_file}
+        return {}
+
+
+def _run(source, *args, env=None):
+    """Run `source` in a fresh interpreter, with `env` added to ours."""
+    child_env = dict(os.environ, **_coverage_env())
+    child_env.update(env or {})
+    return subprocess.run(
+        [sys.executable, '-c', textwrap.dedent(source), *args],
+        capture_output=True, text=True, env=child_env,
+    )
+
+
+def _probe(env=None):
+    """The class VTK renders off screen with under `env`; skip if it cannot."""
+    probe = _run(PROBE, env=env)
+    if probe.returncode != 0:
+        pytest.skip(
+            'VTK itself cannot render off screen in this environment:\n'
+            + probe.stderr
+        )
+    return probe.stdout.strip().splitlines()[-1]
+
+
+def _require_backend(backend):
+    """Skip unless VTK really renders off screen on `backend` here."""
+    env = _backend_env(backend)
+    expected = _probe(env)
+    if backend is not None and expected != backend:
+        # VTK_DEFAULT_OPENGL_WINDOW states a preference, not a demand: the
+        # cascade carries on past the backend asked for when that one will
+        # not initialize (X11 with no display, EGL with no driver, ...).
+        pytest.skip(
+            'VTK falls back to %s rather than %s here' % (expected, backend)
+        )
+    return env, expected
+
+
+@pytest.mark.timeout(60)  # a whole interpreter, import and render
+@pytest.mark.parametrize('backend', BACKENDS)
+def test_offscreen_render(tmp_path, backend):
+    env, expected = _require_backend(backend)
+    saved = tmp_path / 'offscreen.png'
+    result = _run(RENDER, str(saved), env=env)
+    assert result.returncode == 0, result.stderr
+    assert saved.stat().st_size > 0
+    # The whole of gh-1332 is mayavi rendering with a window VTK would not
+    # have chosen, so hold it to the class the probe just got.  It also keeps
+    # a VTK that ignored the variable from passing every case off as coverage
+    # of the one default backend.
+    assert 'render_window=%s' % expected in result.stdout
+
+
+@pytest.mark.timeout(60)
+@pytest.mark.parametrize('backend', BACKENDS)
+def test_remote_scene_importable(backend):
+    """``mayavi.tools.remote`` is imported by the notebook widget manager."""
+    env, _ = _require_backend(backend)
+    result = _run(IMPORT_REMOTE, env=env)
+    assert result.returncode == 0, result.stderr
+    assert 'imported=' in result.stdout
+
+
+@pytest.mark.timeout(60)
+@pytest.mark.skipif(
+    not sys.platform.startswith('linux'),
+    reason='__EGL_VENDOR_LIBRARY_FILENAMES is a libglvnd (Linux) knob',
+)
+def test_offscreen_render_without_an_egl_driver(tmp_path):
+    """Off screen rendering must not need EGL when something else will do.
+
+    The wheels ship EGL support everywhere, so the class being importable says
+    nothing about whether there is a driver behind it -- a slim container with
+    ``libgl1`` and an Xvfb display typically has none.  Point libglvnd at a
+    vendor file that does not exist to get the same situation here.
+
+    """
+    env = {
+        '__EGL_VENDOR_LIBRARY_FILENAMES': str(tmp_path / 'no-such-driver.json')
+    }
+    expected = _probe(env)
+    saved = tmp_path / 'offscreen.png'
+    result = _run(RENDER, str(saved), env=env)
+    assert result.returncode == 0, result.stderr
+    assert saved.stat().st_size > 0
+    assert 'render_window=%s' % expected in result.stdout

--- a/mayavi/tools/remote/remote_scene.py
+++ b/mayavi/tools/remote/remote_scene.py
@@ -16,13 +16,6 @@ options.offscreen = True
 EventInfo = namedtuple('EventInfo', ['id', 'name', 'event', 'data'])
 
 
-if hasattr(vtk, 'vtkOSOpenGLRenderWindow'):
-    # Needed for VTK's vtkglew to be able to load the OSMesa.so. See:
-    # https://www.vtk.org/pipermail/vtk-developers/2017-November/035592.html
-    import ctypes
-    osm = ctypes.CDLL("libOSMesa.so", ctypes.RTLD_GLOBAL)
-
-
 class ImageEncoder(HasTraits):
     scene = Any
     w2if = Instance(tvtk.WindowToImageFilter)

--- a/tvtk/pyface/tvtk_scene.py
+++ b/tvtk/pyface/tvtk_scene.py
@@ -740,23 +740,21 @@ class TVTKScene(HasPrivateTraits):
     def _create_control(self, parent):
         """ Create the toolkit-specific control that represents the widget. """
 
+        # Let VTK's factory pick the concrete render window class, offscreen or
+        # not.  vtkOpenGLRenderWindow::New() honours VTK_DEFAULT_OPENGL_WINDOW
+        # and otherwise tries X11, then EGL, then OSMesa, keeping the first one
+        # that initializes -- so a headless machine gets EGL/OSMesa without
+        # being asked, and a machine with a display keeps its GLX context.
+        # Picking EGLRenderWindow here ourselves, as we used to whenever the
+        # class merely existed, segfaulted everywhere the wheel ships EGL
+        # support but the system has no EGL driver to go with it (the usual
+        # slim Docker image under Xvfb).
+        renwin = self._renwin = tvtk.RenderWindow()
         if self.off_screen_rendering:
-            if hasattr(tvtk, 'EGLRenderWindow'):
-                renwin = tvtk.EGLRenderWindow()
-            elif hasattr(tvtk, 'OSOpenGLRenderWindow'):
-                renwin = tvtk.OSOpenGLRenderWindow()
-            else:
-                renwin = tvtk.RenderWindow()
-                # If we are doing offscreen rendering we set the window size to
-                # (1,1) so the window does not appear at all
-                renwin.size = (1, 1)
-
-            self._renwin = renwin
             self._interactor = tvtk.GenericRenderWindowInteractor(
                 render_window=renwin
             )
         else:
-            renwin = self._renwin = tvtk.RenderWindow()
             self._interactor = tvtk.RenderWindowInteractor(
                 render_window=renwin
             )

--- a/tvtk/tests/test_tvtk_scene.py
+++ b/tvtk/tests/test_tvtk_scene.py
@@ -13,9 +13,31 @@ import gc
 from traits.etsconfig.api import ETSConfig
 from tvtk.pyface.tvtk_scene import TVTKScene
 from tvtk.tests.common import restore_gc_state
+from tvtk.vtk_module import vtkRenderWindow
 
 
 class TestTVTKScene(unittest.TestCase):
+
+    @unittest.skipIf(
+        sys.platform.startswith('win') or ETSConfig.toolkit == 'null',
+        'CI with windows fails due to lack of OpenGL, or toolkit is null.'
+    )
+    def test_offscreen_render_window_left_to_vtk(self):
+        # An offscreen scene must use whatever concrete render window VTK's
+        # own factory picks, and no other.  We used to instantiate
+        # EGLRenderWindow whenever the class existed, which since the wheels
+        # started shipping EGL support means always -- and segfaulted on every
+        # machine with no EGL driver behind it.  See
+        # https://github.com/enthought/mayavi/issues/1332
+        scene = TVTKScene(off_screen_rendering=True)
+        try:
+            renwin = scene.render_window
+            self.assertEqual(
+                renwin.class_name, vtkRenderWindow().GetClassName()
+            )
+            self.assertTrue(renwin.off_screen_rendering)
+        finally:
+            scene.close()
 
     @unittest.skipIf(
         sys.platform.startswith('win') or ETSConfig.toolkit == 'null',


### PR DESCRIPTION
Seems like a high-priority thing to fix:

Closes #1332

- `hasattr(tvtk, 'EGLRenderWindow')` meant "this is an EGL build of VTK" in 2018 and means "always" now
- we don't need the workaround for `vtkOSOpenGLRenderWindow` anymore