### PR TITLE
FIX: Wrap the vtkDataSetAttributes Copy* flags as toggle traits (#1355)

### DIFF
--- a/tvtk/WORKAROUNDS.md
+++ b/tvtk/WORKAROUNDS.md
@@ -58,9 +58,8 @@ from crashing or producing garbage:
   property getters).
 - `_find_get_set_methods()`: per-class/method skips for getters that hang or
   wrap badly (`vtkDataEncoder`/`vtkWebApplication`,
-  `vtkPiecewisePointHandleItem`, the `vtkDataSetAttributes.Copy*` pair on
-  VTK 9.5.2), and version-keyed "broken getter -> no default" entries near
-  the end (grep `Broken in`).
+  `vtkPiecewisePointHandleItem`), and version-keyed "broken getter -> no
+  default" entries near the end (grep `Broken in`).
 - `BROKEN_GETTERS` (module level): getters whose VTK-documented precondition
   a fresh object violates, so probing them aborts an assertion-enabled build.
   Version-independent — see the Policy note above before retiring one.

--- a/tvtk/tests/test_tvtk.py
+++ b/tvtk/tests/test_tvtk.py
@@ -421,6 +421,29 @@ class TestTVTK(unittest.TestCase):
         # If this does not segfault, we are OK.
         mesh.point_data.scalars = sc
 
+    def test_data_set_attributes_copy_toggles(self):
+        """The Copy* flags wrap as toggle traits and resync cleanly.
+
+        Regression test for enthought/mayavi#1355: the copy_* traits were
+        skipped at generation, so touching one raised "Cannot set the
+        undefined 'copy_scalars' attribute of a 'CellData' object", and the
+        resync after any Modified event raised the same for copy_global_ids.
+        """
+        mesh = tvtk.PolyData()
+        cd = mesh.cell_data
+        for name in ('scalars', 'vectors', 'normals', 'tensors', 't_coords',
+                     'global_ids', 'pedigree_ids', 'tangents'):
+            trait = 'copy_' + name
+            cd.trait_set(**{trait: False})
+            self.assertEqual(getattr(cd, trait + '_'), 0)
+            cd.trait_set(**{trait: True})
+            self.assertEqual(getattr(cd, trait + '_'), 1)
+        # A Modified event resyncs every trait from VTK; this used to raise
+        # inside the notification handler.
+        cd.scalars = tvtk.FloatArray()
+        cd.copy_scalars = False
+        self.assertEqual(cd._vtk_obj.GetCopyScalars(), 0)
+
     def test_data_array(self):
         """Test if vtkDataArrays behave in a Pythonic fashion."""
         # Check a 3D array.

--- a/tvtk/tests/test_tvtk.py
+++ b/tvtk/tests/test_tvtk.py
@@ -442,7 +442,7 @@ class TestTVTK(unittest.TestCase):
         # inside the notification handler.
         cd.scalars = tvtk.FloatArray()
         cd.copy_scalars = False
-        self.assertEqual(cd._vtk_obj.GetCopyScalars(), 0)
+        self.assertEqual(tvtk.to_vtk(cd).GetCopyScalars(), 0)
 
     def test_data_array(self):
         """Test if vtkDataArrays behave in a Pythonic fashion."""

--- a/tvtk/vtk_parser.py
+++ b/tvtk/vtk_parser.py
@@ -541,18 +541,9 @@ class VTKMethodParser:
         """
         meths = methods[:]
         tm = self.toggle_meths
-        klass_name = klass.__name__
-        # These wrap badly as On/Off toggles (see tvtk/WORKAROUNDS.md)
-        problem_methods = ['CopyVectors', 'CopyTensors',
-                           'CopyTCoords', 'CopyScalars',
-                           'CopyNormals', 'CopyGlobalIds',
-                           'CopyPedigreeIds']
         for method in meths[:]:
-            if klass_name == 'vtkDataSetAttributes' and \
-               method[:-2] in problem_methods:
-                continue
             # (see tvtk/WORKAROUNDS.md)
-            elif method[:-2] == 'AlphaBitPlanes':
+            if method[:-2] == 'AlphaBitPlanes':
                 continue
             if method[-2:] == 'On':
                 key = method[:-2]
@@ -680,11 +671,6 @@ class VTKMethodParser:
             # These hang on Windows (and maybe Fedora 34)
             # (see tvtk/WORKAROUNDS.md)
             elif (klass_name in ('vtkDataEncoder', 'vtkWebApplication')):
-                continue
-            # On VTK 9.5.2 we get
-            # Cannot set the undefined 'copy_global_ids' attribute of a 'PointData' object
-            # (see tvtk/WORKAROUNDS.md)
-            elif (klass_name == "vtkDataSetAttributes" and method[3:] in ("CopyGlobalIds", "CopyNormals", "CopyPedigreeIds", "CopyScalars", "CopyTCoords", "CopyTensors", "CopyVectors")):
                 continue
             elif ('Get' + method[3:]) in methods:
                 key = method[3:]


### PR DESCRIPTION
- a pre-2011 blocklist in `VTKMethodParser._find_toggle_methods` kept `CopyScalars/Vectors/Normals/Tensors/TCoords/GlobalIds/PedigreeIds` from wrapping as On/Off toggles ("wrap badly", reason lost to history);
- the VTK 9.5 support work (#1364) then also skipped their Get/Set pair in _find_get_set_methods to silence the resulting update_traits() crash, which deleted the traits outright.

This `blocklist` is obsolete.  Remove both skips so all eleven Copy* flags wrap properly. Tested on 9.6.2, on VTK 9.4.x with the 9.6.2 wheel, and on 9.4.x with a 9.4.x-generated wheel.

Closes #1355