### PR TITLE
Test against ETS dev versions

### DIFF
--- a/.github/actions/install-ets-main/action.yml
+++ b/.github/actions/install-ets-main/action.yml
@@ -1,0 +1,20 @@
+name: Install ETS packages from main
+description: >-
+  Replace traits, pyface, traitsui and envisage with their main branches, and
+  prove that is what ended up installed.
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        # Uninstall first: main carries the last released version number on all
+        # four, so `--upgrade` finds the release already installed, calls the
+        # requirement satisfied and leaves PyPI's copy in place.
+        python -m pip uninstall -y -r "$GITHUB_ACTION_PATH/requirements.txt"
+        python -m pip install -r "$GITHUB_ACTION_PATH/requirements.txt"
+        # Runs after the package install rather than before it, so that nothing
+        # can pull a release back over these afterwards.  That leaves `pip
+        # check` to do what installing first would have: report a main that no
+        # longer satisfies a floor mayavi declares.
+        python -m pip check
+        python "$GITHUB_ACTION_PATH/assert_from_main.py"

--- a/.github/actions/install-ets-main/assert_from_main.py
+++ b/.github/actions/install-ets-main/assert_from_main.py
@@ -1,0 +1,43 @@
+"""Fail unless every package in requirements.txt was installed from its VCS URL.
+
+None of the ETS packages carries a dev version on ``main`` -- each one reports
+its last *release* -- so the version says nothing about where a distribution
+came from, and a silent fall back to PyPI would leave the CI row green while
+testing nothing at all.  ``direct_url.json`` (PEP 610) is what records the VCS
+origin, so it is the only thing worth asserting on.
+"""
+import json
+import sys
+from importlib.metadata import distribution
+from pathlib import Path
+
+REQUIREMENTS = Path(__file__).with_name('requirements.txt')
+
+
+def requirement_names(path):
+    """The distribution names in a requirements file, in order."""
+    for line in path.read_text().splitlines():
+        line = line.split('#')[0].strip()
+        if line:
+            yield line.split('@')[0].strip()
+
+
+def origin(name):
+    """Where `name` was installed from: a URL, or None if it came from an index."""
+    raw = distribution(name).read_text('direct_url.json')
+    return json.loads(raw)['url'] if raw else None
+
+
+def main():
+    bad = False
+    for name in requirement_names(REQUIREMENTS):
+        url = origin(name)
+        print(f'{name} {distribution(name).version} from {url or "an index"}')
+        if url is None or not url.rstrip('/').endswith(f'/{name}'):
+            print(f'  ERROR: expected {name} to come from its own repository')
+            bad = True
+    return int(bad)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/.github/actions/install-ets-main/requirements.txt
+++ b/.github/actions/install-ets-main/requirements.txt
@@ -1,0 +1,10 @@
+# The ETS packages mayavi depends on, from their development branches rather
+# than PyPI.  Used by the action beside this file, and usable on its own to
+# reproduce one of those CI rows locally:
+#
+#     pip install -r .github/actions/install-ets-main/requirements.txt
+#
+traits @ git+https://github.com/enthought/traits@main
+pyface @ git+https://github.com/enthought/pyface@main
+traitsui @ git+https://github.com/enthought/traitsui@main
+envisage @ git+https://github.com/enthought/envisage@main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   tests:
-    name: Tests ${{ matrix.os }} ${{ matrix.python-version }} ${{ matrix.qt-api }} ${{ matrix.vtk }} ${{ (matrix.headless && 'headless') || ''}}
+    name: Tests ${{ matrix.os }} ${{ matrix.python-version }} ${{ matrix.qt-api }} ${{ matrix.vtk }} ${{ (matrix.ets && 'ets-main') || '' }} ${{ (matrix.headless && 'headless') || ''}}
     strategy:
       matrix:
         # Always test against the latest VTK, NumPy, and Qt bindings
@@ -27,6 +27,9 @@ jobs:
         # to the includes, `vtk: vtk-dev` was absorbed into the base ubuntu row
         # and there was no ubuntu job on the latest release at all.
         vtk: ['']
+        # Unreleased ETS (traits/traitsui/pyface/envisage from their main
+        # branches).  Has to start here for the same reason `vtk` does.
+        ets: ['']
         # Then add some backward compat checks
         include:
           - python-version: '3.13'
@@ -57,6 +60,13 @@ jobs:
             qt-api: 'pyside6'
             os: ubuntu-latest
             vtk: 'vtk-dev'
+          # Unreleased ETS, on the latest *released* VTK rather than folded
+          # into the row above: that row is what MAX_VTK gets raised on the
+          # strength of, so it has to stay attributable to VTK alone.
+          - python-version: '3.14'
+            qt-api: 'pyside6'
+            os: ubuntu-latest
+            ets: 'main'
           # Linux arm64: plain C char is unsigned there (unlike x86 and
           # unlike Apple's arm64 ABI), which is what broke gh-1194
           - python-version: '3.14'
@@ -124,6 +134,8 @@ jobs:
           echo "extra=[app]" | tee -a $GITHUB_OUTPUT
         fi
     - run: python -m pip install --no-build-isolation --group test -ve .${{ steps.install.outputs.extra }}
+    - uses: ./.github/actions/install-ets-main
+      if: matrix.ets == 'main'
     # `coverage run` rather than pytest-cov: there are two suites per job plus
     # the subprocesses they spawn, and pytest-cov combines at the end of each
     # run, which would consume the children's data before the explicit combine
@@ -154,10 +166,16 @@ jobs:
   # this was first written as one.  A job that stops running is a check that is
   # visibly no longer there.
   #
-  # One configuration is enough: these exercise the Mayavi2 application, not
-  # the VTK version, which the matrix above already covers.
+  # One VTK is enough: these exercise the Mayavi2 application, not the VTK
+  # version, which the matrix above already covers.  ETS is the exception --
+  # this is the layer envisage is actually load-bearing in, so unreleased ETS
+  # gets a second run here as well as a row up there.
   integration:
-    name: Integration tests
+    name: Integration tests ${{ (matrix.ets && 'ets-main') || '' }}
+    strategy:
+      matrix:
+        ets: ['', 'main']
+      fail-fast: false
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -185,6 +203,8 @@ jobs:
     # package does not ask for itself.
     - run: python -m pip install --upgrade pip  # --group needs pip >= 25.1
     - run: python -m pip install --group test pyside6 -ve ".[app]"
+    - uses: ./.github/actions/install-ets-main
+      if: matrix.ets == 'main'
     - run: python -c "import vtk; print(f'VTK {vtk.VTK_VERSION}')"
     # the wrapper sets its own per-script subprocess timeout; pytest's is the
     # backstop behind it.  Every case here *is* a subprocess, so this job only
@@ -224,5 +244,6 @@ jobs:
         title: Scheduled CI run is failing
         body: |
           The weekly scheduled CI run failed. Since these runs test against the
-          latest dependencies (including VTK dev wheels), this probably means a
-          dependency update broke something.
+          latest dependencies (VTK dev wheels, and the ETS packages from their
+          main branches), this probably means an upstream change broke
+          something.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,6 +254,24 @@ commit**:
   schedule, which is how VTK-dev breakage gets noticed; a scheduled failure
   opens an issue (the `issue-on-failure` job) since there is no PR to show it
   on.
+- `.github/actions/install-ets-main` — composite action behind the `ets: main`
+  row of `tests.yml` and the second `integration` job: swaps traits, pyface,
+  traitsui and envisage for their `main` branches, from the `requirements.txt`
+  beside it (which also reproduces the row locally).  Deliberately *not* folded
+  into the `vtk-dev` row, whose greenness is what `MAX_VTK` gets raised on and
+  so has to stay attributable to VTK alone; it runs on the latest released VTK
+  instead.  Two traps, both of which the action guards:
+  - None of the four carries a dev version on `main` — each reports its last
+    *release* — so `pip install --upgrade` finds the requirement already
+    satisfied and silently leaves PyPI's copy in place.  Hence the `pip
+    uninstall` first, and `assert_from_main.py` after, which reads each
+    distribution's `direct_url.json`: nothing else distinguishes a real `main`
+    install from a fall back to PyPI, and the row would be green either way.
+    The package list lives only in `requirements.txt` — `pip uninstall` takes
+    it with `-r` and the script parses it — so the three uses cannot drift.
+  - It runs *after* the package install so nothing can undo it, which is why
+    `pip check` stands in for the floor checking that installing first would
+    have got from the resolver.
 - `.github/actions/open-issue` — composite action behind both
   `issue-on-failure` jobs: files an issue unless one with the same title is
   already open, appending the run URL.  Callers need an `actions/checkout`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ app = [
     # envisage requires a bare "setuptools" so nothing holds it back.  The import
     # is gone from envisage main (enthought/envisage#548) but not from 7.0.4, so
     # drop this once a release carries the fix.
+    # TODO: drop this once the envisage floor can be raised past 7.0.4.  The
+    # tests.yml `ets: main` row already runs against a fixed envisage, so that
+    # row is where the pin becoming unnecessary will show up first.
     "setuptools<82",
 ]
 


### PR DESCRIPTION
It would be good to test against latest `dev` versions of the ETS dependencies (pyface, traits, traitsui, envisage). Let's have a CI run do it!

This is a straightforward CI enhancement so I'll adjust CI reqs and merge once it's green