### PR TITLE
Make "View -> Other..." work again

### DIFF
--- a/mayavi/plugins/_workbench_fixes.py
+++ b/mayavi/plugins/_workbench_fixes.py
@@ -1,0 +1,38 @@
+"""Runtime fixes for the (unmaintained) pyface workbench code.
+
+pyface's "View -> Other..." dialog adapts by calling the interface,
+``IView(obj, Undefined)``.  traits deprecated that in 6.0 and removed it in
+7.0, so with traits >= 7 the dialog raises ``TypeError`` instead of opening
+(mayavi gh-1409, pyface gh-1263).  pyface gh-1264 fixed it on main, but
+pyface's latest release (8.0.0) predates that commit, so mayavi patches the
+method itself until a release carries the fix -- see tvtk/WORKAROUNDS.md.
+"""
+# License: BSD Style.
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def fix_view_chooser():
+    """Repair ``IViewTreeNode.is_node_for`` if the installed pyface needs it."""
+    from pyface.workbench.action.view_chooser import IViewTreeNode
+
+    try:
+        IViewTreeNode().is_node_for(object())
+    except TypeError:
+        pass
+    else:
+        return
+
+    from pyface.workbench.api import IView
+    from traits.adaptation.api import adapt
+    from traits.api import Undefined
+
+    def is_node_for(self, obj):
+        # 'is obj' rather than 'is not None': objects that merely *adapt* to
+        # IView are deliberately not handled by this node.
+        return adapt(obj, IView, default=Undefined) is obj
+
+    IViewTreeNode.is_node_for = is_node_for
+    logger.debug('Patched pyface IViewTreeNode.is_node_for (gh-1409)')

--- a/mayavi/plugins/mayavi_workbench_application.py
+++ b/mayavi/plugins/mayavi_workbench_application.py
@@ -16,6 +16,7 @@ from pyface.api import AboutDialog, ImageResource, SplashScreen
 # Local imports.
 import mayavi.api
 from mayavi.preferences.api import preference_manager
+from mayavi.plugins._workbench_fixes import fix_view_chooser
 
 IMG_DIR = dirname(mayavi.api.__file__)
 logger = logging.getLogger(__name__)
@@ -67,6 +68,8 @@ class MayaviWorkbenchApplication(WorkbenchApplication):
         """
 
         logger.debug('---------- workbench application ----------')
+
+        fix_view_chooser()
 
         # Make sure the GUI has been created (so that, if required, the splash
         # screen is shown).

--- a/mayavi/tests/conftest.py
+++ b/mayavi/tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 # One filter per line, "#" comments allowed.
 WARNING_LINES = r"""
 error::
-# unsatisfiable until pyface.workbench moves
+# unsatisfiable until pyface.workbench moves -- see tvtk/WORKAROUNDS.md
 ignore:Workbench will be moved from pyface:PendingDeprecationWarning
 # should be fixed in traits
 ignore: module 'sre_.+' is deprecated:DeprecationWarning

--- a/mayavi/tests/test_workbench_fixes.py
+++ b/mayavi/tests/test_workbench_fixes.py
@@ -1,0 +1,50 @@
+# Author: Eric Larson
+# License: BSD Style.
+
+import pytest
+
+from traits.api import HasTraits, provides
+from traits.etsconfig.api import ETSConfig
+
+from mayavi.plugins._workbench_fixes import fix_view_chooser
+
+
+@pytest.fixture
+def node_class():
+    from pyface.workbench.action.view_chooser import IViewTreeNode
+
+    original = IViewTreeNode.is_node_for
+    fix_view_chooser()
+    yield IViewTreeNode
+    IViewTreeNode.is_node_for = original
+
+
+def test_view_chooser_rejects_non_views(node_class):
+    """Test that the view chooser's tree can classify a non-view (gh-1409)."""
+    assert node_class().is_node_for(HasTraits()) is False
+
+
+def test_view_chooser_accepts_views(node_class):
+    """Test that objects providing IView still get the view node."""
+    from pyface.workbench.api import IView
+
+    @provides(IView)
+    class FakeView(HasTraits):
+        pass
+
+    assert node_class().is_node_for(FakeView()) is True
+
+
+@pytest.mark.skipif(ETSConfig.toolkit == 'null',
+                    reason='the dialog needs a UI toolkit')
+def test_view_chooser_dialog(node_class):
+    """Test that "View -> Other..." builds its dialog (gh-1409)."""
+    from pyface.api import GUI
+    from pyface.workbench.api import WorkbenchWindow
+    from pyface.workbench.action.view_chooser import ViewChooser
+
+    GUI()  # the toolkit application object the editors need
+    chooser = ViewChooser(window=WorkbenchWindow())
+    # 'panel' rather than 'live': same editors, no window on screen
+    ui = chooser.edit_traits(kind='panel')
+    ui.dispose()

--- a/tvtk/WORKAROUNDS.md
+++ b/tvtk/WORKAROUNDS.md
@@ -1,4 +1,4 @@
-# Where VTK (and Qt) workarounds live
+# Where VTK (and other upstream) workarounds live
 
 TVTK wraps VTK by introspecting the installed VTK at build time and
 generating traits-based wrapper classes into `tvtk_classes.zip`.  VTK has
@@ -6,6 +6,11 @@ bugs — uninitialized values, getters that segfault, API drift between
 versions — and every workaround for those lives in one of the layers below.
 The layers are ordered roughly by preference: fix a problem in the earliest
 layer that can express it.
+
+The layers are VTK-shaped, but the marker and cull rules are not, so
+workarounds for the other upstreams we ship against (Qt, and the ETS
+libraries) are inventoried here too, in the "Outside the layers" sections —
+one grep should find them all.
 
 ## Policy
 
@@ -269,6 +274,30 @@ Those obey the same marker and cull rules; they are keyed on `qVersion()` and
   VTK's Python `QVTK` widgets a `QOpenGLWidget` mode that draws through
   Qt's own GL context instead of embedding a native X window.  Until tvtk
   can require and adopt that, this is in the never-expires class.
+
+## Outside the layers: pyface
+
+Mayavi is the last consumer of `pyface.workbench`, which upstream considers
+unmaintained, so bugs there are ours to carry.  These are keyed on a pyface
+release rather than a VTK version, and cull when `setup.py`'s `pyface` floor
+passes the release that carries the upstream fix.  Current case:
+
+- `mayavi/plugins/_workbench_fixes.py`: pyface's "View -> Other..." dialog
+  adapts by *calling* the interface (`IView(obj, Undefined)` in
+  `IViewTreeNode.is_node_for`), which traits deprecated in 6.0 and removed in
+  7.0 — so with traits >= 7 the menu item raises `TypeError` instead of
+  opening a dialog (#1409, #1339,
+  <https://github.com/enthought/pyface/issues/1263>).  Fixed upstream by
+  <https://github.com/enthought/pyface/pull/1264>, but pyface's latest release
+  (8.0.0, April 2023) predates it and main has not moved since, so
+  `fix_view_chooser()` installs the same one-line fix from
+  `MayaviWorkbenchApplication.run()`.  It probes the installed method rather
+  than comparing versions, so it already no-ops against a fixed pyface;
+  deleting it is still a floor bump away.  `mayavi/tests/test_workbench_fixes.py`
+  goes with it.
+- `mayavi/tests/conftest.py` ignores pyface's "Workbench will be moved from
+  pyface" `PendingDeprecationWarning`.  Unsatisfiable rather than deferred:
+  there is nowhere for the import to move to until the code does.
 
 ## Outside the layers: `mayavi/`
 


### PR DESCRIPTION
Closes  #1409

pyface's workbench view chooser adapts by calling the interface, IView(obj, Undefined).  traits deprecated that in 6.0 and removed it in 7.0, so with traits >= 7 the menu item raises TypeError instead of opening the dialog.  pyface merged the one-line fix in enthought/pyface#1264, but its latest release (8.0.0, April 2023) predates that and main has not moved since, so apply the same fix here until a release carries it.