### PR TITLE
Fix 1194 vtk char signedness

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,11 @@ jobs:
             qt-api: 'pyside6'
             os: ubuntu-latest
             vtk: 'vtk-dev'
+          # Linux arm64: plain C char is unsigned there (unlike x86 and
+          # unlike Apple's arm64 ABI), which is what broke gh-1194
+          - python-version: '3.14'
+            qt-api: 'pyside6'
+            os: ubuntu-24.04-arm
       fail-fast: false
     defaults:
       run:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,10 @@ commit**:
 
 - `tests.yml` — same-version matrix: build + test with the *same* VTK
   (latest on all OSes; older VTK/Python/Qt rows on Linux; one headless row
-  with `ETS_TOOLKIT=null`), plus a `vtk-dev` row against prerelease wheels
+  with `ETS_TOOLKIT=null`; one `ubuntu-24.04-arm` row, because plain C
+  `char` is unsigned on Linux arm64 — but signed in Apple's arm64 ABI, so
+  the macOS rows cannot cover it — which is what gh-1194 tripped over),
+  plus a `vtk-dev` row against prerelease wheels
   from https://wheels.vtk.org and NumPy nightlies from
   https://pypi.anaconda.org/scientific-python-nightly-wheels — that row is
   what `MAX_VTK` is raised on the strength of.  Also runs weekly on a

--- a/tvtk/array_handler.py
+++ b/tvtk/array_handler.py
@@ -41,6 +41,18 @@ elif VTK_LONG_TYPE_SIZE == 8:
     LONG_TYPE_CODE = numpy.int64
     ULONG_TYPE_CODE = numpy.uint64
 
+# VTK_CHAR is plain C ``char``, whose signedness is platform-dependent:
+# signed on x86, unsigned on ARM (e.g. aarch64).  Probe the installed VTK at
+# runtime rather than assuming numpy.int8, and route numpy.int8 data to
+# VTK_SIGNED_CHAR when ``char`` is unsigned, so that negative values
+# round-trip correctly (https://github.com/enthought/mayavi/issues/1194).
+if vtk.vtkCharArray().GetDataTypeMin() < 0:
+    CHAR_TYPE_CODE = numpy.int8
+    INT8_VTK_TYPE = vtkConstants.VTK_CHAR
+else:
+    CHAR_TYPE_CODE = numpy.uint8
+    INT8_VTK_TYPE = vtkConstants.VTK_SIGNED_CHAR
+
 BASE_REFERENCE_COUNT = vtk.vtkObject().GetReferenceCount()
 
 
@@ -179,7 +191,7 @@ def get_vtk_array_type(numeric_array_type):
         numpy.dtype('S'): vtkConstants.VTK_UNSIGNED_CHAR,  # numpy.character
         numpy.dtype(numpy.uint8): vtkConstants.VTK_UNSIGNED_CHAR,
         numpy.dtype(numpy.uint16): vtkConstants.VTK_UNSIGNED_SHORT,
-        numpy.dtype(numpy.int8): vtkConstants.VTK_CHAR,
+        numpy.dtype(numpy.int8): INT8_VTK_TYPE,
         numpy.dtype(numpy.int16): vtkConstants.VTK_SHORT,
         numpy.dtype(numpy.int32): vtkConstants.VTK_INT,
         numpy.dtype(numpy.uint32): vtkConstants.VTK_UNSIGNED_INT,
@@ -213,7 +225,7 @@ def get_vtk_to_numeric_typemap():
     """Returns the VTK array type to numpy array type mapping."""
     _vtk_arr = {
         vtkConstants.VTK_BIT: numpy.bool_,
-        vtkConstants.VTK_CHAR: numpy.int8,
+        vtkConstants.VTK_CHAR: CHAR_TYPE_CODE,
         vtkConstants.VTK_SIGNED_CHAR: numpy.int8,
         vtkConstants.VTK_UNSIGNED_CHAR: numpy.uint8,
         vtkConstants.VTK_SHORT: numpy.int16,

--- a/tvtk/tests/test_array_handler.py
+++ b/tvtk/tests/test_array_handler.py
@@ -182,6 +182,27 @@ class TestArrayHandler(unittest.TestCase):
             array_handler.array2vtk(numpy.zeros((1,),
                                     dtype=numpy.dtype(dtype)))
 
+    def test_char_signedness(self):
+        """int8 must round-trip on either platform char signedness (gh-1194).
+
+        Plain C ``char`` (VTK_CHAR) is signed on x86 but unsigned on ARM,
+        so numpy.int8 must map to a VTK type that is really signed there.
+        """
+        typ = array_handler.get_vtk_array_type(numpy.dtype(numpy.int8))
+        vtk_arr = array_handler.create_vtk_array(typ)
+        self.assertLess(vtk_arr.GetDataTypeMin(), 0)
+        # The reverse map must agree with what VTK says about VTK_CHAR.
+        char_dtype = array_handler.get_numeric_array_type(vtk.VTK_CHAR)
+        signed = vtk.vtkCharArray().GetDataTypeMin() < 0
+        self.assertEqual(char_dtype, numpy.int8 if signed else numpy.uint8)
+        # A native VTK signed char array must convert to int8.
+        vtk_arr = vtk.vtkSignedCharArray()
+        vtk_arr.InsertNextValue(-128)
+        vtk_arr.InsertNextValue(127)
+        arr = array_handler.vtk2array(vtk_arr)
+        self.assertEqual(arr.dtype, numpy.int8)
+        self.assertEqual(list(arr), [-128, 127])
+
     def test_arr2cell_array(self):
         """Test Numeric array to vtkCellArray conversion."""
         # Test list of lists.


### PR DESCRIPTION
This one is pretty simple (in principle) -- triage dtype based on arch. And add a CI run that would have failed without the change.

Closes #1194