### PR TITLE
Fix mapped trait revert

### DIFF
--- a/tvtk/tests/test_tvtk.py
+++ b/tvtk/tests/test_tvtk.py
@@ -209,6 +209,42 @@ class TestTVTK(unittest.TestCase):
         tp.font_family = 0  # vtk.VTK_ARIAL
         self.assertEqual(tp_obj.GetFontFamily(), vtk.VTK_ARIAL)
 
+    def test_mapped_trait_set_survives_reentrant_update(self):
+        """A dynamic shadow-trait listener must find VTK already synced.
+
+        mayavi renders from a dynamic listener on every trait change, and
+        a render can pull a Modified event through messenger, running
+        update_traits() from inside that listener.  The VTK write used to
+        hang off the *main* trait's static handler, which runs after the
+        shadow trait's dynamic listeners -- so update_traits() read the
+        stale VTK value back and silently reverted the first mapped-trait
+        assignment made after any pending pipeline change.
+        """
+        for name, get in (('force_opaque', 'GetForceOpaque'),
+                          ('visibility', 'GetVisibility')):
+            a = tvtk.Actor()
+            new_value = not getattr(a, name)
+            seen = []
+
+            def reentrant():
+                seen.append(bool(getattr(a._vtk_obj, get)()))
+                a.update_traits()
+
+            a.on_trait_change(reentrant, name + '_')
+            setattr(a, name, new_value)
+            # VTK was synced before the dynamic listener ran...
+            self.assertEqual(seen, [new_value], name)
+            # ...so the reentrant resync could not revert the assignment.
+            self.assertEqual(getattr(a, name), new_value, name)
+            self.assertEqual(bool(getattr(a._vtk_obj, get)()), new_value,
+                             name)
+        # Same for a state (RevPrefixMap) trait.
+        p = tvtk.Property()
+        p.on_trait_change(lambda: p.update_traits(), 'representation_')
+        p.representation = 'wireframe'
+        self.assertEqual(p.representation, 'wireframe')
+        self.assertEqual(p._vtk_obj.GetRepresentationAsString(), 'Wireframe')
+
     def test_obj_del(self):
         """Test object deletion and reference cycles."""
         p = tvtk.Property()

--- a/tvtk/tests/test_tvtk.py
+++ b/tvtk/tests/test_tvtk.py
@@ -223,11 +223,12 @@ class TestTVTK(unittest.TestCase):
         for name, get in (('force_opaque', 'GetForceOpaque'),
                           ('visibility', 'GetVisibility')):
             a = tvtk.Actor()
+            vtk_a = tvtk.to_vtk(a)
             new_value = not getattr(a, name)
             seen = []
 
             def reentrant():
-                seen.append(bool(getattr(a._vtk_obj, get)()))
+                seen.append(bool(getattr(vtk_a, get)()))
                 a.update_traits()
 
             a.on_trait_change(reentrant, name + '_')
@@ -236,14 +237,14 @@ class TestTVTK(unittest.TestCase):
             self.assertEqual(seen, [new_value], name)
             # ...so the reentrant resync could not revert the assignment.
             self.assertEqual(getattr(a, name), new_value, name)
-            self.assertEqual(bool(getattr(a._vtk_obj, get)()), new_value,
-                             name)
+            self.assertEqual(bool(getattr(vtk_a, get)()), new_value, name)
         # Same for a state (RevPrefixMap) trait.
         p = tvtk.Property()
         p.on_trait_change(lambda: p.update_traits(), 'representation_')
         p.representation = 'wireframe'
         self.assertEqual(p.representation, 'wireframe')
-        self.assertEqual(p._vtk_obj.GetRepresentationAsString(), 'Wireframe')
+        self.assertEqual(tvtk.to_vtk(p).GetRepresentationAsString(),
+                         'Wireframe')
 
     def test_obj_del(self):
         """Test object deletion and reference cycles."""

--- a/tvtk/wrapper_gen.py
+++ b/tvtk/wrapper_gen.py
@@ -1367,6 +1367,18 @@ class WrapperGenerator:
         map_str = ''
         if mapped:
             map_str = '_'
+            # For a mapped trait the VTK write must hang off the *shadow*
+            # trait (``name_``): assigning ``name`` first runs post_setattr,
+            # which sets the shadow and dispatches its notifications --
+            # static handlers, then dynamic listeners -- before ``name``'s
+            # own notifications ever run.  With the handler on ``name``, a
+            # dynamic shadow listener (e.g. mayavi's render hook) can
+            # therefore run while the VTK object still holds the old value;
+            # if that render pulls a Modified event through messenger,
+            # update_traits() reads the stale value back and silently
+            # reverts the assignment.  A static handler on the shadow runs
+            # before any dynamic listener, closing the window.
+            changed = '_%s__changed'%t_name
         force_str = ''
         if force_update is not None:
             force_str = ', %s'%force_update


### PR DESCRIPTION
This one is tricky, but the fix ends up being simple.

Assigning a mapped tvtk trait runs traits' `post_setattr` first, which sets the shadow trait (`name_`) and dispatches its notifications before the main trait's own notifications run.  The write to the VTK object hung off the main trait's static handler, so a dynamic listener on the shadow could observe the VTK object still holding the old value.

`mayavi` installs exactly such a listener: the render hook fires on every trait change.  If anything upstream in the pipeline was modified (say, the LUT), that render pulls a `Modified` event for the actor through messenger, update_traits() resyncs traits from VTK -- and reads the stale value back, silently reverting the assignment.  Net effect: the first mapped-trait assignment after any pending pipeline change did nothing, order-dependently, which is the shape of long-unexplained reports like #618 and made `actor.force_opaque` (see #1348's) appear broken.

This emits the VTK write as the shadow trait's static handler instead. Static handlers run before any dynamic listener, so by the time anything can trigger a render the VTK object already agrees with the trait and the reentrant resync is a no-op.  Unmapped traits already had this property: their value and notification live on a single trait.

Closes #1348. The `nan_color` translucency is VTK's IsOpaque being conservative, not our behavior to fix. The force_opaque remediation should work now.

Closes #618. Not 100% sure it's the same bug, but very likely.