### PR TITLE
FIX: Make savefig honor the requested size on Qt

### DIFF
--- a/mayavi/tests/test_savefig_size.py
+++ b/mayavi/tests/test_savefig_size.py
@@ -1,0 +1,71 @@
+"""Regression test for mlab.savefig(size=...) on an onscreen figure (gh-1288).
+
+The first savefig used to capture at the window's size instead of the
+requested one: set_size resized the embedded scene widget, which the
+enclosing layout immediately reasserted, and the pre-layout widget size
+inflated the auto magnification.
+"""
+# Copyright (c) Enthought, Inc.
+# License: BSD Style.
+
+import os
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+_SCRIPT = """
+import os
+import tempfile
+
+from mayavi import mlab
+from tvtk.api import tvtk
+
+
+def png_size(fname):
+    r = tvtk.PNGReader(file_name=fname)
+    r.update()
+    ext = r.output.extent
+    return (ext[1] + 1, ext[3] + 1)
+
+
+d = tempfile.mkdtemp()
+mlab.figure()
+sizes = []
+for n in range(3):
+    mlab.test_contour3d()
+    mlab.draw()
+    fname = os.path.join(d, 'i%d.png' % n)
+    mlab.savefig(fname, size=(100, 80))
+    mlab.clf()
+    sizes.append(png_size(fname))
+# the first save is the regression: it saw the unsettled window size
+assert sizes == [(100, 80)] * 3, sizes
+
+# larger than the window exercises the magnification path
+big = os.path.join(d, 'big.png')
+mlab.savefig(big, size=(1200, 900))
+assert png_size(big) == (1200, 900), png_size(big)
+print('OK')
+"""
+
+
+@pytest.mark.timeout(180)
+def test_savefig_size_onscreen():
+    if sys.platform != 'linux':
+        pytest.skip('needs xvfb-run or an X display; exercised on Linux')
+    from traits.etsconfig.api import ETSConfig
+    if ETSConfig.toolkit not in ('', 'qt', 'qt4'):
+        pytest.skip(f'Qt-only test, got toolkit={ETSConfig.toolkit!r}')
+    cmd = [sys.executable, '-c', _SCRIPT]
+    xvfb = shutil.which('xvfb-run')
+    if xvfb is not None:
+        # a fresh server keeps windows off the developer's desktop, and
+        # nests fine inside CI's own Xvfb
+        cmd = [xvfb, '-a'] + cmd
+    elif not os.environ.get('DISPLAY'):
+        pytest.skip('no display and no xvfb-run')
+    res = subprocess.run(cmd, capture_output=True, text=True, timeout=150)
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert 'OK' in res.stdout, res.stdout

--- a/mayavi/tests/test_savefig_size.py
+++ b/mayavi/tests/test_savefig_size.py
@@ -31,7 +31,9 @@ def png_size(fname):
 
 
 d = tempfile.mkdtemp()
-mlab.figure()
+# explicit, since both cases below are relative to it: (100, 80) is smaller
+# than the window and (1200, 900) larger, exercising the magnification path
+mlab.figure(size=(400, 350))
 sizes = []
 for n in range(3):
     mlab.test_contour3d()

--- a/tvtk/pyface/ui/qt4/scene.py
+++ b/tvtk/pyface/ui/qt4/scene.py
@@ -358,15 +358,76 @@ class Scene(TVTKScene, Widget):
         if not self.disable_render:
             self._vtk_control.Render()
 
+    def _activate_layouts(self):
+        """Recompute the layouts between the scene widget and its window.
+
+        Qt only settles geometry when the posted LayoutRequest events are
+        delivered, and every layout in the chain has to be activated, not
+        just the window's.  Activating them directly is synchronous and,
+        unlike pumping the event loop, cannot run arbitrary queued events
+        from inside a save.  Adapted from mne-tools/mne-python#14087.
+        """
+        widget = self._vtk_control
+        processed = set()
+        while widget is not None and widget not in processed:
+            layout = widget.layout()
+            if layout is not None:
+                layout.activate()
+            processed.add(widget)
+            widget = widget.parentWidget()
+
+    def _realize(self):
+        """Flush a pending show so the widget geometry is meaningful.
+
+        Until the queued show/layout events have run once, the widget
+        chain reports pre-layout default sizes (and activating the layouts
+        just bakes them in).  This pumps the event loop only in that
+        never-shown state, so steady-state calls stay purely synchronous.
+        """
+        for _ in range(10):
+            if self._vtk_control.isVisible():
+                break
+            GUI.process_events()
+
     def get_size(self):
         """Return size of the render window."""
+        # A window whose posted show/layout events were never delivered
+        # reports its pre-layout default size, which among other things
+        # inflates savefig's auto magnification (enthought/mayavi#1288)
+        self._realize()
+        self._activate_layouts()
         sz = self._vtk_control.size()
 
         return (sz.width(), sz.height())
 
     def set_size(self, size):
         """Set the size of the window."""
-        self._vtk_control.resize(*size)
+        size = tuple(size)
+        ctrl = self._vtk_control
+        top = ctrl.window()
+        if ctrl is top:
+            ctrl.resize(*size)
+        else:
+            # Resizing the embedded widget itself is futile: the enclosing
+            # layout reasserts its geometry on the next pass, so the size
+            # held only briefly and a save right afterwards captured the
+            # framebuffer at the old size (enthought/mayavi#1288).  Resize
+            # the top-level window and nudge until the layout lands this
+            # widget at the requested size -- the first pass absorbs the
+            # decoration/toolbar delta, so this converges in one or two.
+            self._realize()
+            self._activate_layouts()
+            for _ in range(3):
+                err_w = size[0] - ctrl.width()
+                err_h = size[1] - ctrl.height()
+                if not (err_w or err_h):
+                    break
+                top.resize(top.width() + err_w, top.height() + err_h)
+                self._activate_layouts()
+        # Resize events are deferred while the window has never been shown,
+        # so mirror the final size onto the VTK side as the base class does.
+        sz = ctrl.size()
+        super().set_size((sz.width(), sz.height()))
 
     def hide_cursor(self):
         """Hide the cursor."""

--- a/tvtk/pyface/ui/qt4/scene.py
+++ b/tvtk/pyface/ui/qt4/scene.py
@@ -44,6 +44,13 @@ from .QVTKRenderWindowInteractor import (
     KeyboardModifier,
 )
 
+# Bounds on the two geometry-settling loops in Scene, below.  Both are
+# expected to finish on the first pass; the counts only keep a widget that
+# never settles (a hidden parent, a layout that fights back) from hanging the
+# caller, which a bare `while` would.
+_MAX_REALIZE_PASSES = 10
+_MAX_RESIZE_PASSES = 3
+
 
 ######################################################################
 # `_VTKRenderWindowInteractor` class.
@@ -384,7 +391,7 @@ class Scene(TVTKScene, Widget):
         just bakes them in).  This pumps the event loop only in that
         never-shown state, so steady-state calls stay purely synchronous.
         """
-        for _ in range(10):
+        for _ in range(_MAX_REALIZE_PASSES):
             if self._vtk_control.isVisible():
                 break
             GUI.process_events()
@@ -417,10 +424,11 @@ class Scene(TVTKScene, Widget):
             # decoration/toolbar delta, so this converges in one or two.
             self._realize()
             self._activate_layouts()
-            for _ in range(3):
+            for _ in range(_MAX_RESIZE_PASSES):
+                # either can be negative: the widget can overshoot as well
                 err_w = size[0] - ctrl.width()
                 err_h = size[1] - ctrl.height()
-                if not (err_w or err_h):
+                if err_w == 0 and err_h == 0:
                     break
                 top.resize(top.width() + err_w, top.height() + err_h)
                 self._activate_layouts()


### PR DESCRIPTION
Closes #1288

A layout-settling approach adapted from mne-tools/mne-python#14087 (BSD 3-clause; known to work there in tests and doc builds). The wx backend has the same latent `set_size` problem, deliberately left alone because it would be a pain to dig into (and Qt I expect is much more widely used).