### PR TITLE
Fix 1276 qt5 wheel zoom

### DIFF
--- a/mayavi/tests/test_no_ui_toolkit.py
+++ b/mayavi/tests/test_no_ui_toolkit.py
@@ -30,20 +30,20 @@ class TestNoUIToolkit(unittest.TestCase):
 
         # Remove any references to wx and Qt
         saved = {}
-        for mod in ['wx', 'PyQt4', 'PySide']:
+        for mod in ['wx', 'PyQt5', 'PySide2', 'PyQt6', 'PySide6']:
             saved[mod] = sys.modules.pop(mod, None)
         self.saved = saved
 
     def tearDown(self):
         ETSConfig._toolkit = self.orig_tk
         # Add back any any references to wx and Qt
-        for mod in ['wx', 'PyQt4', 'PySide']:
+        for mod in ['wx', 'PyQt5', 'PySide2', 'PyQt6', 'PySide6']:
             m = self.saved[mod]
             if m is not None:
                 sys.modules[mod] = m
 
     def test_no_ui(self):
-        """Test if mayavi imports work without any UI (wx or PyQt4)."""
+        """Test if mayavi imports work without any UI (wx or Qt)."""
         # These imports should work without any UI.
         from mayavi import mlab
         from mayavi.api import Engine
@@ -52,10 +52,9 @@ class TestNoUIToolkit(unittest.TestCase):
         from mayavi.modules.api import Outline
         from mayavi.preferences.api import preference_manager
 
-        # Should not have triggered an import wx or PyQt4.
-        self.assertEqual('wx' in sys.modules, False)
-        self.assertEqual('PyQt4' in sys.modules, False)
-        self.assertEqual('PySide' in sys.modules, False)
+        # Should not have triggered an import of wx or any Qt binding.
+        for mod in ['wx', 'PyQt5', 'PySide2', 'PyQt6', 'PySide6']:
+            self.assertEqual(mod in sys.modules, False, mod)
 
 
 if __name__ == '__main__':

--- a/tvtk/pyface/ui/qt4/QVTKRenderWindowInteractor.py
+++ b/tvtk/pyface/ui/qt4/QVTKRenderWindowInteractor.py
@@ -546,52 +546,43 @@ class QVTKRenderWindowInteractor(QVTKRWIBaseClass):
                                   ctrl, shift, chr(0), 0, None)
         self._Iren.MouseMoveEvent()
 
-    def keyPressEvent(self, ev):
-        """ React to key pressed event.
+    def _GetKeyCharAndKeySym(self, ev):
+        """ Convert a Qt key into a char and a vtk keysym.
 
-        If event text contains multiple characters, it is truncated to first
-        one.
+        This is essentially copied from the c++ implementation in
+        GUISupport/Qt/QVTKInteractorAdapter.cxx.
         """
+        # if there is a char, convert its ASCII code to a VTK keysym
+        try:
+            keyChar = ev.text()[0]
+            keySym = _keysyms_for_ascii[ord(keyChar)]
+        except IndexError:
+            keyChar = '\0'
+            keySym = None
+
+        # next, try converting Qt key code to a VTK keysym
+        if keySym is None:
+            keySym = _keysyms.get(ev.key())
+
+        # use "None" as a fallback
+        if keySym is None:
+            keySym = "None"
+
+        return keyChar, keySym
+
+    def keyPressEvent(self, ev):
+        key, keySym = self._GetKeyCharAndKeySym(ev)
         ctrl, shift = self._GetCtrlShift(ev)
-        key_sym = _qt_key_to_key_sym(ev.key())
-        if ev.key() < 256:
-            # Sometimes, the OS allows a chord (e.g. Alt-T) to generate
-            # a Unicode character outside of the 8-bit Latin-1 range. We will
-            # try to pass along Latin-1 characters unchanged, since VTK expects
-            # a single `char` byte. If not, we will try to pass on the root key
-            # of the chord (e.g. 'T' above).
-            if ev.text() and ev.text() <= u'\u00ff':
-                key = ev.text().encode('latin-1')
-            else:
-                # Has modifiers, but an ASCII key code.
-                key = chr(ev.key())
-        else:
-            key = chr(0)
-
-        # Truncating key pressed to first character if slow machine leads to
-        # multiple times the same key (required by SetEventInformationFlipY):
-        if ev.isAutoRepeat():
-            key = key[0]
-
         self._setEventInformation(self.__saveX, self.__saveY,
-                                  ctrl, shift, key, 0, key_sym)
+                                  ctrl, shift, key, 0, keySym)
         self._Iren.KeyPressEvent()
         self._Iren.CharEvent()
 
     def keyReleaseEvent(self, ev):
+        key, keySym = self._GetKeyCharAndKeySym(ev)
         ctrl, shift = self._GetCtrlShift(ev)
-        key_sym = _qt_key_to_key_sym(ev.key())
-        if ev.key() < 256:
-            if ev.text() and ev.text() <= u'\u00ff':
-                key = ev.text().encode('latin-1')
-            else:
-                # Has modifiers, but an ASCII key code.
-                key = chr(ev.key())
-        else:
-            key = chr(0)
-
         self._setEventInformation(self.__saveX, self.__saveY,
-                                  ctrl, shift, key, 0, key_sym)
+                                  ctrl, shift, key, 0, keySym)
         self._Iren.KeyReleaseEvent()
 
     def wheelEvent(self, ev):
@@ -650,11 +641,33 @@ def QVTKRenderWidgetConeExample():
     app.exec_()
 
 
+_keysyms_for_ascii = (
+    None, None, None, None, None, None, None, None,
+    None, "Tab", None, None, None, None, None, None,
+    None, None, None, None, None, None, None, None,
+    None, None, None, None, None, None, None, None,
+    "space", "exclam", "quotedbl", "numbersign",
+    "dollar", "percent", "ampersand", "quoteright",
+    "parenleft", "parenright", "asterisk", "plus",
+    "comma", "minus", "period", "slash",
+    "0", "1", "2", "3", "4", "5", "6", "7",
+    "8", "9", "colon", "semicolon", "less", "equal", "greater", "question",
+    "at", "A", "B", "C", "D", "E", "F", "G",
+    "H", "I", "J", "K", "L", "M", "N", "O",
+    "P", "Q", "R", "S", "T", "U", "V", "W",
+    "X", "Y", "Z", "bracketleft",
+    "backslash", "bracketright", "asciicircum", "underscore",
+    "quoteleft", "a", "b", "c", "d", "e", "f", "g",
+    "h", "i", "j", "k", "l", "m", "n", "o",
+    "p", "q", "r", "s", "t", "u", "v", "w",
+    "x", "y", "z", "braceleft", "bar", "braceright", "asciitilde", "Delete",
+    )
+
 _keysyms = {
     Key.Key_Backspace: 'BackSpace',
     Key.Key_Tab: 'Tab',
     Key.Key_Backtab: 'Tab',
-    # Key.Key_Clear : 'Clear',
+    Key.Key_Clear : 'Clear',
     Key.Key_Return: 'Return',
     Key.Key_Enter: 'Return',
     Key.Key_Shift: 'Shift_L',
@@ -664,14 +677,16 @@ _keysyms = {
     Key.Key_CapsLock: 'Caps_Lock',
     Key.Key_Escape: 'Escape',
     Key.Key_Space: 'space',
-    # Key.Key_Prior : 'Prior',
-    # Key.Key_Next : 'Next',
+    Key.Key_PageUp: 'Prior',
+    Key.Key_PageDown: 'Next',
     Key.Key_End: 'End',
     Key.Key_Home: 'Home',
     Key.Key_Left: 'Left',
     Key.Key_Up: 'Up',
     Key.Key_Right: 'Right',
     Key.Key_Down: 'Down',
+    Key.Key_Select: 'Select',
+    Key.Key_Execute: 'Execute',
     Key.Key_SysReq: 'Snapshot',
     Key.Key_Insert: 'Insert',
     Key.Key_Delete: 'Delete',
@@ -714,6 +729,7 @@ _keysyms = {
     Key.Key_Z: 'z',
     Key.Key_Asterisk: 'asterisk',
     Key.Key_Plus: 'plus',
+    Key.Key_Bar: 'bar',
     Key.Key_Minus: 'minus',
     Key.Key_Period: 'period',
     Key.Key_Slash: 'slash',
@@ -744,19 +760,6 @@ _keysyms = {
     Key.Key_NumLock: 'Num_Lock',
     Key.Key_ScrollLock: 'Scroll_Lock',
     }
-
-
-def _qt_key_to_key_sym(key):
-    """ Convert a Qt key into a vtk keysym.
-
-    This is essentially copied from the c++ implementation in
-    GUISupport/Qt/QVTKInteractorAdapter.cxx.
-    """
-
-    if key not in _keysyms:
-        return 'None'
-
-    return _keysyms[key]
 
 
 if __name__ == "__main__":

--- a/tvtk/pyface/ui/qt4/QVTKRenderWindowInteractor.py
+++ b/tvtk/pyface/ui/qt4/QVTKRenderWindowInteractor.py
@@ -42,10 +42,8 @@ Changes by Fabian Wenzel, Jan. 2016
 
 import sys
 
-from pyface.qt import QtCore, qt_api, is_qt4
-if qt_api == 'pyqt':
-    PyQtImpl = "PyQt4"
-elif qt_api == 'pyqt5':
+from pyface.qt import QtCore, qt_api
+if qt_api == 'pyqt5':
     PyQtImpl = "PyQt5"
 elif qt_api == 'pyqt6':
     PyQtImpl = "PyQt6"
@@ -54,7 +52,9 @@ elif qt_api == 'pyside2':
 elif qt_api == 'pyside6':
     PyQtImpl = "PySide6"
 else:
-    PyQtImpl = "PySide"
+    raise ImportError(
+        "Unsupported Qt binding %r: PyQt5, PyQt6, PySide2 and PySide6 "
+        "are supported" % (qt_api,))
 
 import vtk
 
@@ -73,7 +73,7 @@ except (ImportError, AttributeError):
 if QVTKRWIBase != "QWidget":
     if PyQtImpl in ["PySide6", "PyQt6"] and QVTKRWIBase == "QOpenGLWidget":
         pass  # compatible
-    elif PyQtImpl in ["PyQt5", "PySide2","PyQt4", "PySide"] and QVTKRWIBase == "QGLWidget":
+    elif PyQtImpl in ["PyQt5", "PySide2"] and QVTKRWIBase == "QGLWidget":
         pass  # compatible
     else:
         raise ImportError("Cannot load " + QVTKRWIBase + " from " + PyQtImpl)
@@ -130,30 +130,6 @@ elif PyQtImpl == "PySide2":
     from PySide2.QtCore import QObject
     from PySide2.QtCore import QSize
     from PySide2.QtCore import QEvent
-elif PyQtImpl == "PyQt4":
-    if QVTKRWIBase == "QGLWidget":
-        from PyQt4.QtOpenGL import QGLWidget
-    from PyQt4.QtGui import QWidget
-    from PyQt4.QtGui import QSizePolicy
-    from PyQt4.QtGui import QApplication
-    from PyQt4.QtGui import QMainWindow
-    from PyQt4.QtCore import Qt
-    from PyQt4.QtCore import QTimer
-    from PyQt4.QtCore import QObject
-    from PyQt4.QtCore import QSize
-    from PyQt4.QtCore import QEvent
-elif PyQtImpl == "PySide":
-    if QVTKRWIBase == "QGLWidget":
-        from PySide.QtOpenGL import QGLWidget
-    from PySide.QtGui import QWidget
-    from PySide.QtGui import QSizePolicy
-    from PySide.QtGui import QApplication
-    from PySide.QtGui import QMainWindow
-    from PySide.QtCore import Qt
-    from PySide.QtCore import QTimer
-    from PySide.QtCore import QObject
-    from PySide.QtCore import QSize
-    from PySide.QtCore import QEvent
 else:
     raise ImportError("Unknown PyQt implementation " + repr(PyQtImpl))
 
@@ -190,10 +166,7 @@ else:
     SizePolicy = QSizePolicy
     EventType = QEvent
 
-if PyQtImpl in ('PyQt4', 'PySide'):
-    MiddleButton = MouseButton.MidButton
-else:
-    MiddleButton = MouseButton.MiddleButton
+MiddleButton = MouseButton.MiddleButton
 
 
 def _get_event_pos(ev):
@@ -374,15 +347,6 @@ class QVTKRenderWindowInteractor(QVTKRWIBaseClass):
 
         self._Timer = QTimer(self)
         self._Timer.timeout.connect(self.TimerEvent)
-
-        # add wheel timer to fix scrolling issue with trackpad
-        self.wheel_timer = None
-        if is_qt4:
-            self.wheel_timer = QTimer()
-            self.wheel_timer.setSingleShot(True)
-            self.wheel_timer.setInterval(25)
-            self.wheel_timer.timeout.connect(self._emit_wheel_event)
-            self._saved_wheel_event_info = ()
 
         self._Iren.AddObserver('CreateTimerEvent', messenger.send)
         messenger.connect(self._Iren, 'CreateTimerEvent', self.CreateTimer)
@@ -631,45 +595,19 @@ class QVTKRenderWindowInteractor(QVTKRWIBaseClass):
         self._Iren.KeyReleaseEvent()
 
     def wheelEvent(self, ev):
-        """ Reimplemented to work around scrolling bug in Mac.
+        """ Reimplemented to accumulate trackpad scrolling.
 
-        Work around https://bugreports.qt-project.org/browse/QTBUG-22269.
-        Accumulate wheel events that are within a period of 25ms into a single
-        event.  Changes in buttons or modifiers, while a scroll is going on,
-        are not handled, since they seem to be too much of a corner case to be
-        worth handling.
+        Trackpads report a stream of small angle deltas rather than whole
+        notches (https://bugreports.qt-project.org/browse/QTBUG-22269), so
+        accumulate them and emit one VTK wheel event per accumulated notch.
         """
-        if hasattr(ev, 'delta'):
-            self.__wheelDelta += ev.delta()
-            self._saved_wheel_event_info = (
-                ev.pos(),
-                ev.globalPos(),
-                self.__wheelDelta,
-                ev.buttons(),
-                ev.modifiers(),
-                ev.orientation()
-            )
-        else:
-            self.__wheelDelta += ev.angleDelta().y()
-            if self.__wheelDelta >= 60:
-                self._Iren.MouseWheelForwardEvent()
-                self.__wheelDelta = 0
-            elif self.__wheelDelta <= -60:
-                self._Iren.MouseWheelBackwardEvent()
-                self.__wheelDelta = 0
-
-        if self.wheel_timer and not self.wheel_timer.isActive():
-            ev.setAccepted(True)
-            self.wheel_timer.start()
-
-    def _emit_wheel_event(self):
-        ev = QWheelEvent(*self._saved_wheel_event_info)
-        if ev.delta() >= 0:
+        self.__wheelDelta += ev.angleDelta().y()
+        if self.__wheelDelta >= 60:
             self._Iren.MouseWheelForwardEvent()
-        else:
+            self.__wheelDelta = 0
+        elif self.__wheelDelta <= -60:
             self._Iren.MouseWheelBackwardEvent()
-        self.wheel_timer.stop()
-        self.__wheelDelta = 0
+            self.__wheelDelta = 0
 
     def GetRenderWindow(self):
         return self._RenderWindow

--- a/tvtk/tests/test_qvtk_render_window_interactor.py
+++ b/tvtk/tests/test_qvtk_render_window_interactor.py
@@ -2,12 +2,13 @@ import unittest
 
 try:
     from tvtk.pyface.ui.qt4.QVTKRenderWindowInteractor import (
+        QVTKRenderWindowInteractor,
         _repaint_after_render,
     )
 except (ImportError, RuntimeError):
     # No binding installed (ImportError) or QT_API set but empty/invalid, as on
     # the headless CI row (RuntimeError) -- both mean "no Qt here".
-    _repaint_after_render = None
+    QVTKRenderWindowInteractor = _repaint_after_render = None
 
 
 @unittest.skipIf(_repaint_after_render is None, 'Qt is not available.')
@@ -30,6 +31,57 @@ class TestRepaintAfterRender(unittest.TestCase):
 
     def test_unparseable_version_unaffected(self):
         self.assertTrue(self.f('darwin', 'not.a.version'))
+
+
+class _FakeAngleDelta:
+    def __init__(self, y):
+        self._y = y
+
+    def y(self):
+        return self._y
+
+
+class _FakeWheelEvent:
+    """Duck-typed QWheelEvent; Qt 5's also carries the deprecated delta()."""
+
+    def __init__(self, y, with_delta=False):
+        self._y = y
+        if with_delta:
+            self.delta = lambda: self._y
+
+    def angleDelta(self):
+        return _FakeAngleDelta(self._y)
+
+
+@unittest.skipIf(QVTKRenderWindowInteractor is None, 'Qt is not available.')
+class TestWheelEvent(unittest.TestCase):
+    def test_wheel_events_reach_vtk(self):
+        """Wheel events must reach VTK on Qt 5 and Qt 6 alike (gh-1276).
+
+        Qt 5 wheel events still carry the deprecated delta() alongside
+        angleDelta(), which used to divert them onto a legacy path whose
+        coalescing timer was only ever created under Qt 4 -- so wheel
+        zooming silently did nothing on PyQt5/PySide2.
+        """
+        from pyface.qt.QtGui import QApplication
+        app = QApplication.instance() or QApplication([])  # noqa: F841
+        w = QVTKRenderWindowInteractor()
+        try:
+            w._Iren.Enable()
+            events = []
+            w._Iren.AddObserver('MouseWheelForwardEvent',
+                                lambda o, e: events.append('+'))
+            w._Iren.AddObserver('MouseWheelBackwardEvent',
+                                lambda o, e: events.append('-'))
+            w.wheelEvent(_FakeWheelEvent(120, with_delta=True))  # Qt 5 notch
+            w.wheelEvent(_FakeWheelEvent(-120, with_delta=True))
+            w.wheelEvent(_FakeWheelEvent(30))   # Qt 6 trackpad partials...
+            w.wheelEvent(_FakeWheelEvent(30))   # ...accumulate to a notch
+            w.wheelEvent(_FakeWheelEvent(-20))  # never reaches a notch
+            self.assertEqual(events, ['+', '-', '+'])
+        finally:
+            w.close()
+            w.deleteLater()
 
 
 if __name__ == '__main__':

--- a/tvtk/tests/test_qvtk_render_window_interactor.py
+++ b/tvtk/tests/test_qvtk_render_window_interactor.py
@@ -84,5 +84,45 @@ class TestWheelEvent(unittest.TestCase):
             w.deleteLater()
 
 
+class _FakeKeyEvent:
+    def __init__(self, text, key=0):
+        self._text = text
+        self._key = key
+
+    def text(self):
+        return self._text
+
+    def key(self):
+        return self._key
+
+
+@unittest.skipIf(QVTKRenderWindowInteractor is None, 'Qt is not available.')
+class TestKeySyms(unittest.TestCase):
+    def test_key_char_and_keysym(self):
+        """Chars and non-printing keys must map to VTK keysyms."""
+        from pyface.qt.QtCore import Qt
+        from pyface.qt.QtGui import QApplication
+        app = QApplication.instance() or QApplication([])  # noqa: F841
+        w = QVTKRenderWindowInteractor()
+        try:
+            f = w._GetKeyCharAndKeySym
+            self.assertEqual(f(_FakeKeyEvent('r')), ('r', 'r'))
+            self.assertEqual(f(_FakeKeyEvent('+')), ('+', 'plus'))
+            self.assertEqual(f(_FakeKeyEvent('?')), ('?', 'question'))
+            # Non-printing keys have no text and map through the key code;
+            # Prior/Next were dropped from the map for years.
+            self.assertEqual(f(_FakeKeyEvent('', Qt.Key_PageUp)),
+                             ('\0', 'Prior'))
+            self.assertEqual(f(_FakeKeyEvent('', Qt.Key_PageDown)),
+                             ('\0', 'Next'))
+            self.assertEqual(f(_FakeKeyEvent('', Qt.Key_Left)),
+                             ('\0', 'Left'))
+            self.assertEqual(f(_FakeKeyEvent('', Qt.Key_Meta)),
+                             ('\0', 'None'))
+        finally:
+            w.close()
+            w.deleteLater()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tvtk/tests/test_qvtk_render_window_interactor.py
+++ b/tvtk/tests/test_qvtk_render_window_interactor.py
@@ -2,13 +2,14 @@ import unittest
 
 try:
     from tvtk.pyface.ui.qt4.QVTKRenderWindowInteractor import (
+        Key,
         QVTKRenderWindowInteractor,
         _repaint_after_render,
     )
 except (ImportError, RuntimeError):
     # No binding installed (ImportError) or QT_API set but empty/invalid, as on
     # the headless CI row (RuntimeError) -- both mean "no Qt here".
-    QVTKRenderWindowInteractor = _repaint_after_render = None
+    Key = QVTKRenderWindowInteractor = _repaint_after_render = None
 
 
 @unittest.skipIf(_repaint_after_render is None, 'Qt is not available.')
@@ -100,7 +101,8 @@ class _FakeKeyEvent:
 class TestKeySyms(unittest.TestCase):
     def test_key_char_and_keysym(self):
         """Chars and non-printing keys must map to VTK keysyms."""
-        from pyface.qt.QtCore import Qt
+        # Use the module's Key alias: PyQt6 only has the scoped enum
+        # (Qt.Key.Key_PageUp), flat Qt.Key_PageUp is an AttributeError there.
         from pyface.qt.QtGui import QApplication
         app = QApplication.instance() or QApplication([])  # noqa: F841
         w = QVTKRenderWindowInteractor()
@@ -111,13 +113,13 @@ class TestKeySyms(unittest.TestCase):
             self.assertEqual(f(_FakeKeyEvent('?')), ('?', 'question'))
             # Non-printing keys have no text and map through the key code;
             # Prior/Next were dropped from the map for years.
-            self.assertEqual(f(_FakeKeyEvent('', Qt.Key_PageUp)),
+            self.assertEqual(f(_FakeKeyEvent('', Key.Key_PageUp)),
                              ('\0', 'Prior'))
-            self.assertEqual(f(_FakeKeyEvent('', Qt.Key_PageDown)),
+            self.assertEqual(f(_FakeKeyEvent('', Key.Key_PageDown)),
                              ('\0', 'Next'))
-            self.assertEqual(f(_FakeKeyEvent('', Qt.Key_Left)),
+            self.assertEqual(f(_FakeKeyEvent('', Key.Key_Left)),
                              ('\0', 'Left'))
-            self.assertEqual(f(_FakeKeyEvent('', Qt.Key_Meta)),
+            self.assertEqual(f(_FakeKeyEvent('', Key.Key_Meta)),
                              ('\0', 'None'))
         finally:
             w.close()


### PR DESCRIPTION
Closes #1276 

Drop PyQt4 and PySide support, continue supporting PyQt5 and PySide2 (maybe last release for those two?). Pull in upstream fixes from VTK gitlab. Fix the aforementioned issue.