### PR TITLE
FIX: Tolerate pyface with no usable toolkit in the UI helpers

### DIFF
--- a/mayavi/core/common.py
+++ b/mayavi/core/common.py
@@ -38,11 +38,30 @@ def debug(msg):
     logger.debug(msg)
 
 
+def _has_ui():
+    """Whether pyface found a usable GUI toolkit.
+
+    A successful pyface import is not enough: in an environment with no
+    (working) toolkit, pyface resolves GUI to an ``Unimplemented`` stub and
+    the dialog helpers to the null backend's placeholders, and touching
+    either raises -- which took down even the offscreen path, where no UI
+    is wanted in the first place (see enthought/mayavi#1308).
+    """
+    if pyface is None:
+        return False
+    try:
+        return getattr(pyface.GUI, 'process_events', None) is not None
+    except Exception:
+        # resolving the toolkit itself can raise on broken installs; that
+        # must not mask the error currently being reported
+        return False
+
+
 def warning(msg, parent=None):
     """Handle a warning message.
     """
-    logger.warn(msg)
-    if pyface is not None:
+    logger.warning(msg)
+    if _has_ui():
         pyface.warning(parent, msg)
 
 
@@ -50,7 +69,7 @@ def error(msg, parent=None):
     """Handle an error message.
     """
     logger.error(msg)
-    if pyface is not None:
+    if _has_ui():
         pyface.error(parent, msg)
 
 
@@ -71,7 +90,7 @@ def exception(msg='Exception', parent=None):
                    function)
         # Log and display the message.
         logger.exception(msg)
-        if pyface is not None:
+        if _has_ui():
             pyface.error(parent, exc_msg, title='Exception')
     finally:
         type = value = tb = None # clean up
@@ -83,7 +102,7 @@ def process_ui_events():
     This function merely abstracts the function so nothing is done when
     no UI is running.
     """
-    if pyface is not None:
+    if _has_ui():
         pyface.GUI.process_events()
 
 

--- a/mayavi/plugins/mayavi_ui_plugin.py
+++ b/mayavi/plugins/mayavi_ui_plugin.py
@@ -195,8 +195,8 @@ To use Mayavi, you need to load your data in "data sources" and apply "visualiza
         id = SHELL_VIEW
         py = window.get_view_by_id(id)
         if py is None:
-            logger.warn('*'*80)
-            logger.warn("Can't find the Python shell view to bind variables")
+            logger.warning('*'*80)
+            logger.warning("Can't find the Python shell view to bind variables")
             return
 
         # Bind the script and engine instances to names on the
@@ -214,5 +214,5 @@ To use Mayavi, you need to load your data in "data sources" and apply "visualiza
         except AttributeError as msg:
             # This can happen when the shell is not visible.
             # FIXME: fix this when the shell plugin is improved.
-            logger.warn(msg)
-            logger.warn("Can't find the Python shell to bind variables")
+            logger.warning(msg)
+            logger.warning("Can't find the Python shell to bind variables")

--- a/mayavi/tests/test_core_common.py
+++ b/mayavi/tests/test_core_common.py
@@ -68,6 +68,86 @@ def test_core_common_pyface_import_honors_env_var():
     assert result == 'None'
 
 
+def test_no_usable_toolkit_degrades_to_logging():
+    # pyface importable but no toolkit: GUI resolves to an Unimplemented
+    # stub and the UI helpers must degrade to logging instead of raising
+    # (gh-1308).  Blocking the bindings needs a fresh process.
+    code = '\n'.join([
+        "import sys, os",
+        "for mod in ('PySide6', 'PyQt6', 'PyQt5', 'PySide2', 'wx'):",
+        "    sys.modules[mod] = None  # force ImportError",
+        "from mayavi.core import common",
+        "assert common.pyface is not None",
+        "assert not common._has_ui()",
+        "common.process_ui_events()",
+        "common.warning('w')",
+        "common.error('e')",
+        "try:",
+        "    raise RuntimeError('boom')",
+        "except RuntimeError:",
+        "    common.exception('handled')",
+        "print('OK')",
+    ])
+    env = dict(os.environ)
+    env.pop('ETS_TOOLKIT', None)
+    env.pop('CI', None)
+    out = check_output([sys.executable, '-c', code], env=env)
+    assert out.strip().decode('utf-8').endswith('OK')
+
+
+class TestNoUsableToolkitGuards(unittest.TestCase):
+    """In-process checks of the gh-1308 guards against a stubbed pyface."""
+
+    def setUp(self):
+        from mayavi.core import common
+        self.common = common
+        self._pyface = common.pyface
+        self._reraise = common.reraise_exceptions
+
+        class Unimplemented:  # what pyface resolves GUI to with no toolkit
+            pass
+
+        class FakePyface:
+            GUI = Unimplemented
+
+            @staticmethod
+            def warning(parent, msg):
+                raise NotImplementedError()
+
+            @staticmethod
+            def error(parent, msg, title=None):
+                raise NotImplementedError()
+
+        common.pyface = FakePyface
+        common.reraise_exceptions = False
+
+    def tearDown(self):
+        self.common.pyface = self._pyface
+        self.common.reraise_exceptions = self._reraise
+
+    def test_process_ui_events_does_not_raise(self):
+        self.common.process_ui_events()
+
+    def test_message_helpers_do_not_raise(self):
+        self.common.warning('w')
+        self.common.error('e')
+        try:
+            raise RuntimeError('boom')
+        except RuntimeError:
+            self.common.exception('handled')
+
+    def test_has_ui_tolerates_raising_gui_attribute(self):
+        # resolving the toolkit itself raises on broken installs (the
+        # KeyError 'pyface.toolkits' family) -- _has_ui must not propagate
+        class RaisingPyface:
+            @property
+            def GUI(self):
+                raise KeyError('pyface.toolkits')
+
+        self.common.pyface = RaisingPyface()
+        self.assertFalse(self.common._has_ui())
+
+
 class TestCoreCommon(unittest.TestCase):
     def setUp(self):
         e = NullEngine()


### PR DESCRIPTION
In an env where `pyface` imports but no GUI toolkit is usable, `pyface` resolves GUI to an ``Unimplemented`` stub and the dialog helpers to null-backend placeholders, so `process_ui_events()` raises an error.

This adds a `_has_ui()` probe to deal with this.  With this and #1399, the full offscreen pipeline (figure/plot/savefig) works headless with every Qt binding uninstalled.

(Also replace deprecated `logger.warn` with `logger.warning`.)

Closes #1308 